### PR TITLE
Minor javadoc improvements

### DIFF
--- a/src/main/java/net/openhft/chronicle/core/ClassLocal.java
+++ b/src/main/java/net/openhft/chronicle/core/ClassLocal.java
@@ -20,6 +20,8 @@ import java.util.function.Function;
 
 /**
  * Lambda friendly, ClassLocal value to cache information relating to a class.
+ *
+ * @param <V> the type of value in this ClassLocal
  */
 public class ClassLocal<V> extends ClassValue<V> {
     private final Function<Class, V> classVFunction;
@@ -32,6 +34,7 @@ public class ClassLocal<V> extends ClassValue<V> {
      * Function to create a value to cache information associated with a Class
      *
      * @param classVFunction to generate the associated value.
+     * @param <V> the type of value in this ClassLocal
      * @return the ClassLocal
      */
     public static <V> ClassLocal<V> withInitial(Function<Class, V> classVFunction) {

--- a/src/main/java/net/openhft/chronicle/core/Jvm.java
+++ b/src/main/java/net/openhft/chronicle/core/Jvm.java
@@ -33,7 +33,9 @@ public enum Jvm {
      * Cast a CheckedException as an unchecked one.
      *
      * @param throwable to cast
-     * @throws T the throwable as an unchecked thorwable
+     * @param <T> the type of the Throwable
+     * @return this method will never return a Throwable instance, it will just throw it.
+     * @throws T the throwable as an unchecked throwable
      */
     @SuppressWarnings("unchecked")
     public static <T extends Throwable> RuntimeException rethrow(Throwable throwable) throws T {

--- a/src/main/java/net/openhft/chronicle/core/OS.java
+++ b/src/main/java/net/openhft/chronicle/core/OS.java
@@ -208,12 +208,14 @@ public class OS {
 
     /**
      * Map a region of a file into memory.
+     *
      * @param fileChannel to map
      * @param mode of access
      * @param start offset within a file
      * @param size of region to map.
      * @return the address of the memory mapping.
-     * @throws IOException
+     * @throws IOException if the mapping fails
+     * @throws IllegalArgumentException if the arguments are not valid
      */
     public static long map(FileChannel fileChannel, FileChannel.MapMode mode, long start, long size)
             throws IOException, IllegalArgumentException {

--- a/src/main/java/net/openhft/chronicle/core/util/BooleanConsumer.java
+++ b/src/main/java/net/openhft/chronicle/core/util/BooleanConsumer.java
@@ -27,7 +27,7 @@ import java.util.Objects;
  * Represents an operation that accepts a single {@code Boolean}-valued argument and returns no result.  This is the
  * primitive type specialization of {@link java.util.function.Consumer} for {@code Boolean}.  Unlike most other functional
  * interfaces, {@code BooleanConsumer} is expected to operate via side-effects.
- * <p>
+ *
  * <p>This is a <a href="package-summary.html">functional interface</a> whose functional method is
  * {@link #accept(Boolean)}.
  *

--- a/src/main/java/net/openhft/chronicle/core/util/ByteConsumer.java
+++ b/src/main/java/net/openhft/chronicle/core/util/ByteConsumer.java
@@ -27,7 +27,7 @@ import java.util.Objects;
  * Represents an operation that accepts a single {@code byte}-valued argument and returns no result.  This is the
  * primitive type specialization of {@link java.util.function.Consumer} for {@code byte}.  Unlike most other functional
  * interfaces, {@code ByteConsumer} is expected to operate via side-effects.
- * <p>
+ *
  * <p>This is a <a href="package-summary.html">functional interface</a> whose functional method is {@link
  * #accept(byte)}.
  *

--- a/src/main/java/net/openhft/chronicle/core/util/CharConsumer.java
+++ b/src/main/java/net/openhft/chronicle/core/util/CharConsumer.java
@@ -27,7 +27,7 @@ import java.util.Objects;
  * Represents an operation that accepts a single {@code char}-valued argument and returns no result.  This is the
  * primitive type specialization of {@link java.util.function.Consumer} for {@code char}.  Unlike most other functional
  * interfaces, {@code CharConsumer} is expected to operate via side-effects.
- * <p>
+ *
  * <p>This is a <a href="package-summary.html">functional interface</a> whose functional method is
  * {@link #accept(char)}.
  *

--- a/src/main/java/net/openhft/chronicle/core/util/FloatConsumer.java
+++ b/src/main/java/net/openhft/chronicle/core/util/FloatConsumer.java
@@ -27,7 +27,7 @@ import java.util.Objects;
  * Represents an operation that accepts a single {@code float}-valued argument and returns no result.  This is the
  * primitive type specialization of {@link java.util.function.Consumer} for {@code float}.  Unlike most other functional
  * interfaces, {@code FloatConsumer} is expected to operate via side-effects.
- * <p>
+ *
  * <p>This is a <a href="package-summary.html">functional interface</a> whose functional method is
  * {@link #accept(float)}.
  *

--- a/src/main/java/net/openhft/chronicle/core/util/ObjByteConsumer.java
+++ b/src/main/java/net/openhft/chronicle/core/util/ObjByteConsumer.java
@@ -24,7 +24,7 @@ package net.openhft.chronicle.core.util;
  * Represents an operation that accepts a an object-valued and {@code byte}-valued argument, and returns no result.  This is the
  * {@code (reference, long)} specialization of {@link java.util.function.BiConsumer} for {@code byte}.  Unlike most other functional
  * interfaces, {@code ObjByteConsumer} is expected to operate via side-effects.
- * <p>
+ *
  * <p>This is a <a href="package-summary.html">functional interface</a> whose functional method is
  * {@link #accept(Object, byte)}.
  *

--- a/src/main/java/net/openhft/chronicle/core/util/ObjCharConsumer.java
+++ b/src/main/java/net/openhft/chronicle/core/util/ObjCharConsumer.java
@@ -24,7 +24,7 @@ package net.openhft.chronicle.core.util;
  * Represents an operation that accepts a an object-valued and {@code char}-valued argument, and returns no result.  This is the
  * {@code (reference, long)} specialization of {@link java.util.function.BiConsumer} for {@code char}.  Unlike most other functional
  * interfaces, {@code ObjCharConsumer} is expected to operate via side-effects.
- * <p>
+ *
  * <p>This is a <a href="package-summary.html">functional interface</a> whose functional method is
  * {@link #accept(Object, char)}.
  *

--- a/src/main/java/net/openhft/chronicle/core/util/ObjFloatConsumer.java
+++ b/src/main/java/net/openhft/chronicle/core/util/ObjFloatConsumer.java
@@ -24,7 +24,7 @@ package net.openhft.chronicle.core.util;
  * Represents an operation that accepts a an object-valued and {@code float}-valued argument, and returns no result.  This is the
  * {@code (reference, long)} specialization of {@link java.util.function.BiConsumer} for {@code float}.  Unlike most other functional
  * interfaces, {@code ObjFloatConsumer} is expected to operate via side-effects.
- * <p>
+ *
  * <p>This is a <a href="package-summary.html">functional interface</a> whose functional method is
  * {@link #accept(Object, float)}.
  *

--- a/src/main/java/net/openhft/chronicle/core/util/ObjShortConsumer.java
+++ b/src/main/java/net/openhft/chronicle/core/util/ObjShortConsumer.java
@@ -24,7 +24,7 @@ package net.openhft.chronicle.core.util;
  * Represents an operation that accepts a an object-valued and {@code short}-valued argument, and returns no result.  This is the
  * {@code (reference, long)} specialization of {@link java.util.function.BiConsumer} for {@code short}.  Unlike most other functional
  * interfaces, {@code ObjShortConsumer} is expected to operate via side-effects.
- * <p>
+ *
  * <p>This is a <a href="package-summary.html">functional interface</a> whose functional method is
  * {@link #accept(Object, short)}.
  *

--- a/src/main/java/net/openhft/chronicle/core/util/ShortConsumer.java
+++ b/src/main/java/net/openhft/chronicle/core/util/ShortConsumer.java
@@ -27,7 +27,7 @@ import java.util.Objects;
  * Represents an operation that accepts a single {@code int}-valued argument and returns no result.  This is the
  * primitive type specialization of {@link java.util.function.Consumer} for {@code int}.  Unlike most other functional
  * interfaces, {@code IntConsumer} is expected to operate via side-effects.
- * <p>
+ *
  * <p>This is a <a href="package-summary.html">functional interface</a> whose functional method is
  * {@link #accept(short)}.
  *


### PR DESCRIPTION
The javadoc compiler gave variour warnings and causes noise. This
pr contains fixes for these issues. In java 8 it isn't allowed anymore
to use < p / > for empty lines.

At other places type information, return or exception information was
added.