### PR TITLE
Fix map0 access pattern

### DIFF
--- a/src/test/java/net/openhft/chronicle/core/OSTest.java
+++ b/src/test/java/net/openhft/chronicle/core/OSTest.java
@@ -17,25 +17,31 @@
 package net.openhft.chronicle.core;
 
 import net.openhft.chronicle.core.threads.ThreadDump;
-import org.jetbrains.annotations.NotNull;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestName;
 
 import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.lang.reflect.InvocationTargetException;
+import java.nio.ByteOrder;
+import java.nio.MappedByteBuffer;
 import java.nio.channels.FileChannel;
-import java.nio.file.Paths;
-import java.util.UUID;
+import java.nio.channels.FileChannel.MapMode;
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 
 public class OSTest {
 
     private ThreadDump threadDump;
+
+    @Rule
+    public final TestName testName = new TestName();
 
     @Before
     public void threadDump() {
@@ -46,6 +52,7 @@ public class OSTest {
     public void checkThreadDump() {
         threadDump.assertNoNewThreads();
     }
+
     @Test
     public void testIs64Bit() {
         System.out.println("is64 = " + OS.is64Bit());
@@ -56,38 +63,87 @@ public class OSTest {
         System.out.println("pid = " + OS.getProcessId());
     }
 
+    /** tests that windows supports page mapping granularity */
     @Test
-    @Ignore("Failing on TC (linux agent) for unknown reason, anyway the goal of this test is to " +
-            "test mapping granularity on windows")
+    //@Ignore("Failing on TC (linux agent) for unknown reason, anyway the goal of this test is to " +
+    //        "test mapping granularity on windows")
     public void testMapGranularity() throws IOException, NoSuchMethodException, IllegalAccessException, InvocationTargetException {
-        // tests that windows supports page mapping granularity
-        long length = OS.pageSize();
-        String name = Paths.get(OS.TARGET, "deleteme" + UUID.randomUUID().toString()).toString();
-        @NotNull File file = new File(name);
+        File file = new File(OS.TARGET, getClass().getName() + "." + testName.getMethodName() + ".deleteme");
         file.deleteOnExit();
-        FileChannel fc = new RandomAccessFile(name, "rw").getChannel();
+
+        FileChannel fc = new RandomAccessFile(file, "rw").getChannel();
+
+        long length = OS.pageSize();
+        MappedByteBuffer anchor = fc.map(MapMode.READ_WRITE, 0, length);
+        anchor.order(ByteOrder.nativeOrder());
+
         long address = OS.map0(fc, OS.imodeFor(FileChannel.MapMode.READ_WRITE), 0, length);
+
         OS.memory().writeLong(address, 0);
         OS.unmap(address, length);
+
         assertEquals(length, file.length());
     }
 
     @Test
-    @Ignore("Should always pass, or crash the JVM based on length")
+    //@Ignore("Should always pass, or crash the JVM based on length")
     public void testMap() throws IOException, NoSuchMethodException, IllegalAccessException, InvocationTargetException {
-        if (!OS.isWindows()) return;
+        File file = new File(OS.TARGET, getClass().getName() + "." + testName.getMethodName() + ".deleteme");
+        file.deleteOnExit();
+
+        FileChannel fc = new RandomAccessFile(file, "rw").getChannel();
 
         // crashes the JVM.
-//        long length = (4L << 30L) + (64 << 10);
-        // doesn't crash the JVM.
-        long length = (4L << 30L);
+        // long length = (4L << 30L) + (64 << 10);
+        // doesn't crash the JVM, but takes 3s
+        // long length = (4L << 30);
+        // doesn't crash the JVM and runs fast
+        long length = (4L << 25);
 
-        @NotNull String name = OS.TARGET + "/deleteme";
-        new File(name).deleteOnExit();
-        FileChannel fc = new RandomAccessFile(name, "rw").getChannel();
+        long anchorSize = 0x4000_0000L;
+        int anchorCount = (int) ((length + anchorSize - 1) / anchorSize);
+        List<MappedByteBuffer> anchors = new ArrayList<>();
+        long anchorTotalRemain = length;
+        for (int i = 0; i < anchorCount; i++) {
+            MappedByteBuffer anchor = fc.map(MapMode.READ_WRITE, i * anchorSize, Math.min(anchorTotalRemain, anchorSize));
+            anchor.order(ByteOrder.nativeOrder());
+            anchors.add(anchor);
+            anchorTotalRemain -= anchorSize;
+        }
+
         long address = OS.map0(fc, OS.imodeFor(FileChannel.MapMode.READ_WRITE), 0, length);
-        for (long offset = 0; offset < length; offset += OS.pageSize())
+        for (long offset = 0; offset < length; offset += OS.pageSize()) {
             OS.memory().writeLong(address + offset, offset);
+        }
+        for (long offset = 0; offset < length; offset += OS.pageSize()) {
+            assertEquals(offset, OS.memory().readLong(address + offset));
+        }
+
         OS.unmap(address, length);
     }
+
+    @Test
+    public void testMapFast() throws Exception {
+        File file = new File(OS.TARGET, getClass().getName() + "." + testName.getMethodName() + ".deleteme");
+        file.deleteOnExit();
+
+        FileChannel fc = new RandomAccessFile(file, "rw").getChannel();
+
+        long length = Long.BYTES;
+        MappedByteBuffer anchor = fc.map(MapMode.READ_WRITE, 0, length);
+        anchor.order(ByteOrder.nativeOrder());
+
+        long address = OS.map0(fc, OS.imodeFor(FileChannel.MapMode.READ_WRITE), 0, length);
+
+        long value = System.currentTimeMillis();
+        value ^= (value << 32);
+
+        OS.memory().writeLong(address, value);
+
+        assertEquals(value, OS.memory().readLong(address));
+        assertEquals(value, anchor.getLong(0));
+
+        OS.unmap(address, length);
+    }
+
 }


### PR DESCRIPTION
Existing implementation does not follow the pattern, which can be found in FileChannelImpl implementations. As result in some cases it's possible to get OutOfMemoryError (map failed). Actually this error does not relate to any heap memory problem. And correct implementation tries to collect garbage (which is expected to contain mapped memory buffers) and retries map0 again. Finally, repeated OOME is transformed into IOException, which is again makes more sense.

In my case the problem happens when large queue is quickly scanned. And with higher probability this happens if I need to do some intensive random access reading by index. As result the process VmSize grows too quickly and proper gc() helps to save the application. 

So, there are 2 important points:
- follow map0 pattern
- do not terrify the application with OutOfMemoryError 