### PR TITLE
ClassAliasPool: fix default ClassLoader

### DIFF
--- a/src/main/java/net/openhft/chronicle/core/pool/ClassAliasPool.java
+++ b/src/main/java/net/openhft/chronicle/core/pool/ClassAliasPool.java
@@ -43,7 +43,7 @@ public class ClassAliasPool implements ClassLookup {
 
     ClassAliasPool(ClassLookup parent) {
         this.parent = parent;
-        this.classLoader = Thread.currentThread().getContextClassLoader();
+        this.classLoader = getClass().getClassLoader();
     }
 
     @NotNull


### PR DESCRIPTION
The default ClassLoader to be used when invoking
ClassAliasPool(ClassLookup parent) should be the class' own
ClassLoader which is most likely the same one for all
Chronicle JARs.

Previously, Thread.currentThread().getContextClassLoader() had been used
which may be different from the Chronicle classes' ClassLoader.
This may result in weird behavior, as reported by
OpenHFT/Chronicle-Map#127.