### PR TITLE
Fix overspecified parameter in Memory.allocateInstance

### DIFF
--- a/src/main/java/net/openhft/chronicle/core/Memory.java
+++ b/src/main/java/net/openhft/chronicle/core/Memory.java
@@ -172,7 +172,7 @@ public interface Memory {
     long addLong(Object object, long offset, long increment);
 
     @NotNull
-    <E> E allocateInstance(Class<E> clazz) throws InstantiationException;
+    <E> E allocateInstance(Class<? extends E> clazz) throws InstantiationException;
 
     long getFieldOffset(Field field);
 

--- a/src/main/java/net/openhft/chronicle/core/UnsafeMemory.java
+++ b/src/main/java/net/openhft/chronicle/core/UnsafeMemory.java
@@ -74,7 +74,8 @@ public enum UnsafeMemory implements Memory {
     }
 
     @NotNull
-    public <E> E allocateInstance(Class<E> clazz) throws InstantiationException {
+    @Override
+    public <E> E allocateInstance(Class<? extends E> clazz) throws InstantiationException {
         @NotNull @SuppressWarnings("unchecked")
         E e = (E) UNSAFE.allocateInstance(clazz);
         return e;


### PR DESCRIPTION
Method signature called for Class<E>, but Class<? extends E> suffices.
Should make type inference work a little more often.