### PR TITLE
Get correct MAX_DIRECT_MEMORY value in Java 9

### DIFF
--- a/src/main/java/net/openhft/chronicle/core/Jvm.java
+++ b/src/main/java/net/openhft/chronicle/core/Jvm.java
@@ -58,11 +58,15 @@ public enum Jvm {
     @NotNull
     private static final ThreadLocalisedExceptionHandler DEBUG = new ThreadLocalisedExceptionHandler(Slf4jExceptionHandler.DEBUG);
 
-    private static final long MAX_DIRECT_MEMORY = maxDirectMemory0();
-    private static final int JVM_JAVA_MAJOR_VERSION = getMajorVersion0();
-    private static final boolean IS_JAVA_9_PLUS = JVM_JAVA_MAJOR_VERSION > 8;
+    private static final int JVM_JAVA_MAJOR_VERSION;
+    private static final boolean IS_JAVA_9_PLUS;
+    private static final long MAX_DIRECT_MEMORY;
 
     static {
+        JVM_JAVA_MAJOR_VERSION = getMajorVersion0();
+        IS_JAVA_9_PLUS = JVM_JAVA_MAJOR_VERSION > 8; // IS_JAVA_9_PLUS value is used in maxDirectMemory0 method.
+        MAX_DIRECT_MEMORY = maxDirectMemory0();
+
         try {
             bitsClass = Class.forName("java.nio.Bits");
             reservedMemory = bitsClass.getDeclaredField("reservedMemory");
@@ -406,7 +410,14 @@ public enum Jvm {
 
     private static long maxDirectMemory0() {
         try {
-            Class<?> clz = Class.forName("sun.misc.VM");
+            Class<?> clz;
+
+            if (IS_JAVA_9_PLUS) {
+                clz = Class.forName("jdk.internal.misc.VM");
+            } else {
+                clz = Class.forName("sun.misc.VM");
+            }
+
             final Method method = clz.getDeclaredMethod("maxDirectMemory");
             return ((Long) method.invoke(null)).longValue();
         } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {

--- a/src/test/java/net/openhft/chronicle/core/JvmTest.java
+++ b/src/test/java/net/openhft/chronicle/core/JvmTest.java
@@ -119,7 +119,6 @@ public class JvmTest {
 
     @Test
     public void testMaxDirectMemory() {
-        assumeThat(Jvm.majorVersion() < 9, is(true));
         long maxDirectMemory = Jvm.maxDirectMemory();
         assertTrue(maxDirectMemory > 0);
     }


### PR DESCRIPTION
Hi,

this PR gets rid of the message `net.openhft.chronicle.core.Jvm: Unable to determine max direct memory` on Java 9.

Unfortunately, I don't really know if this patch has some far reaching consequences as I don't know the codebase that well.

Best regards,
Martin