### PR TITLE
StringBuilder/String "coder" field reflection caching fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,6 @@
             <artifactId>slf4j-simple</artifactId>
             <scope>test</scope>
         </dependency>
-
     </dependencies>
 
     <build>

--- a/src/main/java/net/openhft/chronicle/core/util/StringUtils.java
+++ b/src/main/java/net/openhft/chronicle/core/util/StringUtils.java
@@ -33,7 +33,7 @@ import static java.lang.Character.toLowerCase;
 public enum StringUtils {
     ;
 
-    private static final Field S_VALUE, SB_COUNT;
+    private static final Field S_VALUE, SB_COUNT, S_CODER, SB_CODER;
     private static final long S_VALUE_OFFSET, SB_VALUE_OFFSET, SB_COUNT_OFFSET, S_COUNT_OFFSET;
     private static final long MAX_VALUE_DIVIDE_10 = Long.MAX_VALUE / 10;
 
@@ -42,6 +42,13 @@ public enum StringUtils {
             S_VALUE = String.class.getDeclaredField("value");
             Jvm.setAccessible(S_VALUE);
             S_VALUE_OFFSET = OS.memory().getFieldOffset(S_VALUE);
+            if (Jvm.isJava9Plus()) {
+                SB_CODER = Jvm.getField(StringBuilder.class.getSuperclass(), "coder");
+                S_CODER = Jvm.getField(String.class, "coder");
+            } else {
+                S_CODER = null;
+                SB_CODER = null;
+            }
         } catch (Exception e) {
             throw new AssertionError(e);
         }
@@ -191,7 +198,9 @@ public enum StringUtils {
     @Java9
     private static byte getStringCoderForStringOrStringBuilder(@NotNull CharSequence charSequence) {
         try {
-            return Jvm.getField(charSequence.getClass(), "coder").getByte(charSequence);
+            if (charSequence instanceof String) return S_CODER.getByte(charSequence);
+            else if (charSequence instanceof StringBuilder) return SB_CODER.getByte(charSequence);
+            else return Jvm.getField(charSequence.getClass(), "coder").getByte(charSequence);
         } catch (IllegalArgumentException | IllegalAccessException e) {
             throw new AssertionError(e);
         }


### PR DESCRIPTION
These values are currently reassessed on each call, even though they are determined on JVM startup. Using the high-level interface in Chronicle, it can really slow down deserialization performance. (also, an exception is currently thrown and recovered from for each String/StringBuilder check, which is really bad for standard deserialziation operation).

This PR fixes both behaviors for pre and post JDK9 versions.