### PR TITLE
Added new field USER_HOME in OS class

### DIFF
--- a/src/main/java/net/openhft/chronicle/core/OS.java
+++ b/src/main/java/net/openhft/chronicle/core/OS.java
@@ -45,6 +45,7 @@ public enum OS {
     public static final String TMP = System.getProperty("java.io.tmpdir");
     public static final String TARGET = System.getProperty("project.build.directory", findTarget());
     public static final String USER_DIR = System.getProperty("user.dir");
+    public static final String USER_HOME = System.getProperty("user.home");
     static final ClassLocal<MethodHandle> MAP0_MH = ClassLocal.withInitial(c -> {
         try {
             Method map0 = Jvm.getMethod(c, "map0", int.class, long.class, long.class);


### PR DESCRIPTION
It is useful to use it instead of System.getProperty("user.home")
each time when the user stores config files in the home
dir in hidden folder like $USER_HOME/.Project (e.g. .gradle,
.IntellijIdea, .m2 etc)