### PR TITLE
Clean direct byte buffers using Unsafe in Java 9+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,6 +130,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
+                <version>3.2.0</version>
                 <configuration>
                     <archive>
                         <manifestEntries>

--- a/src/main/java/net/openhft/chronicle/core/cleaner/impl/jdk9/Jdk9ByteBufferCleanerService.java
+++ b/src/main/java/net/openhft/chronicle/core/cleaner/impl/jdk9/Jdk9ByteBufferCleanerService.java
@@ -12,9 +12,9 @@ import java.nio.ByteBuffer;
 
 @TargetMajorVersion(majorVersion = 9)
 public final class Jdk9ByteBufferCleanerService implements ByteBufferCleanerService {
-    private static final MethodHandle handle = getHandle();
+    private static final MethodHandle invokeCleanerMethod = getInvokeCleanerMethod();
 
-    private static MethodHandle getHandle() {
+    private static MethodHandle getInvokeCleanerMethod() {
         MethodType signature = MethodType.methodType(void.class, ByteBuffer.class);
         try {
             return MethodHandles.publicLookup().findVirtual(UnsafeMemory.UNSAFE.getClass(), "invokeCleaner", signature);
@@ -29,7 +29,7 @@ public final class Jdk9ByteBufferCleanerService implements ByteBufferCleanerServ
     @Override
     public void clean(final ByteBuffer buffer) {
         try {
-            handle.invokeExact(UnsafeMemory.UNSAFE, buffer);
+            invokeCleanerMethod.invokeExact(UnsafeMemory.UNSAFE, buffer);
         } catch (Throwable throwable) {
             Jvm.rethrow(throwable);
         }

--- a/src/main/java/net/openhft/chronicle/core/cleaner/impl/jdk9/Jdk9ByteBufferCleanerService.java
+++ b/src/main/java/net/openhft/chronicle/core/cleaner/impl/jdk9/Jdk9ByteBufferCleanerService.java
@@ -1,0 +1,42 @@
+package net.openhft.chronicle.core.cleaner.impl.jdk9;
+
+import net.openhft.chronicle.core.Jvm;
+import net.openhft.chronicle.core.UnsafeMemory;
+import net.openhft.chronicle.core.annotation.TargetMajorVersion;
+import net.openhft.chronicle.core.cleaner.spi.ByteBufferCleanerService;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.nio.ByteBuffer;
+
+@TargetMajorVersion(majorVersion = 9)
+public final class Jdk9ByteBufferCleanerService implements ByteBufferCleanerService {
+    private static final MethodHandle handle = getHandle();
+
+    private static MethodHandle getHandle() {
+        MethodType signature = MethodType.methodType(void.class, ByteBuffer.class);
+        try {
+            return MethodHandles.publicLookup().findVirtual(UnsafeMemory.UNSAFE.getClass(), "invokeCleaner", signature);
+        } catch (NoSuchMethodException | IllegalAccessException e) {
+            if (Jvm.isJava9Plus()) {
+                throw new ExceptionInInitializerError(e);
+            }
+            return null;
+        }
+    }
+
+    @Override
+    public void clean(final ByteBuffer buffer) {
+        try {
+            handle.invokeExact(UnsafeMemory.UNSAFE, buffer);
+        } catch (Throwable throwable) {
+            Jvm.rethrow(throwable);
+        }
+    }
+
+    @Override
+    public int impact() {
+        return LITTLE_IMPACT;
+    }
+}

--- a/src/main/java/net/openhft/chronicle/core/cleaner/impl/jdk9/Jdk9ByteBufferCleanerService.java
+++ b/src/main/java/net/openhft/chronicle/core/cleaner/impl/jdk9/Jdk9ByteBufferCleanerService.java
@@ -37,6 +37,7 @@ public final class Jdk9ByteBufferCleanerService implements ByteBufferCleanerServ
 
     @Override
     public int impact() {
-        return LITTLE_IMPACT;
+        // invokeExact() + `static final` method handle = inlined to vanilla method call
+        return NO_IMPACT;
     }
 }

--- a/src/main/java/net/openhft/chronicle/core/cleaner/spi/ByteBufferCleanerService.java
+++ b/src/main/java/net/openhft/chronicle/core/cleaner/spi/ByteBufferCleanerService.java
@@ -4,7 +4,8 @@ import java.nio.ByteBuffer;
 
 public interface ByteBufferCleanerService {
     int NO_IMPACT = 0;
-    int SOME_IMPACT = 1;
+    int LITTLE_IMPACT = 1;
+    int SOME_IMPACT = 2;
 
     void clean(final ByteBuffer buffer);
 

--- a/src/main/java/net/openhft/chronicle/core/cleaner/spi/ByteBufferCleanerService.java
+++ b/src/main/java/net/openhft/chronicle/core/cleaner/spi/ByteBufferCleanerService.java
@@ -4,8 +4,7 @@ import java.nio.ByteBuffer;
 
 public interface ByteBufferCleanerService {
     int NO_IMPACT = 0;
-    int LITTLE_IMPACT = 1;
-    int SOME_IMPACT = 2;
+    int SOME_IMPACT = 1;
 
     void clean(final ByteBuffer buffer);
 

--- a/src/main/resources/META-INF/services/net.openhft.chronicle.core.cleaner.spi.ByteBufferCleanerService
+++ b/src/main/resources/META-INF/services/net.openhft.chronicle.core.cleaner.spi.ByteBufferCleanerService
@@ -1,2 +1,3 @@
 net.openhft.chronicle.core.cleaner.impl.jdk8.Jdk8ByteBufferCleanerService
+net.openhft.chronicle.core.cleaner.impl.jdk9.Jdk9ByteBufferCleanerService
 net.openhft.chronicle.core.cleaner.impl.reflect.ReflectionBasedByteBufferCleanerService

--- a/src/test/java/net/openhft/chronicle/core/cleaner/impl/jdk9/Jdk9ByteBufferCleanerServiceTest.java
+++ b/src/test/java/net/openhft/chronicle/core/cleaner/impl/jdk9/Jdk9ByteBufferCleanerServiceTest.java
@@ -1,0 +1,16 @@
+package net.openhft.chronicle.core.cleaner.impl.jdk9;
+
+import net.openhft.chronicle.core.Jvm;
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+
+import static org.junit.Assume.*;
+
+public class Jdk9ByteBufferCleanerServiceTest {
+    @Test
+    public void shouldCleanBuffer() {
+        assumeTrue(Jvm.isJava9Plus());
+        new Jdk9ByteBufferCleanerService().clean(ByteBuffer.allocateDirect(64));
+    }
+}

--- a/src/test/resources/META-INF/services/net.openhft.chronicle.core.cleaner.spi.ByteBufferCleanerService
+++ b/src/test/resources/META-INF/services/net.openhft.chronicle.core.cleaner.spi.ByteBufferCleanerService
@@ -1,2 +1,3 @@
 net.openhft.chronicle.core.cleaner.impl.jdk8.Jdk8ByteBufferCleanerService
+net.openhft.chronicle.core.cleaner.impl.jdk9.Jdk9ByteBufferCleanerService
 net.openhft.chronicle.core.cleaner.impl.reflect.ReflectionBasedByteBufferCleanerService


### PR DESCRIPTION
The first commit fixes a Maven build warning.

(Fixes #92) The second commit implements a `ByteBufferCleanerService` that leverages `Unsafe#invokeCleaner(ByteBuffer)`, which is available since Java 9.

I had to resort to reflection to call the method, because I could not find a way to conditionally compile and package specific files based on the JDK version. Fortunately, since the method handle is constant, there will be no performance overhead.