### PR TITLE
Make unmap0/read0/write0 MethodHandles final

### DIFF
--- a/src/main/java/net/openhft/chronicle/core/OS.java
+++ b/src/main/java/net/openhft/chronicle/core/OS.java
@@ -71,9 +71,9 @@ public enum OS {
     private static final boolean IS_WIN = OS.startsWith("win");
     private static final boolean IS_WIN10 = OS.equals("windows 10");
     private static final AtomicLong memoryMapped = new AtomicLong();
-    private static MethodHandle UNMAPP0_MH;
-    private static MethodHandle READ0_MH;
-    private static MethodHandle WRITE0_MH, WRITE0_MH2;
+    private static final MethodHandle UNMAPP0_MH;
+    private static final MethodHandle READ0_MH;
+    private static final MethodHandle WRITE0_MH, WRITE0_MH2;
     public static final Exception TIME_LIMIT = new TimeLimitExceededException();
     private static int PAGE_SIZE; // avoid circular initialisation
     private static int MAP_ALIGNMENT;


### PR DESCRIPTION
According to Aleksey Shipilёv, MethodHandles should be placed in static final fields in order to achieve an ultimate performance. 

Is it an intentional decision to keep those fields as non-final?

https://shipilev.net/blog/2015/faster-atomic-fu/#_final_fields_and_holder_s_identity
https://shipilev.net/jvm/anatomy-quarks/17-trust-nonstatic-final-fields/