### PR TITLE
Add Instant constructor for SetTimeProvider

### DIFF
--- a/src/main/java/net/openhft/chronicle/core/time/SetTimeProvider.java
+++ b/src/main/java/net/openhft/chronicle/core/time/SetTimeProvider.java
@@ -46,11 +46,19 @@ public class SetTimeProvider extends AtomicLong implements TimeProvider {
         super(initialNanos(timestamp));
     }
 
+    public SetTimeProvider(Instant instant) {
+        super(initialNanos(instant));
+    }
+
     static long initialNanos(String timestamp) {
-        Instant dateTime = LocalDateTime.parse(timestamp.replace("/", "-")).toInstant(ZoneOffset.UTC);
-        long initialNanos = dateTime.getEpochSecond() * 1_000_000_000L;
-        if (dateTime.isSupported(ChronoField.NANO_OF_SECOND))
-            initialNanos += dateTime.getLong(ChronoField.NANO_OF_SECOND);
+        LocalDateTime dateTime = LocalDateTime.parse(timestamp.replace("/", "-"));
+        return initialNanos(dateTime.toInstant(ZoneOffset.UTC));
+    }
+
+    static long initialNanos(Instant instant) {
+        long initialNanos = instant.getEpochSecond() * 1_000_000_000L;
+        if (instant.isSupported(ChronoField.NANO_OF_SECOND))
+            initialNanos += instant.getLong(ChronoField.NANO_OF_SECOND);
         return initialNanos;
     }
 

--- a/src/test/java/net/openhft/chronicle/core/time/SetTimeProviderTest.java
+++ b/src/test/java/net/openhft/chronicle/core/time/SetTimeProviderTest.java
@@ -2,6 +2,7 @@ package net.openhft.chronicle.core.time;
 
 import org.junit.Test;
 
+import java.time.Instant;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
@@ -68,6 +69,16 @@ public class SetTimeProviderTest {
         assertEquals(1534769584075L, tp.currentTimeMillis());
         assertEquals(1534769584075000L, tp.currentTimeMicros());
         SetTimeProvider tp2 = new SetTimeProvider("2018-08-20T12:53:04.075123");
+        assertEquals(1534769584075L, tp2.currentTimeMillis());
+        assertEquals(1534769584075123L, tp2.currentTimeMicros());
+    }
+
+    @Test
+    public void withInstant() {
+        SetTimeProvider tp = new SetTimeProvider(Instant.parse("2018-08-20T12:53:04.075Z"));
+        assertEquals(1534769584075L, tp.currentTimeMillis());
+        assertEquals(1534769584075000L, tp.currentTimeMicros());
+        SetTimeProvider tp2 = new SetTimeProvider(Instant.parse("2018-08-20T12:53:04.075123Z"));
         assertEquals(1534769584075L, tp2.currentTimeMillis());
         assertEquals(1534769584075123L, tp2.currentTimeMicros());
     }


### PR DESCRIPTION
Hi!

Sometimes it may happen that you already have some Instant timestamp to test with. E.g. Instant.now() or timestamp fetched from a test data source.

That would be handy to have a constructor to use it directly.