### PR TITLE
Allow demo repos to be tracked

### DIFF
--- a/src/main/java/net/openhft/chronicle/core/internal/analytics/StandardMaps.java
+++ b/src/main/java/net/openhft/chronicle/core/internal/analytics/StandardMaps.java
@@ -19,6 +19,12 @@ public enum StandardMaps {
 
     private static final long GIB = 1L << 30;
 
+    // Any package containing these sub-strings will be used
+    private static final Set<String> WHITE_LIST_CONTAINS = Stream.of(
+            ".demo",
+            "run.chronicle"
+    ).collect(toSet());
+
     // Exact match of package names. O(1) lookup performance.
     private static final Set<String> BLACK_LIST_EXACT = Stream.of(
             "java.lang",
@@ -41,10 +47,6 @@ public enum StandardMaps {
                     // Add third party libs
             )).collect(toSet());
 
-    private static final Set<String> WHITE_LIST_CONTAINS = Stream.of(
-            ".demo",
-            "run.chronicle"
-    ).collect(toSet());
 
     public static Map<String, String> standardEventParameters(@NotNull final String appVersion) {
         requireNonNull(appVersion);

--- a/src/main/java/net/openhft/chronicle/core/internal/analytics/StandardMaps.java
+++ b/src/main/java/net/openhft/chronicle/core/internal/analytics/StandardMaps.java
@@ -42,7 +42,8 @@ public enum StandardMaps {
             )).collect(toSet());
 
     private static final Set<String> WHITE_LIST_CONTAINS = Stream.of(
-            ".demo"
+            ".demo",
+            "run.chronicle"
     ).collect(toSet());
 
     public static Map<String, String> standardEventParameters(@NotNull final String appVersion) {

--- a/src/main/java/net/openhft/chronicle/core/internal/analytics/StandardMaps.java
+++ b/src/main/java/net/openhft/chronicle/core/internal/analytics/StandardMaps.java
@@ -19,27 +19,31 @@ public enum StandardMaps {
 
     private static final long GIB = 1L << 30;
 
-    // Exact match of package names of length 1 to 3. O(1) lookup performance.
-    private static final Set<String> KNOWN_PACKAGE_NAMES_OF_MAX_DEPTH_3 = Stream.of(
+    // Exact match of package names. O(1) lookup performance.
+    private static final Set<String> BLACK_LIST_EXACT = Stream.of(
             "java.lang",
             "sun.reflect",
             "java.lang.reflect",
-            "net.openhft.chronicle",
             "org.apache.maven"
     ).collect(toSet());
 
     // This is more expensive because we are using startsWith() with
     // these package names.
-    private static final Set<String> OTHER_KNOWN_PACKAGE_NAMES = Stream.of(
-            "software.chronicle", // Enterprise packages
-            "org.junit",
-            "net.openhft",
-            "java",
-            "jdk",
-            "sun"
-            // Add third party libs
-    ).collect(toSet());
+    private static final Set<String> BLACK_LIST_STARTS_WITH = Stream.concat(
+            BLACK_LIST_EXACT.stream(),
+            Stream.of(
+                    "software.chronicle", // Enterprise packages
+                    "org.junit",
+                    "net.openhft",
+                    "java",
+                    "jdk",
+                    "sun"
+                    // Add third party libs
+            )).collect(toSet());
 
+    private static final Set<String> WHITE_LIST_CONTAINS = Stream.of(
+            ".demo"
+    ).collect(toSet());
 
     public static Map<String, String> standardEventParameters(@NotNull final String appVersion) {
         requireNonNull(appVersion);
@@ -74,16 +78,32 @@ public enum StandardMaps {
     static Map<String, String> standardAdditionalEventParameters(@NotNull final StackTraceElement[] stackTraceElements) {
         requireNonNull(stackTraceElements);
         final AtomicInteger cnt = new AtomicInteger();
+        final Set<String> distinctKeys = new HashSet<>();
         return Stream.of(stackTraceElements)
                 .map(StackTraceElement::getClassName)
-                .map(StandardMaps::packageNameUpToMaxLevel3)
-                .filter(StandardMaps::isUnknownPackageName)
-                .distinct()
+                .map(StandardMaps::packageName)
+                .filter(StandardMaps::shouldBeSent)
+                .filter(pn -> StandardMaps.distinctUpToMaxLevel3(pn, distinctKeys))
                 .limit(3)
                 .collect(toOrderedMap(s -> "package_name_" + cnt.getAndIncrement(), Function.identity()));
     }
 
+    static boolean distinctUpToMaxLevel3(final String name, final Set<String> set) {
+        final String packageNameUpToMaxLevel3 = packageNameUpToMaxLevel3(name);
+        return set.add(packageNameUpToMaxLevel3);
+    }
+
+    static String packageName(final String className) {
+        final int lastDotIndex = className.lastIndexOf('.');
+        if (lastDotIndex>0)
+            return className.substring(0, lastDotIndex);
+        else
+            return className;
+    }
+
     static String packageNameUpToMaxLevel3(final String className) {
+        if (className.isEmpty())
+            return className;
         int noDots = 0;
         int i = 0;
         int lastDotIndex = 0;
@@ -97,14 +117,15 @@ public enum StandardMaps {
         }
         if (lastDotIndex == 0) {
             // No package found
-            return "";
+            return className;
         }
         return className.substring(0, lastDotIndex);
     }
 
-    static boolean isUnknownPackageName(final String packageName) {
-        return !KNOWN_PACKAGE_NAMES_OF_MAX_DEPTH_3.contains(packageName)
-                && OTHER_KNOWN_PACKAGE_NAMES.stream().noneMatch(packageName::startsWith);
+    static boolean shouldBeSent(final String packageName) {
+        return WHITE_LIST_CONTAINS.stream().anyMatch(packageName::contains)
+                || (!BLACK_LIST_EXACT.contains(packageName)
+                && BLACK_LIST_STARTS_WITH.stream().noneMatch(packageName::startsWith));
     }
 
     @NotNull


### PR DESCRIPTION
This PR changes the behaviour of the Analytics module by introducing a white list with "contains" package names. Initially, it contains just one element: ".demo". Also, package names are not limited to three levels but are still distinct up to level three (e.g. `a.b.c.d` and `a.b.c.d.e` reports just one of them but the entire package name, for example, `a.b.c.d`).