### PR TITLE
allow system properties loaded from system.properties file to be overriden from command line

### DIFF
--- a/src/main/java/net/openhft/chronicle/core/Jvm.java
+++ b/src/main/java/net/openhft/chronicle/core/Jvm.java
@@ -224,7 +224,8 @@ public enum Jvm {
                 } else {
                     final Properties prop = new Properties();
                     prop.load(is);
-                    System.getProperties().putAll(prop);
+                    // if user has specified a property using -D then don't overwrite it from system.properties
+                    prop.forEach((o, o2) -> System.getProperties().putIfAbsent(o, o2));
                     Slf4jExceptionHandler.DEBUG.on(Jvm.class, "Loaded " + name + " with " + prop);
                 }
             }


### PR DESCRIPTION
Right now if I have a property `foo=woo` set in system.properties and then define `-Dfoo=bar` on command line the value from command line is lost so System.getProperty("foo") == woo.

This change allows the -D on command line to override, which makes more sense from user's POV IMO.

This is not a big change but doing a PR as this is potentially surprising and impactive.