### PR TITLE
Add javadoc for QueryCloseable

### DIFF
--- a/src/main/java/net/openhft/chronicle/core/io/QueryCloseable.java
+++ b/src/main/java/net/openhft/chronicle/core/io/QueryCloseable.java
@@ -5,10 +5,23 @@
 package net.openhft.chronicle.core.io;
 
 public interface QueryCloseable {
+
+    /**
+     * Is this object closed, or in the process of closing
+     * <p>
+     * This should always be true if {@link #isClosed()} is true
+     *
+     * @return true if close() has been called (but not necessarily completed)
+     */
     default boolean isClosing() {
         return isClosed();
     }
 
+    /**
+     * Is this object closed
+     *
+     * @return true if close() has completed
+     */
     boolean isClosed();
 
     /* to be moved in x.22 to ManagedCloseable*/


### PR DESCRIPTION
# Background
QueryClosable defines `boolean isClosed()` and `boolean isClosing()`.

There are a few implementations of these methods that I could find.

## Default implementation
The default implementation for `isClosing()` is:
https://github.com/OpenHFT/Chronicle-Core/blob/30b8713a0314c9f659cdc4872951ac87a61b4196/src/main/java/net/openhft/chronicle/core/io/QueryCloseable.java#L8-L10

So if an implementer only implements `isClosed()`, then `isClosing()` == `isClosed()` (1)

The default implementation of `throwExceptionIfClosed()` also behaves as though "closing" is effectively "closed"
https://github.com/OpenHFT/Chronicle-Core/blob/30b8713a0314c9f659cdc4872951ac87a61b4196/src/main/java/net/openhft/chronicle/core/io/QueryCloseable.java#L15-L18

## Most common implementation
A common implementation that is used everywhere in our code base comes from `AbstractCloseable` (2)
https://github.com/OpenHFT/Chronicle-Core/blob/30b8713a0314c9f659cdc4872951ac87a61b4196/src/main/java/net/openhft/chronicle/core/io/AbstractCloseable.java#L208-L227
https://github.com/OpenHFT/Chronicle-Core/blob/30b8713a0314c9f659cdc4872951ac87a61b4196/src/main/java/net/openhft/chronicle/core/io/AbstractCloseable.java#L285-L293

To summarise
1. At the start of close, we atomically switch `closed` from `STATE_NOT_CLOSED` to `STATE_CLOSING`
2. We call the `performClose()` method implemented by the subclass
3. When it returns we set `closed` to `STATE_CLOSED`
4. `isClosing()` is implemented as `closed != STATE_NOT_CLOSED`
5. `isClosed()` is implemented as `closed == STATE_CLOSED`

So the assumption seems to be that `close()` is synchronous and in the course of the call we go from `STATE_NOT_CLOSED` -> `STATE_CLOSING` -> `STATE_CLOSED`.

## The need for clarity in the contract

Because `close()` is blocking, in a class that is only accessed by a single thread, the distinction between "closing" and "closed" is not important, because nobody would ever observe the class in "closing" state. But in a class that is accessed by multiple threads it is possible for one thread to be in `close()` when another one is querying its state.

In fact in `EventGroup` this happens not irregularly (at least in tests). See the `performClose()` method of `EventGroup`
https://github.com/OpenHFT/Chronicle-Threads/blob/57ad885ef9091856faceb3f33fc06dd6ff6992dc/src/main/java/net/openhft/chronicle/threads/EventGroup.java#L396

It is synchronous and blocks while it calls the blocking close methods of all the component event loops. All of these have similar patterns that wait for an handlers to execute on the final iteration before returning, so it can spend a significant amount of time in "closing" state.

The problem I've observed is in many places we use `isClosed()` to determine the life-cycle of the event loops when we're deciding whether to interact with them. The pattern looks like:

```
if (!eventLoop.isClosed()) {
   // do something you should only do when it's running, like adding a  handler
}
```

And is repeated in [many places](https://github.com/OpenHFT/Chronicle-Network/pull/127)

This isn't a big deal except it leads to flaky tests because the event loops rightfully warn when someone tries to add a handler to a closing loop, for example [here](https://teamcity.chronicle.software/buildConfiguration/OpenHFT_ChronicleQueueEnterprise_Snapshot/590240?expandedTest=build%3A%28id%3A590240%29%2Cid%3A6534).

The real problem is probably that we don't have an explicit life-cycle in the event loops that can be queried for the above purpose, perhaps `QueryCloseable` is exposing state that should only really be used to ensure idempotency of a close method.

But this PR is just an attempt to clarify what the meaning of `isClosed()` and `isClosing()` is because without a definition of the contract the interface is a bit useless and prone to abuse as we've seen throughout Chronicle-Network.

# Summary
So to justify the descriptions I added, because of the default `isClosing()` implementation (see 1 above) `isClosing()` needs to be true when `isClosed()` is true, or the default implementation is invalid. This is also consistent with the most commonly used implementation of the two methods in AbstractCloseable (see 2 above).

From a utility perspective. If we want to use `isClosing()`/`isClosed()` to avoid performing actions that should only be performed on things that aren't "closing" or "closed" (I am open to the argument this is an abuse of the state), it is much simpler to be able to call `isClosing()` and have it cover the "closed" and "closing" states rather than having to call `if  (!(isClosed() || isClosing())) { ....`. The latter form is more cumbersome for the caller and can't be implemented atomically.

I'm aware we can't prevent these warnings entirely because a concurrently accessed event loop could go into closing state between the `isClosing()` check and the action being performed, but given how long some of these close methods block for, we could significanly reduce the likelihood of seeing a warning.