### PR TITLE
Add ability to check if the current thread is the background resource releaser thread

### DIFF
--- a/src/main/java/net/openhft/chronicle/core/io/AbstractCloseable.java
+++ b/src/main/java/net/openhft/chronicle/core/io/AbstractCloseable.java
@@ -29,7 +29,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
-import static net.openhft.chronicle.core.io.BackgroundResourceReleaser.BACKGROUND_RESOURCE_RELEASER;
 import static net.openhft.chronicle.core.io.BackgroundResourceReleaser.BG_RELEASER;
 import static net.openhft.chronicle.core.io.TracingReferenceCounted.asString;
 
@@ -222,7 +221,7 @@ public abstract class AbstractCloseable implements CloseableTracer, ReferenceOwn
         callPerformClose();
         long time = System.nanoTime() - start;
         if (time >= WARN_NS &&
-                !Thread.currentThread().getName().equals(BACKGROUND_RESOURCE_RELEASER))
+                !BackgroundResourceReleaser.isOnBackgroundResourceReleaserThread())
             Jvm.perf().on(getClass(), "Took " + time / 1000_000 + " ms to performClose");
     }
 

--- a/src/main/java/net/openhft/chronicle/core/io/BackgroundResourceReleaser.java
+++ b/src/main/java/net/openhft/chronicle/core/io/BackgroundResourceReleaser.java
@@ -87,4 +87,13 @@ public enum BackgroundResourceReleaser {
             COUNTER.decrementAndGet();
         }
     }
+
+    /**
+     * Is the current thread the background resource releaser thread?
+     *
+     * @return true if the current thread is the background resource releaser thread
+     */
+    public static boolean isOnBackgroundResourceReleaserThread() {
+        return Thread.currentThread() == RELEASER;
+    }
 }


### PR DESCRIPTION
Seems a bit less brittle than using the thread name? e.g. would be easy to switch to a multi-threaded BRR without affecting clients this way, or some other strategy