### PR TITLE
Don't warn when interrupt is called from a non-interrupted thread

### DIFF
--- a/src/main/java/net/openhft/chronicle/core/Jvm.java
+++ b/src/main/java/net/openhft/chronicle/core/Jvm.java
@@ -1541,8 +1541,6 @@ public enum Jvm {
             boolean interrupted = Thread.currentThread().isInterrupted();
             if (Jvm.isDebugEnabled(getClass()))
                 Jvm.debug().on(clazz, fc + " not closed on interrupt, interrupted= " + interrupted);
-            else if (!interrupted)
-                Jvm.warn().on(clazz, fc + " thread not interrupted as expected.");
             inside.set(false);
         }
     }


### PR DESCRIPTION
Fixes #251 & ChronicleEnterprise/Chronicle-Queue-Enterprise#250

The simplest fix is to just remove the warning as it's something that happens sometimes, but I would appreciate a review from @peter-lawrey just in case there is any other logic relying on that assumption, or if this warning is there because interrupt being called by another thread might be problematic?