### PR TITLE
rationalise UnsafeMemory.copyMemory functions, optimise performance, improve test coverage

### DIFF
--- a/src/test/java/net/openhft/chronicle/core/MemoryTest.java
+++ b/src/test/java/net/openhft/chronicle/core/MemoryTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 import sun.misc.Unsafe;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class MemoryTest {
 
@@ -37,10 +38,10 @@ public class MemoryTest {
         long address = memory.allocate(1024);
         try {
             memory.writeInt(address, 1);
-            assert memory.readInt(address) == 1;
+            assertEquals(1, memory.readInt(address));
             final boolean swapped = memory.compareAndSwapInt(address, 1, 2);
-            assert swapped;
-            assert memory.readInt(address) == 2;
+            assertTrue(swapped);
+            assertEquals(2, memory.readInt(address));
         } finally {
             memory.freeMemory(address, 1024);
         }


### PR DESCRIPTION
Confirmed now that this works with build-all. I had to restore the loop for some on heap Object copies