### PR TITLE
SKIP_ASSERTIONS = false

### DIFF
--- a/src/main/java/net/openhft/chronicle/core/util/AssertUtil.java
+++ b/src/main/java/net/openhft/chronicle/core/util/AssertUtil.java
@@ -126,7 +126,7 @@ public final class AssertUtil {
      * Performance critical code should use one of the first two schemes devised above to assert invariants.
      * The third, more convenient form, can be used for non-performance critical code.
      */
-    public static final boolean SKIP_ASSERTIONS = true;
+    public static final boolean SKIP_ASSERTIONS = false;
 
     // Suppresses default constructor, ensuring non-instantiability.
     private AssertUtil() {


### PR DESCRIPTION
This is a temporary flick of this flag to make sure that all libraries build with the zero-cost assertions enabled. Ideally, this should be an automatic procedure during build all. Any ideas @alamar on how we could automate this process?

We should never release with this flag set.