### PR TITLE
Make exception assertion logic reusable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,6 @@
         <dependency>
             <groupId>net.openhft</groupId>
             <artifactId>chronicle-test-framework</artifactId>
-            <version>2.23ea2-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,8 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
 
@@ -26,8 +27,8 @@
     </parent>
     <properties>
       <zero.cost.assertions>disabled</zero.cost.assertions>
-      <sonar.organization>openhft</sonar.organization>
-      <sonar.host.url>https://sonarcloud.io</sonar.host.url>
+        <sonar.organization>openhft</sonar.organization>
+        <sonar.host.url>https://sonarcloud.io</sonar.host.url>
     </properties>
     <artifactId>chronicle-core</artifactId>
     <version>2.23ea9-SNAPSHOT</version>
@@ -209,6 +210,13 @@
                         </manifestEntries>
                     </archive>
                 </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
 
             <!--

--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,7 @@
         <dependency>
             <groupId>net.openhft</groupId>
             <artifactId>chronicle-test-framework</artifactId>
+            <version>2.23ea2-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/java/net/openhft/chronicle/core/Jvm.java
+++ b/src/main/java/net/openhft/chronicle/core/Jvm.java
@@ -841,7 +841,7 @@ public final class Jvm {
         final Iterator<ExceptionKey> iterator = exceptions.keySet().iterator();
         while (iterator.hasNext()) {
             final ExceptionKey k = iterator.next();
-            if (k.level != LogLevel.DEBUG && k.level != LogLevel.PERF)
+            if (k.level() != LogLevel.DEBUG && k.level() != LogLevel.PERF)
                 return true;
         }
 
@@ -945,7 +945,7 @@ public final class Jvm {
         final Slf4jExceptionHandler warn = Slf4jExceptionHandler.WARN;
         for (@NotNull Entry<ExceptionKey, Integer> entry : exceptions.entrySet()) {
             final ExceptionKey key = entry.getKey();
-            warn.on(Jvm.class, key.level + " " + key.clazz.getSimpleName() + " " + key.message, key.throwable);
+            warn.on(Jvm.class, key.level() + " " + key.clazz().getSimpleName() + " " + key.message(), key.throwable());
             final Integer value = entry.getValue();
             if (value > 1)
                 warn.on(Jvm.class, "Repeated " + value + " times");

--- a/src/main/java/net/openhft/chronicle/core/Jvm.java
+++ b/src/main/java/net/openhft/chronicle/core/Jvm.java
@@ -832,6 +832,10 @@ public final class Jvm {
         return eh;
     }
 
+    /**
+     * @deprecated use {@link JvmExceptionTracker#create()} instead
+     */
+    @Deprecated
     public static boolean hasException(@NotNull final Map<ExceptionKey, Integer> exceptions) {
 
         final Iterator<ExceptionKey> iterator = exceptions.keySet().iterator();
@@ -933,6 +937,10 @@ public final class Jvm {
         return DEBUG;
     }
 
+    /**
+     * @deprecated Use {@link JvmExceptionTracker#create()} instead
+     */
+    @Deprecated
     public static void dumpException(@NotNull final Map<ExceptionKey, Integer> exceptions) {
         final Slf4jExceptionHandler warn = Slf4jExceptionHandler.WARN;
         for (@NotNull Entry<ExceptionKey, Integer> entry : exceptions.entrySet()) {

--- a/src/main/java/net/openhft/chronicle/core/Jvm.java
+++ b/src/main/java/net/openhft/chronicle/core/Jvm.java
@@ -833,7 +833,7 @@ public final class Jvm {
     }
 
     /**
-     * @deprecated use {@link JvmExceptionTracker#create()} instead
+     * @deprecated use {@link net.openhft.chronicle.core.internal.JvmExceptionTracker#create()} instead (to be removed in .25)
      */
     @Deprecated
     public static boolean hasException(@NotNull final Map<ExceptionKey, Integer> exceptions) {
@@ -938,7 +938,7 @@ public final class Jvm {
     }
 
     /**
-     * @deprecated Use {@link JvmExceptionTracker#create()} instead
+     * @deprecated Use {@link net.openhft.chronicle.core.internal.JvmExceptionTracker#create()} instead (to be removed in .25)
      */
     @Deprecated
     public static void dumpException(@NotNull final Map<ExceptionKey, Integer> exceptions) {

--- a/src/main/java/net/openhft/chronicle/core/onoes/ExceptionKey.java
+++ b/src/main/java/net/openhft/chronicle/core/onoes/ExceptionKey.java
@@ -25,9 +25,25 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 
 public class ExceptionKey {
+    /**
+     * @deprecated This will become private in .25
+     */
+    @Deprecated
     public final LogLevel level;
+    /**
+     * @deprecated This will become private in .25
+     */
+    @Deprecated
     public final Class<?> clazz;
+    /**
+     * @deprecated This will become private in .25
+     */
+    @Deprecated
     public final String message;
+    /**
+     * @deprecated This will become private in .25
+     */
+    @Deprecated
     public final Throwable throwable;
 
     public ExceptionKey(LogLevel level, Class<?> clazz, String message, Throwable throwable) {
@@ -35,6 +51,22 @@ public class ExceptionKey {
         this.clazz = clazz;
         this.message = message;
         this.throwable = throwable;
+    }
+
+    public LogLevel level() {
+        return level;
+    }
+
+    public Class<?> clazz() {
+        return clazz;
+    }
+
+    public String message() {
+        return message;
+    }
+
+    public Throwable throwable() {
+        return throwable;
     }
 
     @Override

--- a/src/main/java/net/openhft/chronicle/core/onoes/ExceptionKey.java
+++ b/src/main/java/net/openhft/chronicle/core/onoes/ExceptionKey.java
@@ -24,6 +24,7 @@ import org.jetbrains.annotations.NotNull;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 
+@SuppressWarnings({"deprecated", "squid:S1874", "squid:S6355"}) // public fields will become private, they're not being removed entirely
 public class ExceptionKey {
     /**
      * @deprecated This will become private in .25

--- a/src/test/java/net/openhft/chronicle/core/CoreTestCommon.java
+++ b/src/test/java/net/openhft/chronicle/core/CoreTestCommon.java
@@ -1,25 +1,18 @@
 package net.openhft.chronicle.core;
 
+import net.openhft.chronicle.core.internal.ExceptionTracker;
 import net.openhft.chronicle.core.io.AbstractReferenceCounted;
-import net.openhft.chronicle.core.onoes.ExceptionKey;
-import net.openhft.chronicle.core.onoes.Slf4jExceptionHandler;
 import net.openhft.chronicle.core.threads.CleaningThread;
 import net.openhft.chronicle.core.threads.ThreadDump;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
-
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.function.Predicate;
 
 import static net.openhft.chronicle.core.io.AbstractCloseable.waitForCloseablesToClose;
 import static net.openhft.chronicle.core.io.AbstractReferenceCounted.assertReferencesReleased;
 
 public class CoreTestCommon {
     protected ThreadDump threadDump;
-    protected Map<ExceptionKey, Integer> exceptions;
-    private Map<Predicate<ExceptionKey>, String> expectedExceptions = new LinkedHashMap<>();
+    private final ExceptionTracker exceptionTracker = new ExceptionTracker();
 
     @Before
     public void enableReferenceTracing() {
@@ -37,28 +30,15 @@ public class CoreTestCommon {
 
     @Before
     public void recordExceptions() {
-        exceptions = Jvm.recordExceptions();
+        exceptionTracker.recordExceptions();
     }
 
     public void expectException(String message) {
-        expectException(k -> k.message.contains(message) || (k.throwable != null && k.throwable.getMessage().contains(message)), message);
+        exceptionTracker.expectException(message);
     }
 
-    public void expectException(Predicate<ExceptionKey> predicate, String description) {
-        expectedExceptions.put(predicate, description);
-    }
-
-    public void checkExceptions() {
-        for (Map.Entry<Predicate<ExceptionKey>, String> expectedException : expectedExceptions.entrySet()) {
-            if (!exceptions.keySet().removeIf(expectedException.getKey()))
-                Slf4jExceptionHandler.WARN.on(getClass(), "No error for " + expectedException.getValue());
-        }
-        expectedExceptions.clear();
-        if (Jvm.hasException(exceptions)) {
-            Jvm.dumpException(exceptions);
-            Jvm.resetExceptionHandlers();
-            Assert.fail(exceptions.keySet().toString());
-        }
+    public void ignoreException(String message) {
+        exceptionTracker.ignoreException(message);
     }
 
     @After
@@ -71,7 +51,7 @@ public class CoreTestCommon {
 
         assertReferencesReleased();
         checkThreadDump();
-        checkExceptions();
+        exceptionTracker.checkExceptions();
         AbstractReferenceCounted.disableReferenceTracing();
     }
 }

--- a/src/test/java/net/openhft/chronicle/core/CoreTestCommon.java
+++ b/src/test/java/net/openhft/chronicle/core/CoreTestCommon.java
@@ -1,9 +1,10 @@
 package net.openhft.chronicle.core;
 
-import net.openhft.chronicle.core.internal.ExceptionTracker;
+import net.openhft.chronicle.core.internal.JvmExceptionTracker;
 import net.openhft.chronicle.core.io.AbstractReferenceCounted;
 import net.openhft.chronicle.core.threads.CleaningThread;
 import net.openhft.chronicle.core.threads.ThreadDump;
+import net.openhft.chronicle.testframework.internal.ExceptionTracker;
 import org.junit.After;
 import org.junit.Before;
 
@@ -12,7 +13,7 @@ import static net.openhft.chronicle.core.io.AbstractReferenceCounted.assertRefer
 
 public class CoreTestCommon {
     protected ThreadDump threadDump;
-    private final ExceptionTracker exceptionTracker = new ExceptionTracker();
+    private ExceptionTracker<?> exceptionTracker;
 
     @Before
     public void enableReferenceTracing() {
@@ -29,8 +30,8 @@ public class CoreTestCommon {
     }
 
     @Before
-    public void recordExceptions() {
-        exceptionTracker.recordExceptions();
+    public void createExceptionTracker() {
+        exceptionTracker = JvmExceptionTracker.create();
     }
 
     public void expectException(String message) {

--- a/src/test/java/net/openhft/chronicle/core/internal/ExceptionTracker.java
+++ b/src/test/java/net/openhft/chronicle/core/internal/ExceptionTracker.java
@@ -1,0 +1,94 @@
+package net.openhft.chronicle.core.internal;
+
+import net.openhft.chronicle.core.Jvm;
+import net.openhft.chronicle.core.onoes.ExceptionKey;
+import net.openhft.chronicle.core.onoes.Slf4jExceptionHandler;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+/**
+ * A test utility class for recording and executing assertions about the presence (or absence) of exceptions
+ */
+public final class ExceptionTracker {
+    private final Map<Predicate<ExceptionKey>, String> ignoredExceptions = new LinkedHashMap<>();
+    private final Map<Predicate<ExceptionKey>, String> expectedExceptions = new LinkedHashMap<>();
+    private Map<ExceptionKey, Integer> exceptions;
+
+    /**
+     * Call this in @Before to start accumulating exceptions
+     */
+    public void recordExceptions() {
+        exceptions = Jvm.recordExceptions();
+    }
+
+    /**
+     * Ignore exceptions containing the specified string
+     *
+     * @param message The string to ignore
+     */
+    public void ignoreException(String message) {
+        ignoreException(k -> contains(k.message, message) || (k.throwable != null && contains(k.throwable.getMessage(), message)), message);
+    }
+
+    /**
+     * Require than an exception containing the specified string is thrown during the test
+     *
+     * @param message The string to require
+     */
+    public void expectException(String message) {
+        expectException(k -> contains(k.message, message) || (k.throwable != null && contains(k.throwable.getMessage(), message)), message);
+    }
+
+    /**
+     * Ignore exceptions matching the specified predicate
+     *
+     * @param predicate   The predicate to match the exception
+     * @param description The description of the exceptions being ignored
+     */
+    public void ignoreException(Predicate<ExceptionKey> predicate, String description) {
+        ignoredExceptions.put(predicate, description);
+    }
+
+    /**
+     * Require that an exception matching the specified predicate is thrown
+     *
+     * @param predicate   The predicate used to match exceptions
+     * @param description The description of the exceptions being required
+     */
+    public void expectException(Predicate<ExceptionKey> predicate, String description) {
+        expectedExceptions.put(predicate, description);
+    }
+
+    /**
+     * Call this in @After to ensure
+     * <ul>
+     *     <li>No non-ignored exceptions were thrown</li>
+     *     <li>There is an exception matching each of the expected predicates</li>
+     * </ul>
+     */
+    public void checkExceptions() {
+        for (Map.Entry<Predicate<ExceptionKey>, String> expectedException : expectedExceptions.entrySet()) {
+            if (!exceptions.keySet().removeIf(expectedException.getKey()))
+                throw new AssertionError("No error for " + expectedException.getValue());
+        }
+        expectedExceptions.clear();
+        for (Map.Entry<Predicate<ExceptionKey>, String> ignoredException : ignoredExceptions.entrySet()) {
+            if (!exceptions.keySet().removeIf(ignoredException.getKey()))
+                Slf4jExceptionHandler.DEBUG.on(getClass(), "Ignored " + ignoredException.getValue());
+        }
+        ignoredExceptions.clear();
+        if (Jvm.hasException(exceptions)) {
+            final String msg = exceptions.size() + " exceptions were detected: " + exceptions.keySet().stream().map(ek -> ek.message).collect(Collectors.joining(", "));
+            Jvm.dumpException(exceptions);
+            Jvm.resetExceptionHandlers();
+            throw new AssertionError(msg);
+        }
+    }
+
+    private static boolean contains(String text, String message) {
+        return text != null && text.contains(message);
+    }
+}

--- a/src/test/java/net/openhft/chronicle/core/internal/JvmExceptionTracker.java
+++ b/src/test/java/net/openhft/chronicle/core/internal/JvmExceptionTracker.java
@@ -4,7 +4,6 @@ import net.openhft.chronicle.core.Jvm;
 import net.openhft.chronicle.core.onoes.ExceptionKey;
 import net.openhft.chronicle.core.onoes.LogLevel;
 import net.openhft.chronicle.testframework.internal.ExceptionTracker;
-import net.openhft.chronicle.testframework.internal.VanillaExceptionTracker;
 
 import java.util.EnumSet;
 import java.util.Set;
@@ -27,7 +26,7 @@ public enum JvmExceptionTracker {
      * @return the exception tracker
      */
     public static ExceptionTracker<ExceptionKey> create() {
-        return new VanillaExceptionTracker<>(
+        return ExceptionTracker.create(
                 ExceptionKey::message,
                 ExceptionKey::throwable,
                 Jvm::resetExceptionHandlers,

--- a/src/test/java/net/openhft/chronicle/core/internal/JvmExceptionTracker.java
+++ b/src/test/java/net/openhft/chronicle/core/internal/JvmExceptionTracker.java
@@ -4,7 +4,7 @@ import net.openhft.chronicle.core.Jvm;
 import net.openhft.chronicle.core.onoes.ExceptionKey;
 import net.openhft.chronicle.core.onoes.LogLevel;
 import net.openhft.chronicle.testframework.internal.ExceptionTracker;
-import net.openhft.chronicle.testframework.internal.StandardExceptionTracker;
+import net.openhft.chronicle.testframework.internal.VanillaExceptionTracker;
 
 import java.util.EnumSet;
 import java.util.Set;
@@ -27,7 +27,7 @@ public enum JvmExceptionTracker {
      * @return the exception tracker
      */
     public static ExceptionTracker<ExceptionKey> create() {
-        return new StandardExceptionTracker<>(
+        return new VanillaExceptionTracker<>(
                 ExceptionKey::message,
                 ExceptionKey::throwable,
                 Jvm::resetExceptionHandlers,

--- a/src/test/java/net/openhft/chronicle/core/internal/JvmExceptionTracker.java
+++ b/src/test/java/net/openhft/chronicle/core/internal/JvmExceptionTracker.java
@@ -2,92 +2,38 @@ package net.openhft.chronicle.core.internal;
 
 import net.openhft.chronicle.core.Jvm;
 import net.openhft.chronicle.core.onoes.ExceptionKey;
-import net.openhft.chronicle.core.onoes.Slf4jExceptionHandler;
+import net.openhft.chronicle.core.onoes.LogLevel;
 import net.openhft.chronicle.testframework.internal.ExceptionTracker;
+import net.openhft.chronicle.testframework.internal.StandardExceptionTracker;
 
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
+import java.util.EnumSet;
+import java.util.Set;
+
+import static net.openhft.chronicle.core.onoes.LogLevel.DEBUG;
+import static net.openhft.chronicle.core.onoes.LogLevel.PERF;
 
 /**
- * An implementation of ExceptionTracker that uses {@link Jvm} to track exceptions represented
+ * A Factory for creating ExceptionTrackers that use {@link Jvm} to track exceptions represented
  * by {@link ExceptionKey}s.
  */
-public final class JvmExceptionTracker implements ExceptionTracker<ExceptionKey> {
-    private final Map<Predicate<ExceptionKey>, String> ignoredExceptions = new LinkedHashMap<>();
-    private final Map<Predicate<ExceptionKey>, String> expectedExceptions = new LinkedHashMap<>();
-    private final Map<ExceptionKey, Integer> exceptions;
+public enum JvmExceptionTracker {
+    ;
 
-    private JvmExceptionTracker(Map<ExceptionKey, Integer> exceptions) {
-        this.exceptions = exceptions;
-    }
+    private static final Set<LogLevel> IGNORED_LOG_LEVELS = EnumSet.of(DEBUG, PERF);
 
     /**
      * Create a JvmExceptionTracker
      *
      * @return the exception tracker
      */
-    public static JvmExceptionTracker create() {
-        return new JvmExceptionTracker(Jvm.recordExceptions());
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void ignoreException(String message) {
-        ignoreException(k -> contains(k.message, message) || (k.throwable != null && contains(k.throwable.getMessage(), message)), message);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void expectException(String message) {
-        expectException(k -> contains(k.message, message) || (k.throwable != null && contains(k.throwable.getMessage(), message)), message);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void ignoreException(Predicate<ExceptionKey> predicate, String description) {
-        ignoredExceptions.put(predicate, description);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void expectException(Predicate<ExceptionKey> predicate, String description) {
-        expectedExceptions.put(predicate, description);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void checkExceptions() {
-        for (Map.Entry<Predicate<ExceptionKey>, String> expectedException : expectedExceptions.entrySet()) {
-            if (!exceptions.keySet().removeIf(expectedException.getKey()))
-                throw new AssertionError("No error for " + expectedException.getValue());
-        }
-        expectedExceptions.clear();
-        for (Map.Entry<Predicate<ExceptionKey>, String> ignoredException : ignoredExceptions.entrySet()) {
-            if (!exceptions.keySet().removeIf(ignoredException.getKey()))
-                Slf4jExceptionHandler.DEBUG.on(getClass(), "Ignored " + ignoredException.getValue());
-        }
-        ignoredExceptions.clear();
-        if (Jvm.hasException(exceptions)) {
-            final String msg = exceptions.size() + " exceptions were detected: " + exceptions.keySet().stream().map(ek -> ek.message).collect(Collectors.joining(", "));
-            Jvm.dumpException(exceptions);
-            Jvm.resetExceptionHandlers();
-            throw new AssertionError(msg);
-        }
-    }
-
-    private static boolean contains(String text, String message) {
-        return text != null && text.contains(message);
+    public static ExceptionTracker<ExceptionKey> create() {
+        return new StandardExceptionTracker<>(
+                ExceptionKey::message,
+                ExceptionKey::throwable,
+                Jvm::resetExceptionHandlers,
+                Jvm.recordExceptions(),
+                key -> IGNORED_LOG_LEVELS.contains(key.level()),
+                key -> key.level() + " " + key.clazz().getSimpleName() + " " + key.message()
+        );
     }
 }

--- a/src/test/java/net/openhft/chronicle/core/internal/threads/VanillaThreadLockTest.java
+++ b/src/test/java/net/openhft/chronicle/core/internal/threads/VanillaThreadLockTest.java
@@ -5,7 +5,6 @@ import net.openhft.chronicle.core.Jvm;
 import net.openhft.chronicle.core.OS;
 import net.openhft.chronicle.core.threads.InterruptedRuntimeException;
 import net.openhft.chronicle.core.values.LongValue;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.ArrayList;

--- a/src/test/java/net/openhft/chronicle/core/internal/threads/VanillaThreadLockTest.java
+++ b/src/test/java/net/openhft/chronicle/core/internal/threads/VanillaThreadLockTest.java
@@ -93,7 +93,7 @@ public class VanillaThreadLockTest extends CoreTestCommon {
         VanillaThreadLock lock = new VanillaThreadLock(value, 50);
         lock.lock(-1);
 
-        expectException("ThreadId -1 died while holding a lock");
+        ignoreException("ThreadId -1 died while holding a lock");
         expectException("Successfully forced an unlock for threadId: 2, previous thread held by: -1, status: "); // dead or unknown
         lock.lock(2);
 
@@ -111,7 +111,7 @@ public class VanillaThreadLockTest extends CoreTestCommon {
         VanillaThreadLock lock = new VanillaThreadLock(value, 50);
         lock.lock(1);
 
-        expectException("ThreadId 1 is running while still holding a lock after ");
+        ignoreException("ThreadId 1 is running while still holding a lock after ");
         expectException("Successfully forced an unlock for threadId: 2, previous thread held by: 1, status: "); // running or unknown
         lock.lock(2);
 
@@ -158,7 +158,7 @@ public class VanillaThreadLockTest extends CoreTestCommon {
 
         // tryLock
         final long deadThreadId = 1L << 31;
-        expectException("ThreadId -2147483648 died while holding a lock");
+        ignoreException("ThreadId -2147483648 died while holding a lock");
         value.getValues.add(deadThreadId);
         // busyLoop
         value.getValues.add(deadThreadId);
@@ -170,7 +170,7 @@ public class VanillaThreadLockTest extends CoreTestCommon {
         value.getValues.add(deadThreadId);
 
         // OOPS changed at the last nano-second
-        expectException("Failed to forced an unlock for threadId: 1");
+        ignoreException("Failed to forced an unlock for threadId: 1");
         value.getValues.add(deadThreadId << 32);
 
         // tryLock

--- a/src/test/java/net/openhft/chronicle/core/io/AbstractCloseableTest.java
+++ b/src/test/java/net/openhft/chronicle/core/io/AbstractCloseableTest.java
@@ -55,7 +55,7 @@ public class AbstractCloseableTest extends CoreTestCommon {
             assertEquals("Discarded without closing\n" +
                             "java.lang.IllegalStateException: net.openhft.chronicle.core.StackTrace: net.openhft.chronicle.core.io.AbstractCloseableTest$MyCloseable created here on main",
                     map.keySet().stream()
-                            .map(e -> e.message + "\n" + e.throwable)
+                            .map(e -> e.message() + "\n" + e.throwable())
                             .collect(Collectors.joining(", ")));
     }
 


### PR DESCRIPTION
Just an idea, this code is repeated in all our `XXXTestCommon` classes, wouldn't it be easier/more consistent if it were packaged up for reuse like this?

I know this probably belongs in Chronicle-Test-Framework but `ExceptionKey` is in core, and core depends on Chronicle-Test-Framework so ideally we don't add a circular dependency there.

I made it release a test-jar so downstream projects could inherit it.
