### PR TITLE
Catch the NoClassDefFoundError thrown when Windows/OSX attempts to look up a class with the wrong case

### DIFF
--- a/src/test/java/net/openhft/chronicle/core/pool/ClassAliasPoolTest.java
+++ b/src/test/java/net/openhft/chronicle/core/pool/ClassAliasPoolTest.java
@@ -20,12 +20,14 @@ package net.openhft.chronicle.core.pool;
 
 import net.openhft.chronicle.core.CoreTestCommon;
 import net.openhft.chronicle.core.threads.ThreadDump;
+import net.openhft.chronicle.core.util.ClassNotFoundRuntimeException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
 import static net.openhft.chronicle.core.pool.ClassAliasPool.CLASS_ALIASES;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 public class ClassAliasPoolTest extends CoreTestCommon {
 
@@ -72,6 +74,14 @@ public class ClassAliasPoolTest extends CoreTestCommon {
         expectException("Replaced class net.openhft.chronicle.core.pool.ClassAliasPoolTest with class net.openhft.chronicle.core.pool.ClassAliasPoolTest$TestEnum");
         CLASS_ALIASES.addAlias(ClassAliasPoolTest.class, "name1");
         CLASS_ALIASES.addAlias(TestEnum.class, "name1");
+    }
+
+    /**
+     * On Windows this would cause a NoClassDefFoundError
+     */
+    @Test
+    public void wrongCaseClassName() {
+        assertThrows(ClassNotFoundRuntimeException.class, () -> CLASS_ALIASES.forName(TestEnum.class.getName().toLowerCase()));
     }
 
     enum TestEnum {


### PR DESCRIPTION
Fixes #372

This fix was originally in Chronicle-Wire, but really it belongs here. I wanted to keep it as targeted to the specific case (on Windows/OSX only) as I could because I don't like the idea of catching Errors.

The only downside is we break the API for `ClassNotFoundRuntimeException`. If we don't want to do that inside a release I could make it only return the cause when it is actually a `ClassNotFoundException`?