### PR TITLE
Make default set of exception handlers explicit

### DIFF
--- a/src/main/java/net/openhft/chronicle/core/Jvm.java
+++ b/src/main/java/net/openhft/chronicle/core/Jvm.java
@@ -69,6 +69,12 @@ import static net.openhft.chronicle.core.internal.util.MapUtil.ofUnmodifiable;
  */
 public final class Jvm {
 
+    // These are the exception handlers used initially, and restored when resetExceptionHandlers() is called
+    private static final ExceptionHandler DEFAULT_ERROR_EXCEPTION_HANDLER = Slf4jExceptionHandler.ERROR;
+    private static final ExceptionHandler DEFAULT_WARN_EXCEPTION_HANDLER = Slf4jExceptionHandler.WARN;
+    private static final ExceptionHandler DEFAULT_PERF_EXCEPTION_HANDLER = Slf4jExceptionHandler.PERF;
+    private static final ExceptionHandler DEFAULT_DEBUG_EXCEPTION_HANDLER = Slf4jExceptionHandler.DEBUG;
+
     // Suppresses default constructor, ensuring non-instantiability.
     private Jvm() {
     }
@@ -92,13 +98,13 @@ public final class Jvm {
     private static final boolean IS_AZUL_ZING = Bootstrap.isAzulZing0();
     private static final boolean IS_AZUL_ZULU = Bootstrap.isAzulZulu0();
     @NotNull
-    private static final ThreadLocalisedExceptionHandler ERROR = new ThreadLocalisedExceptionHandler(Slf4jExceptionHandler.ERROR);
+    private static final ThreadLocalisedExceptionHandler ERROR = new ThreadLocalisedExceptionHandler(DEFAULT_ERROR_EXCEPTION_HANDLER);
     @NotNull
-    private static final ThreadLocalisedExceptionHandler WARN = new ThreadLocalisedExceptionHandler(Slf4jExceptionHandler.WARN);
+    private static final ThreadLocalisedExceptionHandler WARN = new ThreadLocalisedExceptionHandler(DEFAULT_WARN_EXCEPTION_HANDLER);
     @NotNull
-    private static final ThreadLocalisedExceptionHandler PERF = new ThreadLocalisedExceptionHandler(Slf4jExceptionHandler.PERF);
+    private static final ThreadLocalisedExceptionHandler PERF = new ThreadLocalisedExceptionHandler(DEFAULT_PERF_EXCEPTION_HANDLER);
     @NotNull
-    private static final ThreadLocalisedExceptionHandler DEBUG = new ThreadLocalisedExceptionHandler(Slf4jExceptionHandler.DEBUG);
+    private static final ThreadLocalisedExceptionHandler DEBUG = new ThreadLocalisedExceptionHandler(DEFAULT_DEBUG_EXCEPTION_HANDLER);
     private static final long MAX_DIRECT_MEMORY;
     private static final boolean SAFEPOINT_ENABLED;
     private static final boolean IS_ARM = Bootstrap.isArm0();
@@ -757,10 +763,10 @@ public final class Jvm {
     }
 
     public static void resetExceptionHandlers() {
-        setErrorExceptionHandler(Slf4jExceptionHandler.ERROR);
-        setWarnExceptionHandler(Slf4jExceptionHandler.WARN);
-        setDebugExceptionHandler(Slf4jExceptionHandler.DEBUG);
-        setPerfExceptionHandler(Slf4jExceptionHandler.DEBUG);
+        setErrorExceptionHandler(DEFAULT_ERROR_EXCEPTION_HANDLER);
+        setWarnExceptionHandler(DEFAULT_WARN_EXCEPTION_HANDLER);
+        setDebugExceptionHandler(DEFAULT_DEBUG_EXCEPTION_HANDLER);
+        setPerfExceptionHandler(DEFAULT_PERF_EXCEPTION_HANDLER);
     }
 
     public static void setErrorExceptionHandler(ExceptionHandler exceptionHandler) {

--- a/src/main/java/net/openhft/chronicle/core/onoes/ThreadLocalisedExceptionHandler.java
+++ b/src/main/java/net/openhft/chronicle/core/onoes/ThreadLocalisedExceptionHandler.java
@@ -24,7 +24,15 @@ public class ThreadLocalisedExceptionHandler implements ExceptionHandler {
     private ExceptionHandler defaultHandler;
     private ThreadLocal<ExceptionHandler> handlerTL;
 
+    /**
+     * @deprecated use {@link ThreadLocalisedExceptionHandler(ExceptionHandler)} instead (to be removed in x.24)
+     */
+    @Deprecated
     public ThreadLocalisedExceptionHandler(Slf4jExceptionHandler handler) {
+        this((ExceptionHandler) handler);
+    }
+
+    public ThreadLocalisedExceptionHandler(ExceptionHandler handler) {
         defaultHandler = handler;
         resetThreadLocalHandler();
     }

--- a/src/test/java/net/openhft/chronicle/core/JvmTest.java
+++ b/src/test/java/net/openhft/chronicle/core/JvmTest.java
@@ -20,13 +20,13 @@ package net.openhft.chronicle.core;
 
 import net.openhft.chronicle.core.onoes.ExceptionHandler;
 import net.openhft.chronicle.core.onoes.ExceptionKey;
+import net.openhft.chronicle.core.onoes.ThreadLocalisedExceptionHandler;
 import net.openhft.chronicle.core.threads.ThreadDump;
 import net.openhft.chronicle.core.util.Time;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import sun.misc.Signal;
 import sun.nio.ch.DirectBuffer;
 
 import javax.naming.ConfigurationException;
@@ -79,6 +79,16 @@ public class JvmTest {
     @Test
     public void shouldGetMajorVersion() {
         assertTrue(Jvm.majorVersion() > 0);
+    }
+
+    @Test
+    public void resetExceptionHandlersSetHandlersBackToTheirDefaults() throws IllegalAccessException {
+        Jvm.setExceptionHandlers(null, null, null, null);
+        Jvm.resetExceptionHandlers();
+        assertSame(Jvm.getField(Jvm.class, "DEFAULT_PERF_EXCEPTION_HANDLER").get(null), ((ThreadLocalisedExceptionHandler) Jvm.perf()).defaultHandler());
+        assertSame(Jvm.getField(Jvm.class, "DEFAULT_WARN_EXCEPTION_HANDLER").get(null), ((ThreadLocalisedExceptionHandler) Jvm.warn()).defaultHandler());
+        assertSame(Jvm.getField(Jvm.class, "DEFAULT_ERROR_EXCEPTION_HANDLER").get(null), ((ThreadLocalisedExceptionHandler) Jvm.error()).defaultHandler());
+        assertSame(Jvm.getField(Jvm.class, "DEFAULT_DEBUG_EXCEPTION_HANDLER").get(null), ((ThreadLocalisedExceptionHandler) Jvm.debug()).defaultHandler());
     }
 
     static final class ReportUnoptimised {


### PR DESCRIPTION
...so they can be restored when `Jvm.resetExceptionHandlers()` is called. Fixes #384