### PR TITLE
Add @ScopeConfined annotation, Fix #390

### DIFF
--- a/src/main/java/net/openhft/chronicle/core/annotation/ScopeConfined.java
+++ b/src/main/java/net/openhft/chronicle/core/annotation/ScopeConfined.java
@@ -21,17 +21,20 @@ package net.openhft.chronicle.core.annotation;
 import java.lang.annotation.*;
 
 /**
- * Indicates that the value, value consumer, value mapper etc. should not divulge the value outside
- * the annotated scope. The meaning value should also be construed to include any and all descendant Object properties
- * recursively from the original value.
+ * Indicates that the value consumer, value mapper, structure etc. should not divulge the object outside
+ * the annotated scope. The meaning of "the object" should also be construed to include any and all descendant
+ * non-immutable Object properties recursively dereferenced from the original object.
+ * <p>
+ * <em>
+ * In other words,object contents would be purposely overwritten after they are passed to the receiver and
+ * consequently cannot be kept after the invocation.
+ * </em>
  * <p>
  * This annotation can be used for entities that are dealing with reused-objects.
- * The term divulge obviously includes making the value or any of its descendant objects available to another Thread.
- *
- * @see ThreadConfined
+ * The term divulge also includes making the value or any of its descendant objects available to another Thread.
  */
 @Documented
-@Retention(RetentionPolicy.CLASS)
+@Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE, ElementType.TYPE_USE})
 public @interface ScopeConfined {
 

--- a/src/main/java/net/openhft/chronicle/core/annotation/ScopeConfined.java
+++ b/src/main/java/net/openhft/chronicle/core/annotation/ScopeConfined.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2016-2020 chronicle.software
+ *
+ * https://chronicle.software
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.openhft.chronicle.core.annotation;
+
+import java.lang.annotation.*;
+
+/**
+ * Indicates that the value, value consumer, value mapper etc. should not divulge the value outside
+ * the annotated scope. The meaning value should also be construed to include any and all descendant Object properties
+ * recursively from the original value.
+ * <p>
+ * This annotation can be used for entities that are dealing with reused-objects.
+ * The term divulge obviously includes making the value or any of its descendant objects available to another Thread.
+ *
+ * @see ThreadConfined
+ */
+@Documented
+@Retention(RetentionPolicy.CLASS)
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE, ElementType.TYPE_USE})
+public @interface ScopeConfined {
+
+    /**
+     * Returns a comment as to why this value must meet the condition.
+     *
+     * @return a comment as to why this value must meet the condition
+     */
+    String value() default "";
+}

--- a/src/main/java/net/openhft/chronicle/core/annotation/ScopeConfined.java
+++ b/src/main/java/net/openhft/chronicle/core/annotation/ScopeConfined.java
@@ -21,17 +21,17 @@ package net.openhft.chronicle.core.annotation;
 import java.lang.annotation.*;
 
 /**
- * Indicates that the value consumer, value mapper, structure etc. should not divulge the object outside
+ * Indicates that the value consumer, value mapper, structure etc. should not make the object available outside
  * the annotated scope. The meaning of "the object" should also be construed to include any and all descendant
  * non-immutable Object properties recursively dereferenced from the original object.
  * <p>
  * <em>
- * In other words,object contents would be purposely overwritten after they are passed to the receiver and
+ * In other words, object contents would be purposely overwritten after they are passed to the receiver and
  * consequently cannot be kept after the invocation.
  * </em>
  * <p>
  * This annotation can be used for entities that are dealing with reused-objects.
- * The term divulge also includes making the value or any of its descendant objects available to another Thread.
+ * The term make available also includes making the object or any of its descendant objects available to another Thread.
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)

--- a/src/test/java/net/openhft/chronicle/core/annotation/ScopeConfinedTest.java
+++ b/src/test/java/net/openhft/chronicle/core/annotation/ScopeConfinedTest.java
@@ -1,0 +1,33 @@
+package net.openhft.chronicle.core.annotation;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Type;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ScopeConfinedTest {
+
+    @Test
+    void a() throws NoSuchMethodException {
+        Method method = Foo.class.getMethod("stream");
+        final Type genericReturnType = method.getGenericReturnType();
+
+        // Not sure how to get the Annotation...
+        assertEquals("java.util.stream.Stream<T>", genericReturnType.getTypeName());
+    }
+
+    interface Foo<T> {
+
+        // Shows and validates the use of the annotation in a parameter
+        void forEach(Consumer<? super @ScopeConfined T> action);
+
+        // Shows and validates the use of the annotation in a return value
+        Stream<@ScopeConfined T> stream();
+
+    }
+
+}


### PR DESCRIPTION
```
/**
 * Indicates that the value consumer, value mapper, structure etc. should not divulge the object outside
 * the annotated scope. The meaning of "the object" should also be construed to include any and all descendant
 * non-immutable Object properties recursively dereferenced from the original object.
 * <p>
 * <em>
 * In other words,object contents would be purposely overwritten after they are passed to the receiver and
 * consequently cannot be kept after the invocation.
 * </em>
 * <p>
 * This annotation can be used for entities that are dealing with reused-objects.
 * The term divulge also includes making the value or any of its descendant objects available to another Thread.
 */
@Documented
@Retention(RetentionPolicy.RUNTIME)
@Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE, ElementType.TYPE_USE})
public @interface ScopeConfined {

    /**
     * Returns a comment as to why this value must meet the condition.
     *
     * @return a comment as to why this value must meet the condition
     */
    String value() default "";
}
```



This is useful in case there are consumers/mappers etc. that operate on reused objects and we want to highlight this in the API more than just via the JavaDocs. 

Here is an example:

```
public interface HasIfPresent {

    /**
     * If a value is present, performs the given action with the value,
     * otherwise does nothing.
     * <p>
     * The value and its reference objects are {@code ScopeConfined} and <em>must only be used within the provided
     * {@code action}</em> and must not be leaked to the outside world.
     *
     * @param action the action to be performed, if a value is present
     * @throws NullPointerException if a value is present and the given action is
     *                              {@code null}
     */
    void ifPresent(Consumer<? super @ScopeConfined V> action);

}

```

Here is another example:


```
public interface HasStream<T> {

    /**
     * Returns a stream representing the current value if present, otherwise returns an
     * {@code empty()} stream.
     * <p>
     * The objects (if any) are {@code ScopeConfined} and should not be leaked outside the stream
     * (e.g. collecting etc.).
     *
     * @return a new object representing the current value if present, otherwise returns an
     * {@code empty()} object
     */
    Stream<@ScopeConfined T> stream();

}

```


