### PR TITLE
Deprecate EventLoop#awaitTermination()

### DIFF
--- a/src/main/java/net/openhft/chronicle/core/threads/DelegatingEventLoop.java
+++ b/src/main/java/net/openhft/chronicle/core/threads/DelegatingEventLoop.java
@@ -50,6 +50,7 @@ public class DelegatingEventLoop implements EventLoop {
         return inner.isAlive();
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public void awaitTermination() {
         inner.awaitTermination();

--- a/src/main/java/net/openhft/chronicle/core/threads/EventLoop.java
+++ b/src/main/java/net/openhft/chronicle/core/threads/EventLoop.java
@@ -64,7 +64,10 @@ public interface EventLoop extends Closeable {
 
     /**
      * Wait until the event loop has terminated (after {@link #stop()} has been called)
+     *
+     * @deprecated {@link #stop()} and {@link #close()} both block until the event handlers have finished running, there's no reason to call this explicitly
      */
+    @Deprecated(/* for removal in x.25 */)
     void awaitTermination();
 
     /**
@@ -76,7 +79,7 @@ public interface EventLoop extends Closeable {
 
     /**
      * Stop the event loop, then close any resources being held.
-     *
+     * <p>
      * Blocks until the handlers are all stopped and closed
      */
     @Override

--- a/src/main/java/net/openhft/chronicle/core/threads/OnDemandEventLoop.java
+++ b/src/main/java/net/openhft/chronicle/core/threads/OnDemandEventLoop.java
@@ -74,6 +74,7 @@ public class OnDemandEventLoop implements EventLoop {
         return el != null && el.isStopped();
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public void awaitTermination() {
         if (hasEventLoop())


### PR DESCRIPTION
I'm pretty sure this is redundant given that `stop()` and `close()` both block until the event handlers have finished. The old pattern used to be to call `close()` then `awaitTermination()` because close didn't block (and `stop()` didn't exist).

I think we briefly toyed with the idea you could `stop()` (non-blocking), then `awaitTermination()` optionally (and then `close()` would be `stop();awaitTermination();closeQuietly(handlers);`), but just having `stop()` block is more idiot-proof.