### PR TITLE
Expand applicability of @RequiredForClient

### DIFF
--- a/src/main/java/net/openhft/chronicle/core/annotation/RequiredForClient.java
+++ b/src/main/java/net/openhft/chronicle/core/annotation/RequiredForClient.java
@@ -17,16 +17,13 @@
  */
 package net.openhft.chronicle.core.annotation;
 
-import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
 
 /**
  * Be careful how this class is modified as it is referred to by name in a contract.
  */
 @Retention(RetentionPolicy.SOURCE)
-@Target(ElementType.TYPE)
 public @interface RequiredForClient {
     String value() default "";
 }


### PR DESCRIPTION
It would be useful to be able to tag more things with this annotation, currently it's only usable on classes

From https://docs.oracle.com/javase/8/docs/api/java/lang/annotation/Target.html
> If an @Target meta-annotation is not present on an annotation type T , then an annotation of type T may be written as a modifier for any declaration except a type parameter declaration.

