### PR TITLE
Add ReferenceChangeListener

### DIFF
--- a/src/main/java/net/openhft/chronicle/core/io/AbstractReferenceCounted.java
+++ b/src/main/java/net/openhft/chronicle/core/io/AbstractReferenceCounted.java
@@ -195,6 +195,16 @@ public abstract class AbstractReferenceCounted implements ReferenceCountedTracer
         this.singleThreadedCheckDisabled = singleThreadedCheckDisabled;
     }
 
+    @Override
+    public void addReferenceChangeListener(ReferenceChangeListener referenceChangeListener) {
+        referenceCounted.addReferenceChangeListener(referenceChangeListener);
+    }
+
+    @Override
+    public void removeReferenceChangeListener(ReferenceChangeListener referenceChangeListener) {
+        referenceCounted.removeReferenceChangeListener(referenceChangeListener);
+    }
+
     protected boolean threadSafetyCheck(boolean isUsed) throws IllegalStateException {
         // most common check, and sometimes the only check
         if (DISABLE_SINGLE_THREADED_CHECK || singleThreadedCheckDisabled)

--- a/src/main/java/net/openhft/chronicle/core/io/DualReferenceCounted.java
+++ b/src/main/java/net/openhft/chronicle/core/io/DualReferenceCounted.java
@@ -50,6 +50,16 @@ public class DualReferenceCounted implements MonitorReferenceCounted {
         return a.createdHere();
     }
 
+    @Override
+    public void addReferenceChangeListener(ReferenceChangeListener referenceChangeListener) {
+        a.addReferenceChangeListener(referenceChangeListener);
+    }
+
+    @Override
+    public void removeReferenceChangeListener(ReferenceChangeListener referenceChangeListener) {
+        a.removeReferenceChangeListener(referenceChangeListener);
+    }
+
     @Deprecated(/* To be removed in x.25 */)
     @Override
     public boolean reservedBy(ReferenceOwner owner) throws IllegalStateException {

--- a/src/main/java/net/openhft/chronicle/core/io/ReferenceChangeListener.java
+++ b/src/main/java/net/openhft/chronicle/core/io/ReferenceChangeListener.java
@@ -1,5 +1,7 @@
 package net.openhft.chronicle.core.io;
 
+import org.jetbrains.annotations.Nullable;
+
 /**
  * An interface to be notified when references to a {@link ReferenceCounted} are added, removed or transferred
  */
@@ -24,9 +26,9 @@ public interface ReferenceChangeListener {
      * what you do here that might introduce a deadlock!
      *
      * @param referenceCounted The ReferenceCounted to which the reference was removed
-     * @param referenceOwner   The owner of the reference removed
+     * @param referenceOwner   The owner whose reference was removed, or null if that is not known
      */
-    default void onReferenceRemoved(ReferenceCounted referenceCounted, ReferenceOwner referenceOwner) {
+    default void onReferenceRemoved(@Nullable ReferenceCounted referenceCounted, ReferenceOwner referenceOwner) {
     }
 
     /**

--- a/src/main/java/net/openhft/chronicle/core/io/ReferenceChangeListener.java
+++ b/src/main/java/net/openhft/chronicle/core/io/ReferenceChangeListener.java
@@ -1,0 +1,44 @@
+package net.openhft.chronicle.core.io;
+
+/**
+ * An interface to be notified when references to a {@link ReferenceCounted} are added, removed or transferred
+ */
+public interface ReferenceChangeListener {
+
+    /**
+     * A reference was added
+     * <p>
+     * WARNING: This may be called from a synchronized block in DualReferenceCounted, so be careful
+     * what you do here that might introduce a deadlock!
+     *
+     * @param referenceCounted The ReferenceCounted to which the reference was added
+     * @param referenceOwner   The owner of the reference added
+     */
+    default void onReferenceAdded(ReferenceCounted referenceCounted, ReferenceOwner referenceOwner) {
+    }
+
+    /**
+     * A reference was removed
+     * <p>
+     * WARNING: This may be called from a synchronized block in DualReferenceCounted, so be careful
+     * what you do here that might introduce a deadlock!
+     *
+     * @param referenceCounted The ReferenceCounted to which the reference was removed
+     * @param referenceOwner   The owner of the reference removed
+     */
+    default void onReferenceRemoved(ReferenceCounted referenceCounted, ReferenceOwner referenceOwner) {
+    }
+
+    /**
+     * A reference was transferred
+     * <p>
+     * WARNING: This may be called from a synchronized block in DualReferenceCounted, so be careful
+     * what you do here that might introduce a deadlock!
+     *
+     * @param referenceCounted The ReferenceCounted on which the reference was transferred
+     * @param fromOwner        The owner the reference was transferred from
+     * @param toOwner          The owner the reference was transferred to
+     */
+    default void onReferenceTransferred(ReferenceCounted referenceCounted, ReferenceOwner fromOwner, ReferenceOwner toOwner) {
+    }
+}

--- a/src/main/java/net/openhft/chronicle/core/io/ReferenceChangeListenerManager.java
+++ b/src/main/java/net/openhft/chronicle/core/io/ReferenceChangeListenerManager.java
@@ -1,0 +1,61 @@
+package net.openhft.chronicle.core.io;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+class ReferenceChangeListenerManager {
+
+    private final List<ReferenceChangeListener> referenceChangeListeners;
+    private final ReferenceCounted owner;
+
+    public ReferenceChangeListenerManager(ReferenceCounted owner) {
+        this.owner = owner;
+        referenceChangeListeners = new CopyOnWriteArrayList<>();
+    }
+
+    void add(ReferenceChangeListener referenceChangeListener) {
+        referenceChangeListeners.add(referenceChangeListener);
+    }
+
+    void remove(ReferenceChangeListener referenceChangeListener) {
+        referenceChangeListeners.remove(referenceChangeListener);
+    }
+
+    void notifyAdded(ReferenceOwner referenceOwner) {
+        this.callReferenceChangeListeners(
+                (listener, referenceCounted, lhs, rhs) -> listener.onReferenceAdded(referenceCounted, lhs),
+                referenceOwner, null);
+    }
+
+    void notifyRemoved(ReferenceOwner referenceOwner) {
+        this.callReferenceChangeListeners(
+                (listener, referenceCounted, lhs, rhs) -> listener.onReferenceRemoved(referenceCounted, lhs),
+                referenceOwner, null);
+    }
+
+    void notifyTransferred(ReferenceOwner from, ReferenceOwner to) {
+        this.callReferenceChangeListeners(ReferenceChangeListener::onReferenceTransferred, from, to);
+    }
+
+    private void callReferenceChangeListeners(ListenerInvoker listenerInvoker, ReferenceOwner lhs, ReferenceOwner rhs) {
+        //noinspection ForLoopReplaceableByForEach
+        for (int i = 0; i < referenceChangeListeners.size(); i++) {
+            ReferenceChangeListener listener;
+            try {
+                listener = referenceChangeListeners.get(i);
+            } catch (ArrayIndexOutOfBoundsException e) {
+                // This can happen if a listener is removed concurrently during the iteration
+                continue;
+            }
+            listenerInvoker.invokeListener(listener, owner, lhs, rhs);
+        }
+    }
+
+    public void clear() {
+        referenceChangeListeners.clear();
+    }
+
+    private interface ListenerInvoker {
+        void invokeListener(ReferenceChangeListener listener, ReferenceCounted referenceCounted, ReferenceOwner lhs, ReferenceOwner rhs);
+    }
+}

--- a/src/main/java/net/openhft/chronicle/core/io/ReferenceChangeListenerManager.java
+++ b/src/main/java/net/openhft/chronicle/core/io/ReferenceChangeListenerManager.java
@@ -1,5 +1,7 @@
 package net.openhft.chronicle.core.io;
 
+import org.jetbrains.annotations.Nullable;
+
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
@@ -27,7 +29,7 @@ class ReferenceChangeListenerManager {
                 referenceOwner, null);
     }
 
-    void notifyRemoved(ReferenceOwner referenceOwner) {
+    void notifyRemoved(@Nullable ReferenceOwner referenceOwner) {
         this.callReferenceChangeListeners(
                 (listener, referenceCounted, lhs, rhs) -> listener.onReferenceRemoved(referenceCounted, lhs),
                 referenceOwner, null);

--- a/src/main/java/net/openhft/chronicle/core/io/ReferenceCounted.java
+++ b/src/main/java/net/openhft/chronicle/core/io/ReferenceCounted.java
@@ -93,4 +93,20 @@ public interface ReferenceCounted extends ReferenceOwner {
      * @return the reference count for this resource
      */
     int refCount();
+
+    /**
+     * Add a {@link ReferenceChangeListener} that will be notified whenever the set of references changes
+     *
+     * @param referenceChangeListener The listener to add
+     */
+    void addReferenceChangeListener(ReferenceChangeListener referenceChangeListener);
+
+    /**
+     * Remove a {@link ReferenceChangeListener}
+     * <p>
+     * Uses object equality to determine which to remove so be careful if the listener implements equals
+     *
+     * @param referenceChangeListener The listener to remove
+     */
+    void removeReferenceChangeListener(ReferenceChangeListener referenceChangeListener);
 }

--- a/src/main/java/net/openhft/chronicle/core/io/ReferenceCountedTracer.java
+++ b/src/main/java/net/openhft/chronicle/core/io/ReferenceCountedTracer.java
@@ -38,6 +38,13 @@ public interface ReferenceCountedTracer extends ReferenceCounted {
             throw new ClosedIllegalStateException("Released");
     }
 
+    /**
+     * Release any remaining references, and log a warning if there were any references to release.
+     * <p>
+     * Intended to be called by a finalizer or in a test, to confirm that references are being released correctly
+     * <p>
+     * Note: This will not cause any {@link ReferenceChangeListener}s to fire as it's really just a sanity check
+     */
     void warnAndReleaseIfNotReleased() throws ClosedIllegalStateException;
 
     void throwExceptionIfNotReleased() throws IllegalStateException;

--- a/src/main/java/net/openhft/chronicle/core/io/TracingReferenceCounted.java
+++ b/src/main/java/net/openhft/chronicle/core/io/TracingReferenceCounted.java
@@ -89,7 +89,6 @@ public final class TracingReferenceCounted implements MonitorReferenceCounted {
     private boolean tryReserve(ReferenceOwner id, boolean must) throws IllegalStateException {
         if (id == this)
             throw new AssertionError(type.getName() + " the counter cannot reserve itself");
-        boolean addedOne = false;
         synchronized (references) {
             if (references.isEmpty()) {
                 if (must)
@@ -97,43 +96,34 @@ public final class TracingReferenceCounted implements MonitorReferenceCounted {
                 return false;
             }
             StackTrace stackTrace = references.get(id);
-            if (stackTrace == null) {
-                final StackTrace reference = references.putIfAbsent(id, stackTrace("reserve", id));
-                if (reference == null) {
-                    addedOne = true;
-                }
-            } else
+            if (stackTrace == null)
+                references.put(id, stackTrace("reserve", id));
+            else
                 throw new IllegalStateException(type.getName() + " already reserved resource by " + asString(id) + " here", stackTrace);
         }
         // notify outside the synchronized block to avoid potential deadlock
-        if (addedOne) {
-            referenceChangeListeners.notifyAdded(id);
-        }
+        referenceChangeListeners.notifyAdded(id);
         releases.remove(id);
         return true;
     }
 
     @Override
     public void release(ReferenceOwner id) throws IllegalStateException {
-        boolean oneWasReleased = false;
-        boolean lastWasReleased = false;
+
+        boolean doOnRelease = false;
         synchronized (references) {
             if (references.remove(id) == null) {
-                throwInvalidReleaseException(id);
-            } else {
-                oneWasReleased = true;
+                throw throwInvalidReleaseException(id);
             }
             releases.put(id, stackTrace("release", id));
             if (references.isEmpty()) {
                 // prevent this being called more than once.
-                lastWasReleased = true;
+                doOnRelease = true;
             }
         }
         // needs to be called outside synchronized block above to avoid deadlock.
-        if (oneWasReleased) {
-            referenceChangeListeners.notifyRemoved(id);
-        }
-        if (lastWasReleased) {
+        referenceChangeListeners.notifyRemoved(id);
+        if (doOnRelease) {
             if (releasedHere != null) {
                 throw new IllegalStateException(type.getName() + " already released", releasedHere);
             }
@@ -142,7 +132,24 @@ public final class TracingReferenceCounted implements MonitorReferenceCounted {
         }
     }
 
-    private void throwInvalidReleaseException(ReferenceOwner id) {
+    @Override
+    public void reserveTransfer(ReferenceOwner from, ReferenceOwner to) throws IllegalStateException {
+        synchronized (references) {
+            final StackTrace stackTrace = references.get(to);
+            if (stackTrace != null) {
+                throw new IllegalStateException(type.getName() + " already reserved resource by " + asString(to) + " here", stackTrace);
+            }
+            if (references.remove(from) == null) {
+                throw throwInvalidReleaseException(from);
+            }
+            releases.put(from, stackTrace("reserveTransfer", from));
+            references.put(to, stackTrace("reserveTransfer", to));
+            releases.remove(to);
+        }
+        referenceChangeListeners.notifyTransferred(from, to);
+    }
+
+    private IllegalStateException throwInvalidReleaseException(ReferenceOwner id) {
         StackTrace stackTrace = releases.get(id);
         if (stackTrace == null) {
             Throwable cause = createdHere;

--- a/src/main/java/net/openhft/chronicle/core/io/TracingReferenceCounted.java
+++ b/src/main/java/net/openhft/chronicle/core/io/TracingReferenceCounted.java
@@ -8,10 +8,7 @@ import net.openhft.chronicle.core.Jvm;
 import net.openhft.chronicle.core.StackTrace;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.Collections;
-import java.util.IdentityHashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 
 public final class TracingReferenceCounted implements MonitorReferenceCounted {
@@ -115,37 +112,56 @@ public final class TracingReferenceCounted implements MonitorReferenceCounted {
 
     @Override
     public void release(ReferenceOwner id) throws IllegalStateException {
+        tryRelease(id, true);
+    }
 
-        boolean doOnRelease = false;
+    /**
+     * Try and release a reference
+     *
+     * @param id   The owner whose reference to release
+     * @param must if true, throw an exception if the release was unsuccessful, if false, just return
+     */
+    private void tryRelease(ReferenceOwner id, boolean must) {
+        boolean oneWasReleased = false;
+        boolean lastWasReleased = false;
         synchronized (references) {
             if (references.remove(id) == null) {
-                StackTrace stackTrace = releases.get(id);
-                if (stackTrace == null) {
-                    Throwable cause = createdHere;
-                    if (!references.isEmpty()) {
-                        StackTrace ste = references.values().iterator().next();
-                        cause = new IllegalStateException(type.getName() + " reserved by " + referencesAsString(), ste);
-                    }
-                    throw new IllegalStateException(type.getName() + " not reserved by " + asString(id), cause);
-                } else {
-                    throw new ClosedIllegalStateException(type.getName() + " already released " + asString(id) + " location ", stackTrace);
+                if (must) {
+                    throwInvalidReleaseException(id);
                 }
             } else {
-                referenceChangeListeners.notifyRemoved(id);
+                oneWasReleased = true;
             }
             releases.put(id, stackTrace("release", id));
             if (references.isEmpty()) {
                 // prevent this being called more than once.
-                doOnRelease = true;
+                lastWasReleased = true;
             }
         }
         // needs to be called outside synchronized block above to avoid deadlock.
-        if (doOnRelease) {
+        if (oneWasReleased) {
+            referenceChangeListeners.notifyRemoved(id);
+        }
+        if (lastWasReleased) {
             if (releasedHere != null) {
                 throw new IllegalStateException(type.getName() + " already released", releasedHere);
             }
             onRelease.run();
             releasedHere = new StackTrace(type.getName() + " released here");
+        }
+    }
+
+    private void throwInvalidReleaseException(ReferenceOwner id) {
+        StackTrace stackTrace = releases.get(id);
+        if (stackTrace == null) {
+            Throwable cause = createdHere;
+            if (!references.isEmpty()) {
+                StackTrace ste = references.values().iterator().next();
+                cause = new IllegalStateException(type.getName() + " reserved by " + referencesAsString(), ste);
+            }
+            throw new IllegalStateException(type.getName() + " not reserved by " + asString(id), cause);
+        } else {
+            throw new ClosedIllegalStateException(type.getName() + " already released " + asString(id) + " location ", stackTrace);
         }
     }
 
@@ -253,19 +269,18 @@ public final class TracingReferenceCounted implements MonitorReferenceCounted {
 
     @Override
     public void warnAndReleaseIfNotReleased() {
-        boolean runOnRelease = false;
+        List<ReferenceOwner> remainingOwners = null;
         synchronized (references) {
             if (refCount() > 0) {
                 if (!unmonitored && !AbstractCloseable.DISABLE_DISCARD_WARNING) {
                     Jvm.warn().on(type, "Discarded without being released by " + referencesAsString(), createdHere);
                 }
-                references.clear();
-                runOnRelease = true;
+                remainingOwners = new ArrayList<>(references.keySet());
             }
         }
         // Run outside the synchronized block to avoid risk of deadlock
-        if (runOnRelease) {
-            onRelease.run();
+        if (remainingOwners != null) {
+            remainingOwners.forEach(ro -> this.tryRelease(ro, false));
         }
     }
 

--- a/src/main/java/net/openhft/chronicle/core/io/VanillaReferenceCounted.java
+++ b/src/main/java/net/openhft/chronicle/core/io/VanillaReferenceCounted.java
@@ -124,7 +124,7 @@ public final class VanillaReferenceCounted implements MonitorReferenceCounted {
         }
     }
 
-    public void callOnRelease() throws ClosedIllegalStateException {
+    private void callOnRelease() throws ClosedIllegalStateException {
         if (released && !Jvm.supportThread())
             throw new ClosedIllegalStateException(type.getName() + " already released", releasedHere);
         releasedHere = Jvm.isResourceTracing() ? new StackTrace("Released here") : null;
@@ -170,17 +170,7 @@ public final class VanillaReferenceCounted implements MonitorReferenceCounted {
 
     @Override
     public void warnAndReleaseIfNotReleased() throws ClosedIllegalStateException {
-        int unreleasedReferences = value;
-        for (; ; ) {
-            final int value0 = value;
-            if (value0 == 0) {
-                break;
-            }
-            if (valueCompareAndSet(value0, value0 - 1)) {
-                referenceChangeListeners.notifyRemoved(null);
-            }
-        }
-        if (unreleasedReferences > 0) {
+        if (valueGetAndSet(0) > 0) {
             if (!unmonitored && !AbstractCloseable.DISABLE_DISCARD_WARNING)
                 Jvm.warn().on(type, "Discarded without being released");
             callOnRelease();

--- a/src/main/java/net/openhft/chronicle/core/io/VanillaReferenceCounted.java
+++ b/src/main/java/net/openhft/chronicle/core/io/VanillaReferenceCounted.java
@@ -170,7 +170,17 @@ public final class VanillaReferenceCounted implements MonitorReferenceCounted {
 
     @Override
     public void warnAndReleaseIfNotReleased() throws ClosedIllegalStateException {
-        if (valueGetAndSet(0) > 0) {
+        int unreleasedReferences = value;
+        for (; ; ) {
+            final int value0 = value;
+            if (value0 == 0) {
+                break;
+            }
+            if (valueCompareAndSet(value0, value0 - 1)) {
+                referenceChangeListeners.notifyRemoved(null);
+            }
+        }
+        if (unreleasedReferences > 0) {
             if (!unmonitored && !AbstractCloseable.DISABLE_DISCARD_WARNING)
                 Jvm.warn().on(type, "Discarded without being released");
             callOnRelease();

--- a/src/test/java/net/openhft/chronicle/core/io/ReferenceCountedContractTest.java
+++ b/src/test/java/net/openhft/chronicle/core/io/ReferenceCountedContractTest.java
@@ -4,7 +4,9 @@ import net.openhft.chronicle.core.CoreTestCommon;
 import net.openhft.chronicle.core.Jvm;
 import org.junit.Test;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
@@ -181,6 +183,107 @@ public abstract class ReferenceCountedContractTest extends CoreTestCommon {
             throw new IllegalStateException("ExecutorService didn't shut down");
         }
         counted.releaseLast();
+    }
+
+    @Test
+    public void shouldNotifyListenersWhenReferencesAreAddedAndRemoved() {
+        ReferenceCounted rc = createReferenceCounted();
+        assertEquals(1, rc.refCount());
+        Set<ReferenceOwner> currentOwners = new HashSet<>();
+        Set<ReferenceOwner> untrackedOwners = new HashSet<>();
+        rc.addReferenceChangeListener(new ReferenceChangeListener() {
+
+            @Override
+            public void onReferenceAdded(ReferenceCounted referenceCounted, ReferenceOwner referenceOwner) {
+                currentOwners.add(referenceOwner);
+            }
+
+            @Override
+            public void onReferenceRemoved(ReferenceCounted referenceCounted, ReferenceOwner referenceOwner) {
+                if (!currentOwners.remove(referenceOwner)) {
+                    untrackedOwners.add(referenceOwner);
+                }
+            }
+
+            @Override
+            public void onReferenceTransferred(ReferenceCounted referenceCounted, ReferenceOwner fromOwner, ReferenceOwner toOwner) {
+                currentOwners.remove(fromOwner);
+                currentOwners.add(toOwner);
+            }
+        });
+
+        ReferenceOwner a = ReferenceOwner.temporary("a");
+        ReferenceOwner b = ReferenceOwner.temporary("b");
+
+        rc.reserve(a);
+        assertEquals(1, currentOwners.size());
+        assertTrue(currentOwners.contains(a));
+
+        rc.reserve(b);
+        assertEquals(2, currentOwners.size());
+        assertTrue(currentOwners.contains(b));
+
+        rc.release(a);
+        assertEquals(1, currentOwners.size());
+        assertTrue(currentOwners.contains(b));
+
+        rc.reserveTransfer(b, a);
+        assertEquals(1, currentOwners.size());
+        assertTrue(currentOwners.contains(a));
+
+        rc.release(a);
+        assertEquals(0, currentOwners.size());
+
+        rc.releaseLast(ReferenceOwner.INIT);
+        assertEquals(1, untrackedOwners.size());
+        assertFalse(currentOwners.contains(ReferenceOwner.INIT));
+    }
+
+    @Test
+    public void shouldBeAbleToAddAndRemoveListeners() {
+        ReferenceCounted rc = createReferenceCounted();
+
+        ReferenceOwner a = ReferenceOwner.temporary("a");
+        ReferenceOwner b = ReferenceOwner.temporary("b");
+
+        CounterReferenceChangeListener listener1 = new CounterReferenceChangeListener();
+        CounterReferenceChangeListener listener2 = new CounterReferenceChangeListener();
+
+        rc.addReferenceChangeListener(listener1);
+        rc.reserve(a);
+        assertEquals(1, listener1.invokeCount);
+        assertEquals(0, listener2.invokeCount);
+        rc.addReferenceChangeListener(listener2);
+        rc.reserve(b);
+        assertEquals(2, listener1.invokeCount);
+        assertEquals(1, listener2.invokeCount);
+        rc.removeReferenceChangeListener(listener1);
+        rc.release(a);
+        assertEquals(2, listener1.invokeCount);
+        assertEquals(2, listener2.invokeCount);
+        rc.removeReferenceChangeListener(listener2);
+        rc.release(b);
+        assertEquals(2, listener1.invokeCount);
+        assertEquals(2, listener2.invokeCount);
+    }
+
+    static class CounterReferenceChangeListener implements ReferenceChangeListener {
+        int invokeCount = 0;
+
+        @Override
+        public void onReferenceAdded(ReferenceCounted referenceCounted, ReferenceOwner referenceOwner) {
+            invokeCount++;
+        }
+
+        @Override
+        public void onReferenceRemoved(ReferenceCounted referenceCounted, ReferenceOwner referenceOwner) {
+            invokeCount++;
+        }
+
+        @Override
+        public void onReferenceTransferred(ReferenceCounted referenceCounted, ReferenceOwner fromOwner, ReferenceOwner toOwner) {
+            invokeCount++;
+        }
     }
 
     private void getQuietly(Future<?> future) {

--- a/src/test/java/net/openhft/chronicle/core/io/ReferenceCountedContractTest.java
+++ b/src/test/java/net/openhft/chronicle/core/io/ReferenceCountedContractTest.java
@@ -251,38 +251,40 @@ public abstract class ReferenceCountedContractTest extends CoreTestCommon {
 
         rc.addReferenceChangeListener(listener1);
         rc.reserve(a);
-        assertEquals(1, listener1.invokeCount);
-        assertEquals(0, listener2.invokeCount);
+        assertEquals(1, listener1.referenceAddedCount);
+        assertEquals(0, listener2.referenceAddedCount);
         rc.addReferenceChangeListener(listener2);
         rc.reserve(b);
-        assertEquals(2, listener1.invokeCount);
-        assertEquals(1, listener2.invokeCount);
+        assertEquals(2, listener1.referenceAddedCount);
+        assertEquals(1, listener2.referenceAddedCount);
         rc.removeReferenceChangeListener(listener1);
         rc.release(a);
-        assertEquals(2, listener1.invokeCount);
-        assertEquals(2, listener2.invokeCount);
+        assertEquals(0, listener1.referenceRemovedCount);
+        assertEquals(1, listener2.referenceRemovedCount);
         rc.removeReferenceChangeListener(listener2);
         rc.release(b);
-        assertEquals(2, listener1.invokeCount);
-        assertEquals(2, listener2.invokeCount);
+        assertEquals(0, listener1.referenceRemovedCount);
+        assertEquals(1, listener2.referenceRemovedCount);
     }
 
     static class CounterReferenceChangeListener implements ReferenceChangeListener {
-        int invokeCount = 0;
+        int referenceAddedCount = 0;
+        int referenceRemovedCount = 0;
+        int referenceTransferredCount = 0;
 
         @Override
         public void onReferenceAdded(ReferenceCounted referenceCounted, ReferenceOwner referenceOwner) {
-            invokeCount++;
+            referenceAddedCount++;
         }
 
         @Override
         public void onReferenceRemoved(ReferenceCounted referenceCounted, ReferenceOwner referenceOwner) {
-            invokeCount++;
+            referenceRemovedCount++;
         }
 
         @Override
         public void onReferenceTransferred(ReferenceCounted referenceCounted, ReferenceOwner fromOwner, ReferenceOwner toOwner) {
-            invokeCount++;
+            referenceTransferredCount++;
         }
     }
 

--- a/src/test/java/net/openhft/chronicle/core/io/ReferenceCountedContractTest.java
+++ b/src/test/java/net/openhft/chronicle/core/io/ReferenceCountedContractTest.java
@@ -240,6 +240,45 @@ public abstract class ReferenceCountedContractTest extends CoreTestCommon {
     }
 
     @Test
+    public void whenAReferenceIsAddedTheReferenceChangeListenerShouldFire() {
+        ReferenceCounted rc = createReferenceCounted();
+
+        ReferenceOwner a = ReferenceOwner.temporary("a");
+        final CounterReferenceChangeListener referenceChangeListener = new CounterReferenceChangeListener();
+        rc.addReferenceChangeListener(referenceChangeListener);
+
+        rc.reserve(a);
+        assertEquals(1, referenceChangeListener.referenceAddedCount);
+    }
+
+    @Test
+    public void whenAReferenceIsRemovedTheReferenceChangeListenerShouldFire() {
+        ReferenceCounted rc = createReferenceCounted();
+
+        ReferenceOwner a = ReferenceOwner.temporary("a");
+        final CounterReferenceChangeListener referenceChangeListener = new CounterReferenceChangeListener();
+        rc.addReferenceChangeListener(referenceChangeListener);
+
+        rc.reserve(a);
+        rc.release(a);
+        assertEquals(1, referenceChangeListener.referenceRemovedCount);
+    }
+
+    @Test
+    public void referenceChangeListenerShouldFireWhenAReferenceIsTransferred() {
+        ReferenceCounted rc = createReferenceCounted();
+
+        ReferenceOwner a = ReferenceOwner.temporary("a");
+        ReferenceOwner b = ReferenceOwner.temporary("b");
+        final CounterReferenceChangeListener referenceChangeListener = new CounterReferenceChangeListener();
+        rc.addReferenceChangeListener(referenceChangeListener);
+
+        rc.reserve(a);
+        rc.reserveTransfer(a, b);
+        assertEquals(1, referenceChangeListener.referenceTransferredCount);
+    }
+
+    @Test
     public void shouldBeAbleToAddAndRemoveListeners() {
         ReferenceCounted rc = createReferenceCounted();
 

--- a/src/test/java/net/openhft/chronicle/core/io/ReferenceCountedTracerContractTest.java
+++ b/src/test/java/net/openhft/chronicle/core/io/ReferenceCountedTracerContractTest.java
@@ -46,7 +46,7 @@ public abstract class ReferenceCountedTracerContractTest extends ReferenceCounte
     }
 
     @Test
-    public void listenersShouldBeNotifiedOnWarnAndReleaseIfNotReleased() {
+    public void listenersShouldNotBeNotifiedOnWarnAndReleaseIfNotReleased() {
         ReferenceCountedTracer rc = createReferenceCounted();
 
         ReferenceOwner a = ReferenceOwner.temporary("a");
@@ -59,6 +59,6 @@ public abstract class ReferenceCountedTracerContractTest extends ReferenceCounte
 
         expectException("Discarded without being released");
         rc.warnAndReleaseIfNotReleased();
-        assertEquals(3, listener.referenceRemovedCount);
+        assertEquals(0, listener.referenceRemovedCount);
     }
 }

--- a/src/test/java/net/openhft/chronicle/core/io/ReferenceCountedTracerContractTest.java
+++ b/src/test/java/net/openhft/chronicle/core/io/ReferenceCountedTracerContractTest.java
@@ -3,6 +3,7 @@ package net.openhft.chronicle.core.io;
 
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 
 /**
@@ -42,5 +43,22 @@ public abstract class ReferenceCountedTracerContractTest extends ReferenceCounte
 
         referenceCounted.releaseLast();
         referenceCounted.throwExceptionIfNotReleased();
+    }
+
+    @Test
+    public void listenersShouldBeNotifiedOnWarnAndReleaseIfNotReleased() {
+        ReferenceCountedTracer rc = createReferenceCounted();
+
+        ReferenceOwner a = ReferenceOwner.temporary("a");
+        ReferenceOwner b = ReferenceOwner.temporary("b");
+
+        CounterReferenceChangeListener listener = new CounterReferenceChangeListener();
+        rc.addReferenceChangeListener(listener);
+        rc.reserve(a);
+        rc.reserve(b);
+
+        expectException("Discarded without being released");
+        rc.warnAndReleaseIfNotReleased();
+        assertEquals(3, listener.referenceRemovedCount);
     }
 }

--- a/src/test/java/net/openhft/chronicle/core/io/TracingReferenceCountedTest.java
+++ b/src/test/java/net/openhft/chronicle/core/io/TracingReferenceCountedTest.java
@@ -137,4 +137,33 @@ public class TracingReferenceCountedTest extends MonitorReferenceCountedContract
 
         assertNotNull(referenceCounted.createdHere());
     }
+
+    @Test
+    public void reserveTransferWillThrowWhenFromHasNoReservation() {
+        TracingReferenceCounted referenceCounted = createReferenceCounted();
+
+        ReferenceOwner a = ReferenceOwner.temporary("a");
+        ReferenceOwner b = ReferenceOwner.temporary("b");
+
+        assertThrows(IllegalStateException.class, () -> referenceCounted.reserveTransfer(a, b));
+    }
+
+    @Test
+    public void reserveTransferWillThrowWhenToAlreadyHasAReservation() {
+        TracingReferenceCounted referenceCounted = createReferenceCounted();
+
+        ReferenceOwner a = ReferenceOwner.temporary("a");
+        ReferenceOwner b = ReferenceOwner.temporary("b");
+        referenceCounted.reserve(a);
+        referenceCounted.reserve(b);
+
+        assertThrows(IllegalStateException.class, () -> referenceCounted.reserveTransfer(a, b));
+    }
+
+    @Test
+    public void reserveWillThrowWhenCalledWithSelf() {
+        TracingReferenceCounted referenceCounted = createReferenceCounted();
+
+        assertThrows(AssertionError.class, () -> referenceCounted.reserve(referenceCounted));
+    }
 }


### PR DESCRIPTION
This is to support the implementation of reliable expiry in `ReferenceCountedCache`. We should be able to add a `ReferenceCountedListener` which can schedule a cache flush when the refCount goes to 1 for a tracked `ReferenceCounted`.

**Note**
I made it so the `ReferenceCountedListeners` DO NOT get called for releases that happen as part of `warnAndReleaseIfNotReleased`, because I think this method may be called in a finalizer, so we probably don't want to be executing arbitrary code there. This is explained in the javadoc for `warnAndReleaseIfNotReleased`