### PR TITLE
Deprecate DualReferenceCounted

### DIFF
--- a/src/main/java/net/openhft/chronicle/core/Memory.java
+++ b/src/main/java/net/openhft/chronicle/core/Memory.java
@@ -164,6 +164,10 @@ public interface Memory {
 
     boolean compareAndSwapLong(Object object, long offset, long expected, long value) throws MisAlignedAssertionError;
 
+    int getAndSetInt(long address, int value) throws MisAlignedAssertionError;
+
+    int getAndSetInt(Object object, long offset, int value) throws MisAlignedAssertionError;
+
     int pageSize();
 
     byte readVolatileByte(long address);

--- a/src/main/java/net/openhft/chronicle/core/UnsafeMemory.java
+++ b/src/main/java/net/openhft/chronicle/core/UnsafeMemory.java
@@ -1016,6 +1016,20 @@ public class UnsafeMemory implements Memory {
     }
 
     @Override
+    public int getAndSetInt(long address, int value) throws MisAlignedAssertionError {
+        assert (address & 63) <= 64 - 4;
+        assert SKIP_ASSERTIONS || address != 0;
+        return UNSAFE.getAndSetInt(null, address, value);
+    }
+
+    @Override
+    public int getAndSetInt(Object object, long offset, int value) throws MisAlignedAssertionError {
+        assert (offset & 63) <= 64 - 4;
+        assert SKIP_ASSERTIONS || assertIfEnabled(Longs.nonNegative(), offset);
+        return UNSAFE.getAndSetInt(object, offset, value);
+    }
+
+    @Override
     public int pageSize() {
         return UNSAFE.pageSize();
     }
@@ -1481,6 +1495,22 @@ public class UnsafeMemory implements Memory {
             assert SKIP_ASSERTIONS || assertIfEnabled(Longs.nonNegative(), offset);
             if (safeAlignedInt(offset))
                 return super.compareAndSwapInt(object, offset, expected, value);
+            throw new MisAlignedAssertionError();
+        }
+
+        @Override
+        public int getAndSetInt(long address, int value) throws MisAlignedAssertionError {
+            assert SKIP_ASSERTIONS || address != 0;
+            if (safeAlignedInt(address))
+                return super.getAndSetInt(address, value);
+            throw new MisAlignedAssertionError();
+        }
+
+        @Override
+        public int getAndSetInt(Object object, long offset, int value) throws MisAlignedAssertionError {
+            assert SKIP_ASSERTIONS || assertIfEnabled(Longs.nonNegative(), offset);
+            if (safeAlignedInt(offset))
+                return super.getAndSetInt(object, offset, value);
             throw new MisAlignedAssertionError();
         }
 

--- a/src/main/java/net/openhft/chronicle/core/io/AbstractCloseable.java
+++ b/src/main/java/net/openhft/chronicle/core/io/AbstractCloseable.java
@@ -43,7 +43,9 @@ public abstract class AbstractCloseable implements ReferenceOwner, ManagedClosea
     @Deprecated(/* remove in x.25 */)
     protected static final boolean DISABLE_THREAD_SAFETY = DISABLE_SINGLE_THREADED_CHECK;
     protected static final boolean DISABLE_DISCARD_WARNING = Jvm.getBoolean("disable.discard.warning", false);
-    protected static final boolean STRICT_DISCARD_WARNING = Jvm.getBoolean("strict.discard.warning", false);
+    @SuppressWarnings("DeprecatedIsStillUsed")
+    @Deprecated(/* remove in x.25 */)
+    protected static final boolean STRICT_DISCARD_WARNING;
 
     protected static final long WARN_NS = (long) (Jvm.getDouble("closeable.warn.secs", 0.02) * 1e9);
 
@@ -57,6 +59,10 @@ public abstract class AbstractCloseable implements ReferenceOwner, ManagedClosea
         if (Jvm.isResourceTracing())
             enableCloseableTracing();
         CLOSED_OFFSET = UnsafeMemory.unsafeObjectFieldOffset(Jvm.getField(AbstractCloseable.class, "closed"));
+        if (Jvm.getProperty("strict.discard.warning") != null) {
+            Jvm.warn().on(AbstractCloseable.class, "strict.discard.warning is deprecated and has no effect, it will be removed in x.25");
+        }
+        STRICT_DISCARD_WARNING = Jvm.getBoolean("strict.discard.warning", false);
     }
 
     private final transient StackTrace createdHere;

--- a/src/main/java/net/openhft/chronicle/core/io/AbstractReferenceCounted.java
+++ b/src/main/java/net/openhft/chronicle/core/io/AbstractReferenceCounted.java
@@ -20,7 +20,6 @@ package net.openhft.chronicle.core.io;
 
 import net.openhft.chronicle.core.Jvm;
 import net.openhft.chronicle.core.StackTrace;
-import net.openhft.chronicle.core.onoes.Slf4jExceptionHandler;
 import net.openhft.chronicle.core.util.WeakIdentityHashMap;
 import org.jetbrains.annotations.NotNull;
 
@@ -30,7 +29,7 @@ import java.util.Set;
 import static net.openhft.chronicle.core.io.AbstractCloseable.*;
 import static net.openhft.chronicle.core.io.BackgroundResourceReleaser.BG_RELEASER;
 
-public abstract class AbstractReferenceCounted implements ReferenceCountedTracer, ReferenceOwner {
+public abstract class AbstractReferenceCounted implements ReferenceCountedTracer, ReferenceOwner, SingleThreadedChecked {
     protected static final long WARN_NS = (long) (Jvm.getDouble("reference.warn.secs", 0.003) * 1e9);
     protected static final int WARN_COUNT = Jvm.getInteger("reference.warn.count", Integer.MAX_VALUE);
     static volatile Set<AbstractReferenceCounted> referenceCountedSet;
@@ -186,10 +185,12 @@ public abstract class AbstractReferenceCounted implements ReferenceCountedTracer
         referenceCounted.warnAndReleaseIfNotReleased();
     }
 
+    @Deprecated
     public boolean reservedBy(ReferenceOwner owner) throws IllegalStateException {
         return referenceCounted.reservedBy(owner);
     }
 
+    @Override
     public void singleThreadedCheckDisabled(boolean singleThreadedCheckDisabled) {
         this.singleThreadedCheckDisabled = singleThreadedCheckDisabled;
     }

--- a/src/main/java/net/openhft/chronicle/core/io/DualReferenceCounted.java
+++ b/src/main/java/net/openhft/chronicle/core/io/DualReferenceCounted.java
@@ -21,6 +21,7 @@ package net.openhft.chronicle.core.io;
 import net.openhft.chronicle.core.Jvm;
 import net.openhft.chronicle.core.StackTrace;
 
+@Deprecated(/* To be removed in x.25 */)
 public class DualReferenceCounted implements MonitorReferenceCounted {
     private final MonitorReferenceCounted a;
     private final MonitorReferenceCounted b;
@@ -49,6 +50,7 @@ public class DualReferenceCounted implements MonitorReferenceCounted {
         return a.createdHere();
     }
 
+    @Deprecated(/* To be removed in x.25 */)
     @Override
     public boolean reservedBy(ReferenceOwner owner) throws IllegalStateException {
         return a.reservedBy(owner);

--- a/src/main/java/net/openhft/chronicle/core/io/ReferenceCounted.java
+++ b/src/main/java/net/openhft/chronicle/core/io/ReferenceCounted.java
@@ -56,7 +56,9 @@ public interface ReferenceCounted extends ReferenceOwner {
      *
      * @param owner to check
      * @return false if the owner definitely doesn't own it.
+     * @deprecated Deprecated with no replacement
      */
+    @Deprecated(/* to be removed in x.25 */)
     boolean reservedBy(ReferenceOwner owner) throws IllegalStateException;
 
     /**

--- a/src/main/java/net/openhft/chronicle/core/io/ReferenceCountedTracer.java
+++ b/src/main/java/net/openhft/chronicle/core/io/ReferenceCountedTracer.java
@@ -28,10 +28,7 @@ public interface ReferenceCountedTracer extends ReferenceCounted {
     @NotNull
     static ReferenceCountedTracer onReleased(final Runnable onRelease, Supplier<String> uniqueId, Class<?> type) {
         return Jvm.isResourceTracing()
-                ? new DualReferenceCounted(
-                new TracingReferenceCounted(onRelease, uniqueId.get(), type),
-                new VanillaReferenceCounted(() -> {
-                }, type))
+                ? new TracingReferenceCounted(onRelease, uniqueId.get(), type)
                 : new VanillaReferenceCounted(onRelease, type);
     }
 

--- a/src/main/java/net/openhft/chronicle/core/io/TracingReferenceCounted.java
+++ b/src/main/java/net/openhft/chronicle/core/io/TracingReferenceCounted.java
@@ -6,8 +6,6 @@ package net.openhft.chronicle.core.io;
 
 import net.openhft.chronicle.core.Jvm;
 import net.openhft.chronicle.core.StackTrace;
-import net.openhft.chronicle.core.onoes.ExceptionHandler;
-import net.openhft.chronicle.core.onoes.Slf4jExceptionHandler;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Collections;
@@ -42,8 +40,8 @@ public final class TracingReferenceCounted implements MonitorReferenceCounted {
         if (id instanceof ReferenceCounted)
             s += " refCount=" + ((ReferenceCounted) id).refCount();
         try {
-            if (id instanceof Closeable)
-                s += " closed=" + ((Closeable) id).isClosed();
+            if (id instanceof QueryCloseable)
+                s += " closed=" + ((QueryCloseable) id).isClosed();
         } catch (NullPointerException ignored) {
             // not initialised
         }
@@ -55,6 +53,7 @@ public final class TracingReferenceCounted implements MonitorReferenceCounted {
         return createdHere;
     }
 
+    @Deprecated
     @Override
     public boolean reservedBy(ReferenceOwner owner) throws IllegalStateException {
         if (references.containsKey(owner))
@@ -139,15 +138,13 @@ public final class TracingReferenceCounted implements MonitorReferenceCounted {
 
     @Override
     public void releaseLast(ReferenceOwner id) throws IllegalStateException {
-        if (references.size() <= 1) {
+        Exception e0 = null;
+        try {
             release(id);
-        } else {
-            Exception e0 = null;
-            try {
-                release(id);
-            } catch (Exception e) {
-                e0 = e;
-            }
+        } catch (Exception e) {
+            e0 = e;
+        }
+        if (references.size() > 0) {
             IllegalStateException ise = new IllegalStateException(type.getName() + " still reserved " + referencesAsString(), createdHere);
             synchronized (references) {
                 references.values().forEach(ise::addSuppressed);
@@ -156,6 +153,8 @@ public final class TracingReferenceCounted implements MonitorReferenceCounted {
                 ise.addSuppressed(e0);
             throw ise;
         }
+        if (e0 != null)
+            Jvm.rethrow(e0);
     }
 
     @Override
@@ -230,11 +229,18 @@ public final class TracingReferenceCounted implements MonitorReferenceCounted {
 
     @Override
     public void warnAndReleaseIfNotReleased() {
-        if (refCount() > 0) {
-            if (!unmonitored && !AbstractCloseable.DISABLE_DISCARD_WARNING) {
-                ExceptionHandler warn = AbstractCloseable.STRICT_DISCARD_WARNING ? Jvm.warn() : Slf4jExceptionHandler.WARN;
-                warn.on(type, "Discarded without being released by " + referencesAsString(), createdHere);
+        boolean runOnRelease = false;
+        synchronized (references) {
+            if (refCount() > 0) {
+                if (!unmonitored && !AbstractCloseable.DISABLE_DISCARD_WARNING) {
+                    Jvm.warn().on(type, "Discarded without being released by " + referencesAsString(), createdHere);
+                }
+                references.clear();
+                runOnRelease = true;
             }
+        }
+        // Run outside the synchronized block to avoid risk of deadlock
+        if (runOnRelease) {
             onRelease.run();
         }
     }

--- a/src/test/java/net/openhft/chronicle/core/UnsafeMemoryTest.java
+++ b/src/test/java/net/openhft/chronicle/core/UnsafeMemoryTest.java
@@ -248,6 +248,28 @@ public class UnsafeMemoryTest {
     }
 
     @Test
+    public void getAndSetInt() throws MisAlignedAssertionError {
+        int initialValue = 9876;
+        for (int i = 0; i <= 64; i += 4)
+            try {
+                if (onHeap == null) {
+                    memory.writeInt(addr + i, initialValue);
+                    final int previous = memory.getAndSetInt(addr + i, INT_VAL);
+                    assertEquals(initialValue, previous);
+                    assertEquals(INT_VAL, memory.readInt(addr + i));
+                } else {
+                    memory.writeInt(object, addr + i, initialValue);
+                    final int previous = memory.getAndSetInt(object, addr + i, INT_VAL);
+                    assertEquals(initialValue, previous);
+                    assertEquals(INT_VAL, memory.readInt(object, addr + i));
+                }
+            } catch (MisAlignedAssertionError e) {
+                if (memory.safeAlignedInt(addr + i))
+                    throw e;
+            }
+    }
+
+    @Test
     public void readVolatileByte() {
         for (int i = 0; i <= 64; i++)
             if (onHeap == null) {

--- a/src/test/java/net/openhft/chronicle/core/io/AbstractCloseableReferenceCountedTest.java
+++ b/src/test/java/net/openhft/chronicle/core/io/AbstractCloseableReferenceCountedTest.java
@@ -18,19 +18,18 @@
 
 package net.openhft.chronicle.core.io;
 
-import net.openhft.chronicle.core.CoreTestCommon;
 import net.openhft.chronicle.core.Jvm;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
 import static org.junit.Assume.assumeTrue;
 
-public class AbstractCloseableReferenceCountedTest extends CoreTestCommon {
+public class AbstractCloseableReferenceCountedTest extends ReferenceCountedTracerContractTest {
 
     @Test
     public void reserve() throws IllegalStateException, IllegalArgumentException {
         assumeTrue(Jvm.isResourceTracing());
-        MyCloseableReferenceCounted rc = new MyCloseableReferenceCounted();
+        MyCloseableReferenceCounted rc = createReferenceCounted();
         assertEquals(1, rc.refCount());
 
         ReferenceOwner a = ReferenceOwner.temporary("a");
@@ -62,7 +61,7 @@ public class AbstractCloseableReferenceCountedTest extends CoreTestCommon {
 
     @Test
     public void reserveWhenClosed() throws IllegalStateException, IllegalArgumentException {
-        MyCloseableReferenceCounted rc = new MyCloseableReferenceCounted();
+        MyCloseableReferenceCounted rc = createReferenceCounted();
         assertEquals(1, rc.refCount());
 
         ReferenceOwner a = ReferenceOwner.temporary("a");
@@ -93,6 +92,11 @@ public class AbstractCloseableReferenceCountedTest extends CoreTestCommon {
         } catch (IllegalStateException ignored) {
 
         }
+    }
+
+    @Override
+    protected MyCloseableReferenceCounted createReferenceCounted() {
+        return new MyCloseableReferenceCounted();
     }
 
     static class MyCloseableReferenceCounted extends AbstractCloseableReferenceCounted {

--- a/src/test/java/net/openhft/chronicle/core/io/AbstractReferenceCountedTest.java
+++ b/src/test/java/net/openhft/chronicle/core/io/AbstractReferenceCountedTest.java
@@ -18,7 +18,6 @@
 
 package net.openhft.chronicle.core.io;
 
-import net.openhft.chronicle.core.CoreTestCommon;
 import net.openhft.chronicle.core.Jvm;
 import org.junit.Test;
 
@@ -26,13 +25,13 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
 
-public class AbstractReferenceCountedTest extends CoreTestCommon {
+public class AbstractReferenceCountedTest extends ReferenceCountedTracerContractTest {
 
     @Test
     public void reserve() throws IllegalStateException, IllegalArgumentException {
         assumeTrue(Jvm.isResourceTracing());
 
-        MyReferenceCounted rc = new MyReferenceCounted();
+        MyReferenceCounted rc = createReferenceCounted();
         assertEquals(1, rc.refCount());
 
         ReferenceOwner a = ReferenceOwner.temporary("a");
@@ -60,6 +59,11 @@ public class AbstractReferenceCountedTest extends CoreTestCommon {
         rc.releaseLast();
         assertEquals(0, rc.refCount());
         assertEquals(1, rc.performRelease);
+    }
+
+    @Override
+    protected MyReferenceCounted createReferenceCounted() {
+        return new MyReferenceCounted();
     }
 
     static class MyReferenceCounted extends AbstractReferenceCounted {

--- a/src/test/java/net/openhft/chronicle/core/io/MonitorReferenceCountedContractTest.java
+++ b/src/test/java/net/openhft/chronicle/core/io/MonitorReferenceCountedContractTest.java
@@ -1,0 +1,41 @@
+package net.openhft.chronicle.core.io;
+
+
+import org.junit.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Any implementation of {@link ReferenceCountedTracer} should implement a test class
+ * that extends this class
+ */
+public abstract class MonitorReferenceCountedContractTest extends ReferenceCountedTracerContractTest {
+
+    @Override
+    protected abstract MonitorReferenceCounted createReferenceCounted();
+
+    @Test
+    public void warnAndReleaseWillLogAWarningAndReleaseWhenMonitored() {
+        final MonitorReferenceCounted referenceCounted = createReferenceCounted();
+        referenceCounted.unmonitored(false);
+        referenceCounted.warnAndReleaseIfNotReleased();
+        assertEquals(0, referenceCounted.refCount());
+        expectException("Discarded without being released");
+    }
+
+    @Test
+    public void warnAndReleaseWillJustReleaseWhenMonitored() {
+        final MonitorReferenceCounted referenceCounted = createReferenceCounted();
+        referenceCounted.unmonitored(true);
+        referenceCounted.warnAndReleaseIfNotReleased();
+        assertEquals(0, referenceCounted.refCount());
+    }
+
+    @Test
+    public void warnAndReleaseWillDoNothingIfTheResourceIsAlreadyReleased() {
+        final MonitorReferenceCounted referenceCounted = createReferenceCounted();
+        referenceCounted.unmonitored(false);
+        referenceCounted.releaseLast();
+        referenceCounted.warnAndReleaseIfNotReleased();
+    }
+}

--- a/src/test/java/net/openhft/chronicle/core/io/ReferenceCountedContractTest.java
+++ b/src/test/java/net/openhft/chronicle/core/io/ReferenceCountedContractTest.java
@@ -1,0 +1,254 @@
+package net.openhft.chronicle.core.io;
+
+import net.openhft.chronicle.core.CoreTestCommon;
+import net.openhft.chronicle.core.Jvm;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.junit.Assert.*;
+
+/**
+ * Any implementor of {@link ReferenceCounted} should implement a test class
+ * that extends this or one of its more specific children
+ */
+public abstract class ReferenceCountedContractTest extends CoreTestCommon {
+
+    /**
+     * Create an instance of the {@link ReferenceCounted} under test
+     *
+     * @return the instance
+     */
+    protected abstract ReferenceCounted createReferenceCounted();
+
+    @Test
+    public void reserveWillIncrementReferenceCount() {
+        ReferenceCounted referenceCounted = createReferenceCounted();
+
+        assertEquals(1, referenceCounted.refCount());
+
+        ReferenceOwner a = ReferenceOwner.temporary("a");
+        referenceCounted.reserve(a);
+        assertEquals(2, referenceCounted.refCount());
+
+        ReferenceOwner b = ReferenceOwner.temporary("b");
+        referenceCounted.reserve(b);
+        assertEquals(3, referenceCounted.refCount());
+    }
+
+    @Test
+    public void reserveWillFailWhenResourceIsAlreadyReleased() {
+        ReferenceCounted referenceCounted = createReferenceCounted();
+
+        referenceCounted.releaseLast();
+
+        ReferenceOwner a = ReferenceOwner.temporary("a");
+        assertThrows(IllegalStateException.class, () -> referenceCounted.reserve(a));
+    }
+
+    @Test
+    public void reserveTransferWillNotChangeReferenceCount() {
+        ReferenceCounted referenceCounted = createReferenceCounted();
+
+        ReferenceOwner a = ReferenceOwner.temporary("a");
+        referenceCounted.reserve(a);
+        assertEquals(2, referenceCounted.refCount());
+
+        ReferenceOwner b = ReferenceOwner.temporary("b");
+        referenceCounted.reserveTransfer(a, b);
+        assertEquals(2, referenceCounted.refCount());
+    }
+
+    @Test
+    public void releaseWillDecrementReferenceCount() {
+        ReferenceCounted referenceCounted = createReferenceCounted();
+
+        assertEquals(1, referenceCounted.refCount());
+
+        ReferenceOwner a = ReferenceOwner.temporary("a");
+        referenceCounted.reserve(a);
+        assertEquals(2, referenceCounted.refCount());
+
+        ReferenceOwner b = ReferenceOwner.temporary("b");
+        referenceCounted.reserve(b);
+        assertEquals(3, referenceCounted.refCount());
+
+        referenceCounted.release(b);
+        assertEquals(2, referenceCounted.refCount());
+
+        referenceCounted.release(a);
+        assertEquals(1, referenceCounted.refCount());
+    }
+
+    @Test
+    public void releaseWillFailWhenResourceAlreadyReleased() {
+        ReferenceCounted referenceCounted = createReferenceCounted();
+
+        referenceCounted.releaseLast();
+
+        ReferenceOwner a = ReferenceOwner.temporary("a");
+        assertThrows(IllegalStateException.class, () -> referenceCounted.release(a));
+    }
+
+    @Test
+    public void releaseWillGoAllTheWayToZero() {
+        ReferenceCounted referenceCounted = createReferenceCounted();
+
+        referenceCounted.release(ReferenceOwner.INIT);
+        assertEquals(0, referenceCounted.refCount());
+    }
+
+    @Test
+    public void releaseLastWillDecrementReferenceCount() {
+        ReferenceCounted referenceCounted = createReferenceCounted();
+
+        assertEquals(1, referenceCounted.refCount());
+
+        referenceCounted.releaseLast();
+        assertEquals(0, referenceCounted.refCount());
+    }
+
+    @Test
+    public void releaseLastWillReleaseThenFailWhenReferenceIsNotLast() {
+        ReferenceCounted referenceCounted = createReferenceCounted();
+
+        ReferenceOwner a = ReferenceOwner.temporary("a");
+        referenceCounted.reserve(a);
+
+        assertEquals(2, referenceCounted.refCount());
+
+        assertThrows(IllegalStateException.class, referenceCounted::releaseLast);
+
+        assertEquals(1, referenceCounted.refCount());
+    }
+
+    @Test
+    public void releaseLastWillFailWhenResourceAlreadyReleased() {
+        ReferenceCounted referenceCounted = createReferenceCounted();
+
+        referenceCounted.releaseLast();
+        assertThrows(IllegalStateException.class, referenceCounted::releaseLast);
+    }
+
+    @Test
+    public void tryReserveWillReturnTrueWhenReservationWasSuccessful() {
+        ReferenceCounted referenceCounted = createReferenceCounted();
+
+        ReferenceOwner a = ReferenceOwner.temporary("a");
+        assertTrue(referenceCounted.tryReserve(a));
+    }
+
+    @Test
+    public void tryReserveWillReturnFalseWhenResourceIsAlreadyReleased() {
+        ReferenceCounted referenceCounted = createReferenceCounted();
+
+        referenceCounted.releaseLast();
+        ReferenceOwner a = ReferenceOwner.temporary("a");
+        assertFalse(referenceCounted.tryReserve(a));
+    }
+
+    @Test
+    public void reservedByWillReturnTrueWhenOwnerHasReferenceReserved() {
+        ReferenceCounted referenceCounted = createReferenceCounted();
+
+        ReferenceOwner a = ReferenceOwner.temporary("a");
+        referenceCounted.reserve(a);
+        assertTrue(referenceCounted.reservedBy(a));
+    }
+
+    @Test
+    public void implementationsShouldBeThreadSafe() throws InterruptedException {
+        int numThreads = Math.max(3, Math.min(6, Runtime.getRuntime().availableProcessors()));
+        int numReferences = 10;
+        AtomicBoolean running = new AtomicBoolean(true);
+        ReferenceCounted counted = createReferenceCounted();
+        if (counted instanceof SingleThreadedChecked) {
+            ((SingleThreadedChecked) counted).singleThreadedCheckDisabled(true);
+        }
+        ExecutorService executorService = Executors.newFixedThreadPool(numThreads);
+        final List<? extends Future<?>> futures = IntStream.range(0, numThreads)
+                .mapToObj(i -> executorService.submit(new ResourceGetter(i, numReferences, running, counted)))
+                .collect(Collectors.toList());
+        Jvm.pause(3_000);
+        running.set(false);
+        futures.forEach(this::getQuietly);
+        executorService.shutdown();
+        if (!executorService.awaitTermination(5, TimeUnit.SECONDS)) {
+            throw new IllegalStateException("ExecutorService didn't shut down");
+        }
+        counted.releaseLast();
+    }
+
+    private void getQuietly(Future<?> future) {
+        try {
+            future.get();
+        } catch (ExecutionException | InterruptedException e) {
+            Jvm.error().on(ReferenceCountedContractTest.class, "Exception thrown by acquirer", e);
+        }
+    }
+
+    private static class ResourceGetter implements Runnable {
+
+        private final int id;
+        private final AtomicBoolean running;
+        private final ReferenceCounted resource;
+        private final Reference[] references;
+
+        private ResourceGetter(int id, int numReferences, AtomicBoolean running, ReferenceCounted resource) {
+            this.id = id;
+            this.references = new Reference[numReferences];
+            this.running = running;
+            this.resource = resource;
+        }
+
+        @Override
+        public void run() {
+            int acquired = 0, released = 0;
+            while (running.get()) {
+                final int i = ThreadLocalRandom.current().nextInt(references.length);
+                if (references[i] == null) {
+                    references[i] = new Reference(id, acquired, resource);
+                    acquired++;
+                } else {
+                    references[i].release();
+                    references[i] = null;
+                    released++;
+                }
+            }
+            for (Reference reference : references) {
+                if (reference != null) {
+                    reference.release();
+                    released++;
+                }
+            }
+            Jvm.startup().on(ResourceGetter.class, "Acquired " + acquired + ", released " + released);
+        }
+    }
+
+    private static class Reference implements ReferenceOwner {
+
+        private final int owner;
+        private final int index;
+        private final ReferenceCounted resource;
+
+        public Reference(int owner, int index, ReferenceCounted resource) {
+            this.owner = owner;
+            this.index = index;
+            this.resource = resource;
+            this.resource.reserve(this);
+        }
+
+        public void release() {
+            resource.release(this);
+        }
+
+        @Override
+        public String referenceName() {
+            return String.format("{id=%s, index=%s}", owner, index);
+        }
+    }
+}

--- a/src/test/java/net/openhft/chronicle/core/io/ReferenceCountedTracerContractTest.java
+++ b/src/test/java/net/openhft/chronicle/core/io/ReferenceCountedTracerContractTest.java
@@ -1,0 +1,46 @@
+package net.openhft.chronicle.core.io;
+
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertThrows;
+
+/**
+ * Any implementor of {@link ReferenceCountedTracer} should implement a test class
+ * that extends this or one of its more specific children
+ */
+public abstract class ReferenceCountedTracerContractTest extends ReferenceCountedContractTest {
+
+    @Override
+    protected abstract ReferenceCountedTracer createReferenceCounted();
+
+    @Test
+    public void throwIfReleasedWillThrowIfResourceIsReleased() {
+        ReferenceCountedTracer referenceCounted = createReferenceCounted();
+
+        referenceCounted.releaseLast();
+        assertThrows(ClosedIllegalStateException.class, referenceCounted::throwExceptionIfReleased);
+    }
+
+    @Test
+    public void throwIfReleasedWillNotThrowIfResourceIsNotReleased() {
+        ReferenceCountedTracer referenceCounted = createReferenceCounted();
+
+        referenceCounted.throwExceptionIfReleased();
+    }
+
+    @Test
+    public void throwIfNotReleasedWillThrowIfResourceIsNotReleased() {
+        ReferenceCountedTracer referenceCounted = createReferenceCounted();
+
+        assertThrows(IllegalStateException.class, referenceCounted::throwExceptionIfNotReleased);
+    }
+
+    @Test
+    public void throwIfNotReleasedWillNotThrowIfResourceIsReleased() {
+        ReferenceCountedTracer referenceCounted = createReferenceCounted();
+
+        referenceCounted.releaseLast();
+        referenceCounted.throwExceptionIfNotReleased();
+    }
+}

--- a/src/test/java/net/openhft/chronicle/core/io/TracingReferenceCountedTest.java
+++ b/src/test/java/net/openhft/chronicle/core/io/TracingReferenceCountedTest.java
@@ -1,0 +1,140 @@
+package net.openhft.chronicle.core.io;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.regex.Pattern;
+
+import static org.junit.Assert.*;
+
+public class TracingReferenceCountedTest extends MonitorReferenceCountedContractTest {
+
+    private AtomicInteger onReleaseCallCount;
+
+    @Before
+    public void setUp() {
+        onReleaseCallCount = new AtomicInteger(0);
+    }
+
+    @Override
+    protected TracingReferenceCounted createReferenceCounted() {
+        return new TracingReferenceCounted(onReleaseCallCount::incrementAndGet, "uniqueId", TracingReferenceCounted.class);
+    }
+
+    @Test
+    public void reserveWillThrowAndNotReserveWhenReferenceOwnerAttemptsToMakeASecondReservation() {
+        TracingReferenceCounted referenceCounted = createReferenceCounted();
+
+        ReferenceOwner a = ReferenceOwner.temporary("a");
+        referenceCounted.reserve(a);
+
+        assertEquals(2, referenceCounted.refCount());
+        assertThrows(IllegalStateException.class, () -> referenceCounted.reserve(a));
+        assertEquals(2, referenceCounted.refCount());
+    }
+
+    @Test
+    public void releaseWillFailWhenResourceOwnerHasNoReservation() {
+        TracingReferenceCounted referenceCounted = createReferenceCounted();
+
+        ReferenceOwner a = ReferenceOwner.temporary("a");
+        assertThrows(IllegalStateException.class, () -> referenceCounted.release(a));
+    }
+
+    @Test
+    public void releaseLastWillThrowWithReferenceDetailsWhenReleaseIsNotLast() {
+        TracingReferenceCounted referenceCounted = createReferenceCounted();
+
+        ReferenceOwner a = ReferenceOwner.temporary("a");
+        referenceCounted.reserve(a);
+        try {
+            referenceCounted.releaseLast(a);
+            fail("Release last should throw here");
+        } catch (IllegalStateException e) {
+            assertEquals("net.openhft.chronicle.core.io.TracingReferenceCounted still reserved [INIT]", e.getMessage());
+            assertEquals("uniqueId main init INIT on main", e.getSuppressed()[0].getMessage());
+        }
+    }
+
+    @Test
+    public void releaseLastWillThrowWithSuppressedInnerFailuresWhenReleaseFails() {
+        TracingReferenceCounted referenceCounted = createReferenceCounted();
+
+        ReferenceOwner a = ReferenceOwner.temporary("a");
+        try {
+            referenceCounted.releaseLast(a);
+            fail("Release last should throw here");
+        } catch (IllegalStateException e) {
+            assertEquals("net.openhft.chronicle.core.io.TracingReferenceCounted still reserved [INIT]", e.getMessage());
+            assertEquals("uniqueId main init INIT on main", e.getSuppressed()[0].getMessage());
+            assertEquals("net.openhft.chronicle.core.io.TracingReferenceCounted not reserved by VanillaReferenceOwner{name='a'} closed=false", e.getSuppressed()[1].getMessage());
+        }
+    }
+
+    /**
+     * This is actually a deviation from the contract, it should return false rather than throwing
+     * <p>
+     * Should we fix the contract or fix the behaviour?
+     */
+    @Test
+    public void reservedByWillThrowIllegalStateExceptionWhenReferenceOwnerNeverHadAReference() {
+        TracingReferenceCounted referenceCounted = createReferenceCounted();
+
+        ReferenceOwner a = ReferenceOwner.temporary("a");
+        assertThrows(IllegalStateException.class, () -> referenceCounted.reservedBy(a));
+    }
+
+    /**
+     * This is actually a deviation from the contract, it should return false rather than throwing
+     * <p>
+     * Should we fix the contract or fix the behaviour?
+     */
+    @Test
+    public void reservedByWillThrowIllegalStateExceptionAfterReferenceOwnerReleasedItsReference() {
+        TracingReferenceCounted referenceCounted = createReferenceCounted();
+
+        ReferenceOwner a = ReferenceOwner.temporary("a");
+        referenceCounted.reserve(a);
+        referenceCounted.release(a);
+        assertThrows(IllegalStateException.class, () -> referenceCounted.reservedBy(a));
+    }
+
+    @Test
+    public void asStringWillIncludeReferenceCountedDetails() {
+        final TracingReferenceCounted referenceCounted = createReferenceCounted();
+        assertTrue(Pattern.matches("TracingReferenceCounted@\\w+ refCount=1", TracingReferenceCounted.asString(referenceCounted)));
+    }
+
+    @Test
+    public void asStringWillIncludeCloseableDetails() {
+        class SomeCloseable implements QueryCloseable, ReferenceOwner {
+
+            @Override
+            public boolean isClosed() {
+                return false;
+            }
+
+            @Override
+            public String referenceName() {
+                return "testCloseable";
+            }
+        }
+        assertEquals("testCloseable closed=false", TracingReferenceCounted.asString(new SomeCloseable()));
+    }
+
+    @Test
+    public void asStringRenderClassNameAndAddressForPojos() {
+        class SomePlainObject {
+
+        }
+        assertTrue(Pattern.matches("SomePlainObject@\\w+", TracingReferenceCounted.asString(new SomePlainObject())));
+    }
+
+    @Test
+    public void createdHereWillReturnCreatedStackTrace() {
+        TracingReferenceCounted referenceCounted = createReferenceCounted();
+
+        assertNotNull(referenceCounted.createdHere());
+    }
+}

--- a/src/test/java/net/openhft/chronicle/core/io/VanillaReferenceCountedTest.java
+++ b/src/test/java/net/openhft/chronicle/core/io/VanillaReferenceCountedTest.java
@@ -1,0 +1,54 @@
+package net.openhft.chronicle.core.io;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.*;
+
+public class VanillaReferenceCountedTest extends MonitorReferenceCountedContractTest {
+
+    private AtomicInteger onReleasedCallCount;
+
+    @Before
+    public void setUp() {
+        onReleasedCallCount = new AtomicInteger(0);
+    }
+
+    @Override
+    protected VanillaReferenceCounted createReferenceCounted() {
+        return new VanillaReferenceCounted(onReleasedCallCount::incrementAndGet, VanillaReferenceCounted.class);
+    }
+
+    @Test
+    public void createdHereWillReturnNull() {
+        final VanillaReferenceCounted referenceCounted = createReferenceCounted();
+        assertNull(referenceCounted.createdHere());
+    }
+
+    /**
+     * This is another deviation from the contract, it is supposed to return false
+     */
+    @Test
+    public void reservedByWillThrowWhenResourceHasBeenReleased() {
+        final VanillaReferenceCounted referenceCounted = createReferenceCounted();
+        referenceCounted.releaseLast();
+
+        ReferenceOwner a = ReferenceOwner.temporary("a");
+        assertThrows(IllegalStateException.class, () -> referenceCounted.reservedBy(a));
+    }
+
+    @Test
+    public void reservedByWillReturnTrueWheneverThereAreAnyReferencesHeld() {
+        final VanillaReferenceCounted referenceCounted = createReferenceCounted();
+
+        ReferenceOwner a = ReferenceOwner.temporary("a");
+        assertTrue(referenceCounted.reservedBy(a));
+
+        ReferenceOwner b = ReferenceOwner.temporary("b");
+        assertTrue(referenceCounted.reservedBy(b));
+
+        referenceCounted.releaseLast();
+    }
+}

--- a/system.properties
+++ b/system.properties
@@ -26,5 +26,4 @@ jvm.safepoint.enabled=true
 warnAndCloseIfNotClosed=true
 # reduce logging of the announcer
 chronicle.announcer.disable=true
-strict.discard.warning=false
 report.unoptimised=true

--- a/systemProperties.adoc
+++ b/systemProperties.adoc
@@ -22,6 +22,5 @@ and so are enabled if either `-Dflag` or `-Dflag=true` or `-Dflag=yes`
 | reference.warn.count | unknown | If there is a high reserve count (relative to referenceCounted), warning is thrown stating the referenceName with the high reserve count | _WARN_COUNT_ (int)
 | reference.warn.secs | 0.003 | If time of inThreadPerformanceRelease is greater than default, message is thrown to state the ms it takes to performRelease | _WARN_NS_ (long)
 | report.unoptimised | `false` | If enabled, returns usage of unoptimised method | REPORT_UNOPTIMISED (boolean)
-| strict.discard.warning | `false` | If enabled, message is displayed stating that resources have been 'discarded without being released by' + referencesAsString() | _STRICT_DISCARD_WARNING_ (boolean)
 | warnAndCloseIfNotClosed | `true` |If 'false', returns the DEBUG exception handler, which prints as System.out or DEBUG level logging | boolean
 |===


### PR DESCRIPTION
Fixes #445

I assume the reason for DualReferenceCounted was as a kind of integration test to confirm that the behaviour of Tracing and Vanilla `ReferenceCounted`s was consistent (it wasn't, see changes to `TracingReferenceCounted#releaseLast`).

I think a better way to ensure their consistency is to implement contract tests for the interfaces and run all the implementations through them.

I also found some inconsistencies between the contract and the implementations.
