### PR TITLE
log a warning with link to doco for command line args for Java >= 11

### DIFF
--- a/src/main/java/net/openhft/chronicle/core/Jvm.java
+++ b/src/main/java/net/openhft/chronicle/core/Jvm.java
@@ -224,6 +224,7 @@ public final class Jvm {
             return lookup.findVirtual(AccessibleObject.class, "setAccessible0", signature);
         } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException |
                  IllegalArgumentException e) {
+            Jvm.error().on(Jvm.class, "Chronicle products require command line arguments to be provided for Java 11 and above. See https://chronicle.software/chronicle-support-java-17");
             throw new ExceptionInInitializerError(e);
         }
     }


### PR DESCRIPTION
As customers do not necessarily know about these command line flags