### PR TITLE
better detection of Mac Intel vs Arm. Closes #451

### DIFF
--- a/src/main/java/net/openhft/chronicle/core/Bootstrap.java
+++ b/src/main/java/net/openhft/chronicle/core/Bootstrap.java
@@ -72,8 +72,7 @@ final class Bootstrap {
     }
 
     static boolean isMacArm0() {
-        return OS_NAME.equals("Mac OS X");
-        // TODO FIX && CpuClass.CPU_MODEL.startsWith("Apple M");
+        return OS_NAME.equals("Mac OS X") && !OS_ARCH.equals("x86_64");
     }
 
     static boolean isAzulZing0() {


### PR DESCRIPTION
This change works in the build farm - so it has not regressed Mac Arm functionality.