### PR TITLE
Interfaces for Observable prototype (Experimental, do not merge)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <groupId>net.openhft</groupId>
         <artifactId>java-parent-pom</artifactId>
         <version>1.1.36</version>
-        <relativePath />
+        <relativePath></relativePath>
     </parent>
     <artifactId>chronicle-core</artifactId>
     <version>2.24ea7-SNAPSHOT</version>

--- a/src/main/java/net/openhft/chronicle/core/observable/AppendableStateReporter.java
+++ b/src/main/java/net/openhft/chronicle/core/observable/AppendableStateReporter.java
@@ -1,0 +1,90 @@
+package net.openhft.chronicle.core.observable;
+
+import net.openhft.chronicle.core.io.IORuntimeException;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.IdentityHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class AppendableStateReporter implements StateReporter {
+
+    private static final String INDENT = "   ";
+    private static final String COLLECTION_SEPARATOR = "---";
+    private static final String NULL_STRING = "<null>";
+    private static final String ID_PROPERTY = "_id";
+    private final Appendable appendable;
+    private final IdentityHashMap<Object, Object> seenObjects;
+    private int indentLevel = 0;
+
+    public AppendableStateReporter(Appendable appendable) {
+        this.appendable = appendable;
+        this.seenObjects = new IdentityHashMap<>();
+    }
+
+    @Override
+    public void writeProperty(String name, CharSequence value) {
+        writeIndent().append(name).append(": ").append(value != null ? value : NULL_STRING).newLine();
+
+    }
+
+    @Override
+    public void writeChild(String name, Object value) {
+        writeIndent().append(name).append(":").newLine();
+        indentLevel++;
+        writeSingleChild(value);
+        indentLevel--;
+    }
+
+    private void writeSingleChild(Object value) {
+        if (value == null) {
+            writeIndent().append(NULL_STRING).newLine();
+        } else {
+            if (value instanceof Observable) {
+                Observable observable = (Observable) value;
+                writeIndent().append(ID_PROPERTY).append(": ").append(observable.idString()).newLine();
+                if (!seenObjects.containsKey(value)) {
+                    seenObjects.put(value, value);
+                    observable.dumpState(this);
+                }
+            } else {
+                writeIndent().append(value.toString()).newLine();
+            }
+        }
+    }
+
+    @Override
+    public void writeChildren(String name, Collection<?> children) {
+        writeIndent().append(name).append(":").newLine();
+        indentLevel++;
+        AtomicBoolean first = new AtomicBoolean(true);
+        children.forEach(child -> {
+            if (!first.get()) {
+                writeIndent().append(COLLECTION_SEPARATOR).newLine();
+            }
+            writeSingleChild(child);
+            first.set(false);
+        });
+        indentLevel--;
+    }
+
+    private void newLine() {
+        append(System.lineSeparator());
+    }
+
+    private AppendableStateReporter writeIndent() {
+        for (int i = 0; i < indentLevel; i++) {
+            append(INDENT);
+        }
+        return this;
+    }
+
+    private AppendableStateReporter append(CharSequence string) {
+        try {
+            appendable.append(string);
+            return this;
+        } catch (IOException e) {
+            throw new IORuntimeException("Couldn't append!", e);
+        }
+    }
+}

--- a/src/main/java/net/openhft/chronicle/core/observable/Observable.java
+++ b/src/main/java/net/openhft/chronicle/core/observable/Observable.java
@@ -1,0 +1,10 @@
+package net.openhft.chronicle.core.observable;
+
+public interface Observable {
+
+    void dumpState(StateReporter stateReporter);
+
+    default String idString() {
+        return getClass().getSimpleName() + "@" + System.identityHashCode(this);
+    }
+}

--- a/src/main/java/net/openhft/chronicle/core/observable/StateReporter.java
+++ b/src/main/java/net/openhft/chronicle/core/observable/StateReporter.java
@@ -1,0 +1,18 @@
+package net.openhft.chronicle.core.observable;
+
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collection;
+
+public interface StateReporter {
+
+    static StateReporter toAppendable(Appendable appendable) {
+        return new AppendableStateReporter(appendable);
+    }
+
+    void writeProperty(String name, @Nullable CharSequence value);
+
+    void writeChild(String name, @Nullable Object value);
+
+    void writeChildren(String name, @Nullable Collection<?> children);
+}


### PR DESCRIPTION
These provide some interfaces that can be implemented to allow system state to be dumped. It abstracts over how the output is written, there is a basic StateReporter that writes to an Appendable (Bytes/StringBuilder/PrintWriter) and there is one [implemented in Wire](https://github.com/OpenHFT/Chronicle-Wire/pull/622) that writes to a Wire.