### PR TITLE
Revert concurrent exceptions map change

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <groupId>net.openhft</groupId>
         <artifactId>java-parent-pom</artifactId>
         <version>1.1.36</version>
-        <relativePath />
+        <relativePath></relativePath>
     </parent>
     <artifactId>chronicle-core</artifactId>
     <version>2.24ea7-SNAPSHOT</version>

--- a/src/main/java/net/openhft/chronicle/core/Jvm.java
+++ b/src/main/java/net/openhft/chronicle/core/Jvm.java
@@ -46,7 +46,6 @@ import java.nio.file.Paths;
 import java.util.*;
 import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
@@ -823,7 +822,7 @@ public final class Jvm {
     public static Map<ExceptionKey, Integer> recordExceptions(final boolean debug,
                                                               final boolean exceptionsOnly,
                                                               final boolean logToSlf4j) {
-        final Map<ExceptionKey, Integer> map = new ConcurrentSkipListMap<>(Comparator.comparing(ExceptionKey::nanoTimestamp));
+        final Map<ExceptionKey, Integer> map = Collections.synchronizedMap(new LinkedHashMap<>());
         setErrorExceptionHandler(recordingExceptionHandler(LogLevel.ERROR, map, exceptionsOnly, logToSlf4j));
         setWarnExceptionHandler(recordingExceptionHandler(LogLevel.WARN, map, exceptionsOnly, logToSlf4j));
         setPerfExceptionHandler(debug

--- a/src/main/java/net/openhft/chronicle/core/onoes/ExceptionKey.java
+++ b/src/main/java/net/openhft/chronicle/core/onoes/ExceptionKey.java
@@ -19,33 +19,22 @@
 
 package net.openhft.chronicle.core.onoes;
 
-import net.openhft.chronicle.core.time.SystemTimeProvider;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
 
 public class ExceptionKey {
-    public final long nanoTimestamp;
     public final LogLevel level;
     public final Class<?> clazz;
     public final String message;
     public final Throwable throwable;
 
     public ExceptionKey(LogLevel level, Class<?> clazz, String message, Throwable throwable) {
-        this(SystemTimeProvider.CLOCK.currentTimeNanos(), level, clazz, message, throwable);
-    }
-
-    public ExceptionKey(long nanoTimestamp, LogLevel level, Class<?> clazz, String message, Throwable throwable) {
-        this.nanoTimestamp = nanoTimestamp;
         this.level = level;
         this.clazz = clazz;
         this.message = message;
         this.throwable = throwable;
-    }
-
-    public long nanoTimestamp() {
-        return nanoTimestamp;
     }
 
     public LogLevel level() {
@@ -93,8 +82,7 @@ public class ExceptionKey {
         if (throwable != null)
             throwable.printStackTrace(new PrintWriter(sw));
         return "ExceptionKey{" +
-                "nanoTimestamp=" + nanoTimestamp / 1e9 +
-                ", level=" + level +
+                "level=" + level +
                 ", clazz=" + clazz +
                 ", message='" + message + '\'' +
                 ", throwable=" + sw +

--- a/src/test/java/net/openhft/chronicle/core/onoes/ExceptionKeyTest.java
+++ b/src/test/java/net/openhft/chronicle/core/onoes/ExceptionKeyTest.java
@@ -18,36 +18,22 @@
 
 package net.openhft.chronicle.core.onoes;
 
-import net.openhft.chronicle.core.time.SetTimeProvider;
-import net.openhft.chronicle.core.time.SystemTimeProvider;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 
-import java.util.concurrent.TimeUnit;
-
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 
 public class ExceptionKeyTest {
-    @Before
-    public void setUp() {
-        SystemTimeProvider.CLOCK = new SetTimeProvider((long) 1e9).autoIncrement(1, TimeUnit.SECONDS);
-    }
-
-    @After
-    public void tearDown() {
-        SystemTimeProvider.CLOCK = SystemTimeProvider.INSTANCE;
-    }
 
     @Test
-    public void hasTimestamp() {
+    public void testEqualsAndHashCode() {
         ExceptionKey ek1 = new ExceptionKey(LogLevel.PERF, getClass(), "one", null);
-        ExceptionKey ek1b = new ExceptionKey((long) 1e9, LogLevel.PERF, getClass(), "one", null);
+        ExceptionKey ek1b = new ExceptionKey(LogLevel.PERF, getClass(), "one", null);
         assertEquals(ek1, ek1b);
         assertEquals(ek1.hashCode(), ek1b.hashCode());
-        assertEquals("ExceptionKey{nanoTimestamp=1.0, level=PERF, clazz=class net.openhft.chronicle.core.onoes.ExceptionKeyTest, message='one', throwable=}", ek1.toString());
+        assertEquals("ExceptionKey{level=PERF, clazz=class net.openhft.chronicle.core.onoes.ExceptionKeyTest, message='one', throwable=}", ek1.toString());
         ExceptionKey ek2 = new ExceptionKey(LogLevel.WARN, getClass(), "two", null);
-        assertEquals("ExceptionKey{nanoTimestamp=2.0, level=WARN, clazz=class net.openhft.chronicle.core.onoes.ExceptionKeyTest, message='two', throwable=}", ek2.toString());
+        assertEquals("ExceptionKey{level=WARN, clazz=class net.openhft.chronicle.core.onoes.ExceptionKeyTest, message='two', throwable=}", ek2.toString());
         assertNotEquals(ek1, ek2);
         assertNotEquals(ek1.hashCode(), ek2.hashCode());
     }


### PR DESCRIPTION
I suspect this change has made expectException unreliable under some circumstances. The javadoc for ConcurrentSkipListMap states that the iterators and spliterators are "[weakly consistent](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/package-summary.html#Weakly)" but they supposedly guarantee that

> they are guaranteed to traverse elements as they existed upon construction exactly once

[This test](https://teamcity.chronicle.software/test/-225424188231083925?currentProjectId=Chronicle_ChronicleFIX&expandTestHistoryChartSection=true) started breaking the day after I introduced the change. And if you look at the logs, it breaks because an expected exception is not present. But the logs suggest it was thrown.

reverts 1b709f8c8e645aee43b0acb15058cafb870e394e.
