### PR TITLE
Don't swallow exceptions in close methods

### DIFF
--- a/src/main/java/net/openhft/chronicle/core/io/AbstractCloseable.java
+++ b/src/main/java/net/openhft/chronicle/core/io/AbstractCloseable.java
@@ -371,7 +371,7 @@ public abstract class AbstractCloseable implements ReferenceOwner, ManagedClosea
         try {
             performClose();
         } catch (Throwable t) {
-            Jvm.debug().on(getClass(), t);
+            Jvm.warn().on(getClass(), "Error occurred in close method", t);
         } finally {
             closed = STATE_CLOSED;
         }

--- a/src/main/java/net/openhft/chronicle/core/io/Closeable.java
+++ b/src/main/java/net/openhft/chronicle/core/io/Closeable.java
@@ -45,10 +45,8 @@ public interface Closeable extends java.io.Closeable, QueryCloseable {
         } else if (o instanceof java.lang.AutoCloseable) {
             try {
                 ((java.lang.AutoCloseable) o).close();
-            } catch (Exception e) {
-                Jvm.debug().on(Closeable.class, e);
             } catch (Throwable e) {
-                Jvm.warn().on(Closeable.class, e);
+                Jvm.warn().on(Closeable.class, "Error occurred closing resources", e);
             }
 
         } else if (o instanceof Reference) {


### PR DESCRIPTION
This goes further than removing the swallowing of exceptions in `Closeable#closeQuietly()`, but also stops swallowing them in `AbstractCloseable#close()`.