### PR TITLE
Fix flaky JitterSamplerTest#takeSnapshot, deprecate JitterSampler#sleepSilently

### DIFF
--- a/src/main/java/net/openhft/chronicle/core/threads/JitterSampler.java
+++ b/src/main/java/net/openhft/chronicle/core/threads/JitterSampler.java
@@ -22,7 +22,8 @@ import net.openhft.chronicle.core.Jvm;
 import java.util.concurrent.TimeUnit;
 
 public final class JitterSampler {
-    private JitterSampler() { }
+    private JitterSampler() {
+    }
 
     public static final String PROFILE_OF_THE_THREAD = "profile of the thread";
     public static final String THREAD_HAS_BLOCKED_FOR = "thread has blocked for";
@@ -76,11 +77,11 @@ public final class JitterSampler {
         time = Long.MAX_VALUE;
     }
 
+    /**
+     * @deprecated Use {@link Jvm#pause(long)} instead
+     */
+    @Deprecated(/* For removal in x.26 */)
     public static void sleepSilently(int millis) {
-        try {
-            Thread.sleep(millis);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-        }
+        Jvm.pause(millis);
     }
 }

--- a/src/main/java/net/openhft/chronicle/core/threads/MonitorProfileAnalyserMain.java
+++ b/src/main/java/net/openhft/chronicle/core/threads/MonitorProfileAnalyserMain.java
@@ -48,7 +48,7 @@ public class MonitorProfileAnalyserMain {
         } else {
             for (; ; ) {
                 main0(ignoreSubStrings, args);
-                JitterSampler.sleepSilently(interval * 1000);
+                Jvm.pause(interval * 1000L);
                 System.out.println("\n---\n");
             }
         }
@@ -90,9 +90,9 @@ public class MonitorProfileAnalyserMain {
                         .limit(20)
                         .collect(Collectors.toList());
         stackSortedByCount.forEach(e -> {
-                    stackCount.remove(e.getKey());
-                    System.out.println(e.getValue() + e.getKey());
-                });
+            stackCount.remove(e.getKey());
+            System.out.println(e.getValue() + e.getKey());
+        });
 
         System.out.println("Grouped by method.");
         Map<String, Integer> methodCount = new LinkedHashMap<>();


### PR DESCRIPTION
This one has failed in TC a few times, I assume because putting a `Thread.sleep` in the `takeSnapshot` loop saw it sleep through the whole "finishing" phase sometimes. I replaced it with a call to `Jvm.busyWaitMicros(1000)` which should never pause for longer than the expected time?

Also deprecated `JitterSampler#sleepQuietly` as it seemed to be a lesser `Jvm.pause(..)`