### PR TITLE
Update EventHandler JavaDoc to more accurately represent the current API

### DIFF
--- a/src/main/java/net/openhft/chronicle/core/threads/EventHandler.java
+++ b/src/main/java/net/openhft/chronicle/core/threads/EventHandler.java
@@ -24,6 +24,7 @@ import java.io.Closeable;
 
 @FunctionalInterface
 public interface EventHandler extends VanillaEventHandler {
+
     /**
      * This method is called once when it is added to an eventLoop, which might be before the EventLoop has started
      * This could be called in any thread.
@@ -34,28 +35,31 @@ public interface EventHandler extends VanillaEventHandler {
     }
 
     /**
-     * This handler has been added to an EventLoop or when the EventLoop starts.
-     * This is always called in the EventLoop thread.
-     * This is called after the first called to eventLoop() to make it clearer.
+     * This handler has begun being executed on the event loop. This will be called after the call to {@link #eventLoop(EventLoop)}
+     * and will always be called on the EventLoop thread.
+     * <p>
+     * This call will be followed by zero or more invocations of {@link #action()} and then an invocation of {@link #loopFinished()}
+     * <p>
+     * Exceptions thrown by loopStarted will be logged and the handler will be removed from the event loop.
      */
     default void loopStarted() {
     }
 
     /**
-     * Notify handler that the event handler's action method
-     * will not be called again. This is an appropriate place to perform cleanup.
-     * Event loop implementations call this once only, from the event loop's execution thread.
-     * <p>This is called either when the event loop is terminating, or if this EventHandler is being
+     * Notify handler that the event handler's action method will not be called again. It will be called
+     * if and only if {@link #loopStarted()} was called, and will always be called on the event loop thread.
+     * <p>
+     * This is called either when the event loop is terminating, or if this EventHandler is being
      * removed from the event loop.
-     * <p>If this implements {@link Closeable} then the event loop will call close (once only) on this after
+     * <p>
+     * If this handler implements {@link Closeable} then the event loop will call close (once only) on this after
      * loopFinished has been called.
-     * <p>If this implements {@link Closeable} and something other than the event loop
-     * calls close then it is expected that this will throw {@link InvalidEventHandlerException} next time
-     * {@link #action()} is called. This will then allow the event loop to call loopFinished (and close) on this.
-     * If this use case is required it is strongly recommend that this event handler guards against close
-     * being called more than once (and ignores subsequent calls).
-     * <p>Exceptions thrown by loopFinished or close are caught and logged (at debug level)
-     * and cleanup continues.
+     * <p>
+     * loopFinished is the place to put any clean-up that MUST be performed on the event loop thread, or
+     * cleanup that only needs to occur if {@link #loopStarted()} was called. All other clean up can be put into
+     * {@link Closeable#close()}.
+     * <p>
+     * Exceptions thrown by loopFinished or close are caught and logged (at warning level) and cleanup continues.
      */
     default void loopFinished() {
     }


### PR DESCRIPTION
The JavaDoc (and contract) had a few inconsistencies and was probably a bit too verbose in places.

One issue was OpenHFT/Chronicle-Threads#160

It's not possible to always call `loopFinished` from the event loop thread if we guarantee it's always called (e.g. if the handler was never started there may be NO event loop thread to call `loopFinished` from).

I've changed the contract to indicate that if and only if `loopStarted` is called, `loopFinished` will be called, and `loopFinished` will always be called from the event loop thread.

The lifecycle of an event handler becomes:
- eventLoop(...) {once, on any thread}
    - loopStarted() {once, on eventloop thread}
    - action() {zero or more times, on eventloop thread}
    - loopFinished() {once, on eventloop thread}
- close() 

The indented calls either all happen or none happen