### PR TITLE
fix log level mapping for PERF

### DIFF
--- a/src/main/java/net/openhft/chronicle/core/onoes/Slf4jExceptionHandler.java
+++ b/src/main/java/net/openhft/chronicle/core/onoes/Slf4jExceptionHandler.java
@@ -67,6 +67,8 @@ public enum Slf4jExceptionHandler implements ExceptionHandler {
             return ERROR;
         if (logLevel == LogLevel.WARN)
             return WARN;
+        if (logLevel == LogLevel.PERF)
+            return PERF;
         return DEBUG;
     }
 


### PR DESCRIPTION
`perf` messages were being logged as `DEBUG` in tests