### PR TITLE
OS.mapAlign is not working correctly when offset is not already aligned.

### DIFF
--- a/src/main/java/net/openhft/chronicle/core/OS.java
+++ b/src/main/java/net/openhft/chronicle/core/OS.java
@@ -285,7 +285,11 @@ public final class OS {
      */
     public static long mapAlign(long offset) {
         int chunkMultiple = (int) mapAlignment();
-        return (offset + chunkMultiple - 1) / chunkMultiple * chunkMultiple;
+        return mapAlign(offset, chunkMultiple);
+    }
+
+    public static long mapAlign(long offset, int pageAlignment) {
+        return ((offset + pageAlignment) / pageAlignment - 1) * pageAlignment;
     }
 
     /**

--- a/src/test/java/net/openhft/chronicle/core/OSTest.java
+++ b/src/test/java/net/openhft/chronicle/core/OSTest.java
@@ -206,4 +206,12 @@ public class OSTest {
         String tmp = OS.getTmp();
         assertNotNull(tmp);
     }
+
+    @Test
+    public void mapAlign() {
+        for (int i = 0; i < 1024; i++) {
+            assertEquals("Unexpected alignment for offset " + i, 0, OS.mapAlign(i, 1024));
+        }
+        assertEquals(1024, OS.mapAlign(1024, 1024));
+    }
 }


### PR DESCRIPTION
I've found some segmentation faults when trying to integrate Chronicle-Core in Apache Pinot.

It seems that the problem is actually in mapAlign method, which rounds up to the next page (like `pageAlign` does). TBH I don't find specially useful the ability to map a random offset if I'm not going to know the position of my offset in the actually paged page. Instead I would prefer to receive an error if the offset is not page aligned or return a structure with the memory address and the offset inside that.

Anyway, I've added a test that verifies the behavior of `mapAlign`. As said, the javadoc is not very clear to me, so maybe the old behavior is what you actually expect. In that case we can revert the changes on OS.java and update OSTest.java accordenly to have a test that verifies the expected behavior.