### PR TITLE
Ignore UnsupportedOperationException when thrown by `AbstractCloseabl…e#singleThreadedCheckDisabled()`

### DIFF
--- a/src/main/java/net/openhft/chronicle/core/io/AbstractCloseable.java
+++ b/src/main/java/net/openhft/chronicle/core/io/AbstractCloseable.java
@@ -140,7 +140,11 @@ public abstract class AbstractCloseable implements ReferenceOwner, ManagedClosea
                     try {
                         // too late to be checking thread safety.
                         if (key instanceof AbstractCloseable) {
-                            ((AbstractCloseable) key).singleThreadedCheckDisabled(true);
+                            try {
+                                ((AbstractCloseable) key).singleThreadedCheckDisabled(true);
+                            } catch (UnsupportedOperationException e) {
+                                // Ignore
+                            }
                         }
                         if (key instanceof ReferenceCountedTracer) {
                             ((ReferenceCountedTracer) key).throwExceptionIfNotReleased();


### PR DESCRIPTION
Acquired Appenders will do this to prevent them being used across threads.