### PR TITLE
Scoped thread locals

### DIFF
--- a/src/main/java/net/openhft/chronicle/core/scoped/AbstractScopedResource.java
+++ b/src/main/java/net/openhft/chronicle/core/scoped/AbstractScopedResource.java
@@ -1,0 +1,48 @@
+package net.openhft.chronicle.core.scoped;
+
+import org.jetbrains.annotations.Nullable;
+
+abstract class AbstractScopedResource<T> implements ScopedResource<T> {
+
+    private final long createdTimeNanos;
+    private final ScopedThreadLocal<T> scopedThreadLocal;
+
+    protected AbstractScopedResource(ScopedThreadLocal<T> scopedThreadLocal) {
+        this.scopedThreadLocal = scopedThreadLocal;
+        this.createdTimeNanos = System.nanoTime();
+    }
+
+    @Override
+    public void close() {
+        scopedThreadLocal.returnResource(this);
+    }
+
+    /**
+     * Do anything that needs to be done before returning a resource to a caller
+     */
+    void preAcquire() {
+        // Do nothing by default
+    }
+
+    /**
+     * Close the contained resource and clear any references
+     */
+    abstract void closeResource();
+
+    /**
+     * The time this resource was created
+     *
+     * @return the {@link System#nanoTime()} of creation
+     */
+    public long getCreatedTimeNanos() {
+        return createdTimeNanos;
+    }
+
+    /**
+     * Get the type of object contained, may return null
+     *
+     * @return the type of object contained, or null if it can't be determined
+     */
+    @Nullable
+    public abstract Class<?> getType();
+}

--- a/src/main/java/net/openhft/chronicle/core/scoped/ScopedResource.java
+++ b/src/main/java/net/openhft/chronicle/core/scoped/ScopedResource.java
@@ -1,0 +1,27 @@
+package net.openhft.chronicle.core.scoped;
+
+import java.io.Closeable;
+
+/**
+ * A scoped resource, it is drawn from a "pool" of sorts, and will be returned
+ * to that pool when {@link #close()} is called.
+ * <p>
+ * Do not keep a reference to the contained resource beyond the scope.
+ *
+ * @param <T> The type of the resource contained
+ */
+public interface ScopedResource<T> extends Closeable {
+
+    /**
+     * Get the contained resource
+     *
+     * @return The resource
+     */
+    T get();
+
+    /**
+     * Signifies the end of the scope, will return the resource to the "pool" for use by other acquirers
+     */
+    @Override
+    void close();
+}

--- a/src/main/java/net/openhft/chronicle/core/scoped/ScopedResourcePool.java
+++ b/src/main/java/net/openhft/chronicle/core/scoped/ScopedResourcePool.java
@@ -1,0 +1,26 @@
+package net.openhft.chronicle.core.scoped;
+
+/**
+ * A pool of resources, whereby a lease is taken on an instance
+ * by calling {@link #get()} and that lease is relinquished when
+ * {@link ScopedResource#close()} is called.
+ * <p>
+ * Example of use:
+ * <pre>{@code
+ *   try (ScopedResource<Wire> sharedWire = sharedWireScopedThreadLocal.get()) {
+ *     Wire wire = sharedWire.get();
+ *     // ... do something with the wire
+ *   } // it is returned for use by inner scopes here
+ * }</pre>
+ *
+ * @param <T> The type of object contained in the pool
+ */
+public interface ScopedResourcePool<T> {
+
+    /**
+     * Get a scoped instance of the shared resource
+     *
+     * @return the {@link ScopedResource}, to be closed once it is finished being used
+     */
+    ScopedResource<T> get();
+}

--- a/src/main/java/net/openhft/chronicle/core/scoped/ScopedThreadLocal.java
+++ b/src/main/java/net/openhft/chronicle/core/scoped/ScopedThreadLocal.java
@@ -1,0 +1,177 @@
+package net.openhft.chronicle.core.scoped;
+
+import net.openhft.chronicle.core.Jvm;
+import net.openhft.chronicle.core.threads.CleaningThreadLocal;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.lang.reflect.Array;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+/**
+ * A thread-local {@link ScopedResourcePool}.
+ * <p>
+ * This is used for small, tightly-scoped thread-local resource "pools", a safer alternative
+ * to a thread-local singleton.
+ * <p>
+ * Holds a limited-depth stack of instances local to each thread, which are allocated as
+ * acquired and returned to the stack as the scopes close. If too many are acquired, a warning
+ * is logged and the extra instances are made eligible for garbage collection.
+ */
+public class ScopedThreadLocal<T> implements ScopedResourcePool<T> {
+
+    private final Supplier<T> supplier;
+    private final Consumer<T> onAcquire;
+    private final CleaningThreadLocal<SimpleStack> instancesTL;
+    private final boolean useWeakReferences;
+
+    /**
+     * Constructor
+     *
+     * @param supplier     The supplier of new instances
+     * @param maxInstances The maximum number of instances that will be retained for re-use
+     */
+    public ScopedThreadLocal(Supplier<T> supplier, int maxInstances) {
+        this(supplier, ScopedThreadLocal::noOp, maxInstances);
+    }
+
+    /**
+     * Constructor
+     *
+     * @param supplier     The supplier of new instances
+     * @param onAcquire    A function to run on each instance upon it's acquisition
+     * @param maxInstances The maximum number of instances that will be retained for re-use
+     */
+    public ScopedThreadLocal(@NotNull Supplier<T> supplier, @NotNull Consumer<T> onAcquire, int maxInstances) {
+        this(supplier, onAcquire, maxInstances, false);
+    }
+
+    /**
+     * Constructor
+     *
+     * @param supplier          The supplier of new instances
+     * @param onAcquire         A function to run on each instance upon it's acquisition
+     * @param maxInstances      The maximum number of instances that will be retained for re-use
+     * @param useWeakReferences Whether to allow resources to be garbage collected when they're not in use
+     */
+    public ScopedThreadLocal(@NotNull Supplier<T> supplier, @NotNull Consumer<T> onAcquire, int maxInstances, boolean useWeakReferences) {
+        this.supplier = supplier;
+        this.onAcquire = onAcquire;
+        this.instancesTL = CleaningThreadLocal.withCloseQuietly(() -> new SimpleStack(maxInstances));
+        this.useWeakReferences = useWeakReferences;
+    }
+
+    /**
+     * Get a scoped instance of the shared resource
+     *
+     * @return the {@link ScopedResource}, to be closed once it is finished being used
+     */
+    public ScopedResource<T> get() {
+        final SimpleStack scopedThreadLocalResources = instancesTL.get();
+        AbstractScopedResource<T> instance;
+        if (scopedThreadLocalResources.isEmpty()) {
+            instance = createNewResource();
+        } else {
+            instance = scopedThreadLocalResources.pop();
+        }
+        instance.preAcquire();
+        onAcquire.accept(instance.get());
+        return instance;
+    }
+
+    private AbstractScopedResource<T> createNewResource() {
+        if (useWeakReferences)
+            return new WeakReferenceScopedResource<>(this, supplier);
+        else
+            return new StrongReferenceScopedResource<>(this, supplier.get());
+    }
+
+    /**
+     * Return a {@link ScopedResource} to the "pool"
+     *
+     * @param scopedResource The resource to return
+     */
+    void returnResource(AbstractScopedResource<T> scopedResource) {
+        final SimpleStack scopedThreadLocalResources = instancesTL.get();
+        scopedThreadLocalResources.push(scopedResource);
+    }
+
+    /**
+     * The default onAcquire function
+     */
+    private static <T> void noOp(T instance) {
+        // Do nothing
+    }
+
+    /**
+     * A simple array-based stack for managing retained {@link ScopedResource}s
+     */
+    class SimpleStack implements java.io.Closeable {
+
+        private final AbstractScopedResource<T>[] instances;
+        private boolean warnedAboutCapacity = false;
+        private int headIndex = -1;
+
+        SimpleStack(int maxInstances) {
+            this.instances = (AbstractScopedResource<T>[]) Array.newInstance(AbstractScopedResource.class, maxInstances);
+        }
+
+        AbstractScopedResource<T> pop() {
+            if (headIndex == -1) {
+                throw new IllegalStateException("Can't pop an empty stack");
+            }
+            final AbstractScopedResource<T> instance = instances[headIndex];
+            instances[headIndex] = null;
+            --headIndex;
+            return instance;
+        }
+
+        void push(AbstractScopedResource<T> instance) {
+            if (headIndex < instances.length - 1) {
+                instances[++headIndex] = instance;
+            } else {
+                // Only warn the first time
+                if (!warnedAboutCapacity) {
+                    @Nullable
+                    Class<?> containedType = instances[instances.length - 1].getType();
+                    Jvm.warn().on(ScopedThreadLocal.class,
+                            "Pool capacity exceeded, consider increasing maxInstances, maxInstances=" + instances.length + (containedType != null ? ", resourceType=" + containedType.getSimpleName() : ""));
+                    warnedAboutCapacity = true;
+                }
+                replaceNewestInstance(instance).closeResource();
+            }
+        }
+
+        private AbstractScopedResource<T> replaceNewestInstance(AbstractScopedResource<T> returningInstance) {
+            long latestCreationTime = returningInstance.getCreatedTimeNanos();
+            int latestCreationIndex = -1;
+            for (int i = 0; i < instances.length; i++) {
+                if (instances[i].getCreatedTimeNanos() > latestCreationTime) {
+                    latestCreationTime = instances[i].getCreatedTimeNanos();
+                    latestCreationIndex = i;
+                }
+            }
+            AbstractScopedResource<T> instanceBeingDiscarded = returningInstance;
+            if (latestCreationIndex >= 0) {
+                instanceBeingDiscarded = instances[latestCreationIndex];
+                instances[latestCreationIndex] = returningInstance;
+            }
+            return instanceBeingDiscarded;
+        }
+
+        boolean isEmpty() {
+            return headIndex == -1;
+        }
+
+        @Override
+        public void close() throws IllegalStateException {
+            for (int i = 0; i < instances.length; i++) {
+                if (instances[i] != null) {
+                    instances[i].closeResource();
+                    instances[i] = null;
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/net/openhft/chronicle/core/scoped/StrongReferenceScopedResource.java
+++ b/src/main/java/net/openhft/chronicle/core/scoped/StrongReferenceScopedResource.java
@@ -1,0 +1,34 @@
+package net.openhft.chronicle.core.scoped;
+
+import static net.openhft.chronicle.core.io.Closeable.closeQuietly;
+
+/**
+ * A {@link ScopedResource} that will always retain a strong reference to the
+ * contained resource, even when not "in use"
+ *
+ * @param <T> The type of the contained resource
+ */
+public class StrongReferenceScopedResource<T> extends AbstractScopedResource<T> {
+
+    private final T resource;
+
+    StrongReferenceScopedResource(ScopedThreadLocal<T> scopedThreadLocal, T resource) {
+        super(scopedThreadLocal);
+        this.resource = resource;
+    }
+
+    public T get() {
+        return resource;
+    }
+
+    @Override
+    public void closeResource() {
+        closeQuietly(resource);
+    }
+
+    @Override
+    public Class<?> getType() {
+        return resource.getClass();
+    }
+}
+

--- a/src/main/java/net/openhft/chronicle/core/scoped/WeakReferenceScopedResource.java
+++ b/src/main/java/net/openhft/chronicle/core/scoped/WeakReferenceScopedResource.java
@@ -1,0 +1,64 @@
+package net.openhft.chronicle.core.scoped;
+
+import net.openhft.chronicle.core.io.Closeable;
+import org.jetbrains.annotations.Nullable;
+
+import java.lang.ref.WeakReference;
+import java.util.function.Supplier;
+
+/**
+ * A weak-referenced {@link ScopedResource} when the resource is acquired, we create
+ * a strong reference to prevent it being GC'd while it's "in use". Upon return, the
+ * strong reference is cleared, leaving only the weak reference thus allowing the
+ * resource to be GC'd.
+ *
+ * @param <T> The type of the contained resource
+ */
+public class WeakReferenceScopedResource<T> extends AbstractScopedResource<T> {
+
+    private final Supplier<T> supplier;
+    private WeakReference<T> ref;
+    private T strongRef;
+
+    public WeakReferenceScopedResource(ScopedThreadLocal<T> scopedThreadLocal, Supplier<T> supplier) {
+        super(scopedThreadLocal);
+        this.supplier = supplier;
+    }
+
+    /**
+     * Before acquire we check that the reference is populated and populate it if not
+     */
+    @Override
+    void preAcquire() {
+        if (ref == null || ((strongRef = ref.get()) == null)) {
+            strongRef = supplier.get();
+            ref = new WeakReference<>(strongRef);
+        }
+    }
+
+    @Override
+    public T get() {
+        return strongRef;
+    }
+
+    @Override
+    public void close() {
+        strongRef = null;
+        super.close();
+    }
+
+    @Override
+    public void closeResource() {
+        if (ref != null) {
+            Closeable.closeQuietly(ref.get());
+            ref.clear();
+            ref = null;
+        }
+    }
+
+    @Override
+    public @Nullable Class<?> getType() {
+        T val = ref != null ? ref.get() : null;
+        return val != null ? val.getClass() : null;
+    }
+}

--- a/src/test/java/net/openhft/chronicle/core/scoped/ScopedThreadLocalTest.java
+++ b/src/test/java/net/openhft/chronicle/core/scoped/ScopedThreadLocalTest.java
@@ -1,0 +1,159 @@
+package net.openhft.chronicle.wire.scoped;
+
+import net.openhft.chronicle.core.CoreTestCommon;
+import net.openhft.chronicle.core.Jvm;
+import net.openhft.chronicle.core.scoped.ScopedResource;
+import net.openhft.chronicle.core.scoped.ScopedThreadLocal;
+import net.openhft.chronicle.core.threads.CleaningThread;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.Closeable;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static net.openhft.chronicle.core.io.Closeable.closeQuietly;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+
+public class ScopedThreadLocalTest extends CoreTestCommon {
+
+    private static final int MAX_INSTANCES = 3;
+
+    private ScopedThreadLocal<AtomicLong> scopedThreadLocal;
+
+    @Before
+    public void createSTL() {
+        scopedThreadLocal = new ScopedThreadLocal<>(AtomicLong::new, al -> al.set(0), MAX_INSTANCES);
+    }
+
+    @Test
+    public void warningWillBeDisplayedWhenWeUseMoreThanMaxInstances() {
+        expectException("Pool capacity exceeded, consider increasing maxInstances, maxInstances=3");
+        ArrayList<ScopedResource<AtomicLong>> allLongs = new ArrayList<>();
+        for (int i = 0; i < MAX_INSTANCES + 1; i++) {
+            allLongs.add(scopedThreadLocal.get());
+        }
+        closeQuietly(allLongs);
+    }
+
+    @Test
+    public void nestedCallsWillGetDifferentResources() {
+        try (ScopedResource<AtomicLong> l1 = scopedThreadLocal.get()) {
+            l1.get().set(123);
+            try (ScopedResource<AtomicLong> l2 = scopedThreadLocal.get()) {
+                l2.get().set(456);
+                try (ScopedResource<AtomicLong> l3 = scopedThreadLocal.get()) {
+                    l3.get().set(789);
+                }
+                assertEquals(456L, l2.get().get());
+            }
+            assertEquals(123L, l1.get().get());
+        }
+    }
+
+    @Test
+    public void differentThreadsWillGetDifferentResources() throws InterruptedException {
+        Set<Integer> instanceObjectIDs = new HashSet<>();
+        final int numThreads = 10;
+        for (int i = 0; i < numThreads; i++) {
+            final Thread thread = new CleaningThread(() -> {
+                try (final ScopedResource<AtomicLong> resource = scopedThreadLocal.get()) {
+                    if (resource == null) {
+                        throw new IllegalStateException();
+                    }
+                    final int e = System.identityHashCode(resource.get());
+                    instanceObjectIDs.add(e);
+                } catch (Exception e) {
+                    Jvm.error().on(ScopedThreadLocalTest.class, e);
+                }
+            });
+            thread.start();
+            thread.join();
+        }
+        assertEquals(numThreads, instanceObjectIDs.size());
+    }
+
+    @Test
+    public void onAcquireIsPerformedBeforeEachAcquisition() {
+        int objectId;
+        try (ScopedResource<AtomicLong> l1 = scopedThreadLocal.get()) {
+            l1.get().set(123);
+            objectId = System.identityHashCode(l1.get());
+        }
+        try (ScopedResource<AtomicLong> l1 = scopedThreadLocal.get()) {
+            assertEquals(0L, l1.get().get());
+            assertEquals(objectId, System.identityHashCode(l1.get()));
+        }
+    }
+
+    @Test
+    public void cleaningThreadWillCloseResources() throws InterruptedException {
+        List<CloseableResource> allResources = new ArrayList<>();
+        ScopedThreadLocal<CloseableResource> stl = new ScopedThreadLocal<>(() -> {
+            CloseableResource cr = new CloseableResource();
+            allResources.add(cr);
+            return cr;
+        }, 2);
+        final CleaningThread cleaningThread = new CleaningThread(() -> {
+            try (final ScopedResource<CloseableResource> cr1 = stl.get();
+                 final ScopedResource<CloseableResource> cr2 = stl.get()) {
+                // Create two resources, do nothing
+            }
+            // None should be closed
+            assertTrue(allResources.stream().noneMatch(cr -> cr.closed));
+        });
+        cleaningThread.start();
+        cleaningThread.join();
+        // All should be closed
+        assertEquals(2, allResources.size());
+        assertTrue(allResources.stream().allMatch(cr -> cr.closed));
+    }
+
+    @Test
+    public void whenOverflowOccursNewestInstanceIsDiscarded() {
+        expectException("Pool capacity exceeded, consider increasing maxInstances, maxInstances=3");
+        AtomicInteger values = new AtomicInteger(0);
+        ScopedThreadLocal<Integer> ints = new ScopedThreadLocal<>(values::getAndIncrement, i -> {
+        }, MAX_INSTANCES);
+
+        // Should get 0,1,2,3 on the first excessive acquire
+        assertEquals(new HashSet<>(Arrays.asList(0, 1, 2, 3)),
+                retrieveAndReturnNValues(MAX_INSTANCES + 1, ints));
+
+        // Should get 0,1,2,4,5 on the next excessive acquire
+        assertEquals(new HashSet<>(Arrays.asList(0, 1, 2, 4, 5)),
+                retrieveAndReturnNValues(MAX_INSTANCES + 2, ints));
+
+        // Should get 0,1,2,6,7 on the next excessive acquire
+        assertEquals(new HashSet<>(Arrays.asList(0, 1, 2, 6, 7)),
+                retrieveAndReturnNValues(MAX_INSTANCES + 2, ints));
+    }
+
+    private Set<Integer> retrieveAndReturnNValues(int numberToRetrieve, ScopedThreadLocal<Integer> scopedInts) {
+        Set<Integer> values = new HashSet<>();
+        retrieveAndRecord(values, scopedInts, numberToRetrieve);
+        return values;
+    }
+
+    private void retrieveAndRecord(Set<Integer> values, ScopedThreadLocal<Integer> scopedInts, int depth) {
+        if (depth > 0) {
+            try (final ScopedResource<Integer> isr = scopedInts.get()) {
+                values.add(isr.get());
+                retrieveAndRecord(values, scopedInts, depth - 1);
+            }
+        }
+    }
+
+    private static class CloseableResource implements Closeable {
+
+        private boolean closed = false;
+
+        @Override
+        public void close() {
+            closed = true;
+        }
+    }
+}

--- a/src/test/java/net/openhft/chronicle/core/scoped/WeakReferenceScopedResourceTest.java
+++ b/src/test/java/net/openhft/chronicle/core/scoped/WeakReferenceScopedResourceTest.java
@@ -1,0 +1,39 @@
+package net.openhft.chronicle.core.scoped;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+class WeakReferenceScopedResourceTest {
+
+    private ScopedThreadLocal<AtomicLong> scopedThreadLocal;
+
+    @BeforeEach
+    void setUp() {
+        scopedThreadLocal = new ScopedThreadLocal<>(AtomicLong::new, 3);
+    }
+
+    @Test
+    void resourceIsCreatedPreAcquire() {
+        final WeakReferenceScopedResource<AtomicLong> sr = new WeakReferenceScopedResource<>(scopedThreadLocal, AtomicLong::new);
+        assertNull(sr.get()); // There should be nothing in it (this would never happen in the real world)
+        sr.preAcquire();
+        assertNotNull(sr.get());
+    }
+
+    @Test
+    void strongReferenceIsCreatedPreAcquire() {
+        final WeakReferenceScopedResource<AtomicLong> sr = new WeakReferenceScopedResource<>(scopedThreadLocal, AtomicLong::new);
+        sr.preAcquire(); // creates the strong reference
+        assertNotNull(sr.get());
+        System.gc();
+        assertNotNull(sr.get());
+        sr.close(); // clears the strong reference
+        System.gc();
+        assertNull(sr.get());
+    }
+}


### PR DESCRIPTION
Fixes #575

Also use a scoped thread-local for the `StringBuilderPool`

Kept the interfaces generic enough that we could investigate more elaborate pools, e.g ones that were thread-safe and shared instances between threads.