### PR TITLE
Add overloaded OS.map() and OS.unmap() methods supporting custom page size.

### DIFF
--- a/src/test/java/net/openhft/chronicle/core/OSTest.java
+++ b/src/test/java/net/openhft/chronicle/core/OSTest.java
@@ -245,4 +245,31 @@ public class OSTest extends CoreTestCommon {
         assertThrows(IllegalArgumentException.class, () -> OS.mapAlign(10, 0));
     }
 
+    @Test
+    public void pageAlign() {
+        // Testing for 64 bytes alignment
+        assertEquals(0, OS.pageAlign(0, 64)); // Perfectly aligned already
+        assertEquals(64, OS.pageAlign(1, 64)); // Not aligned, should round up to 64
+        assertEquals(128, OS.pageAlign(96, 64)); // Not aligned, should round up to 128
+
+        // Testing for 1024 bytes alignment
+        assertEquals(0, OS.pageAlign(0, 1024)); // Perfectly aligned already
+        assertEquals(1024, OS.pageAlign(1024, 1024)); // Perfectly aligned already
+        assertEquals(2048, OS.pageAlign(1025, 1024)); // Not aligned, should round up to 2048
+
+        // Testing for 4096 bytes alignment
+        assertEquals(0, OS.pageAlign(0, 4096)); // Perfectly aligned already
+        assertEquals(4096, OS.pageAlign(1, 4096)); // Not aligned, should round up to 4096
+        assertEquals(4096, OS.pageAlign(4096, 4096)); // Perfectly aligned already
+        assertEquals(8192, OS.pageAlign(4097, 4096)); // Not aligned, should round up to 8192
+
+        // Testing for 2M bytes alignment (hugetlbfs)
+        int customPageSize = 2 * 1024 * 1024;
+        assertEquals(0, OS.pageAlign(0, customPageSize)); // Perfectly aligned already
+        assertEquals(customPageSize, OS.pageAlign(1, customPageSize)); // Not aligned, should round up to higher closest
+        assertEquals(customPageSize, OS.pageAlign(customPageSize, customPageSize)); // Perfectly aligned already
+        assertEquals(2 * customPageSize, OS.pageAlign(customPageSize + 1, customPageSize)); // Not aligned, should round up to higher closest
+        assertEquals(2 * customPageSize, OS.pageAlign(2 * customPageSize - 1, customPageSize)); // Not aligned, should round up to higher closest
+    }
+
 }

--- a/src/test/java/net/openhft/chronicle/core/util/LongsTest.java
+++ b/src/test/java/net/openhft/chronicle/core/util/LongsTest.java
@@ -22,10 +22,15 @@ import net.openhft.chronicle.core.CoreTestCommon;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 public class LongsTest extends CoreTestCommon {
+
+    @Test
+    public void requireBoolean() {
+        assertThrows(IllegalArgumentException.class, () -> Longs.require(() -> false, "Error"));
+        Longs.require(() -> true, "OK");
+    }
 
     @Test
     public void require1Arg() {


### PR DESCRIPTION
Dependency for https://github.com/OpenHFT/Chronicle-Bytes/pull/562
Part of https://github.com/ChronicleSoftware/QueueEvolution/issues/68