### PR TITLE
Changes to compile in windows on java 21

### DIFF
--- a/src/main/java/net/openhft/chronicle/core/Jvm.java
+++ b/src/main/java/net/openhft/chronicle/core/Jvm.java
@@ -477,11 +477,7 @@ public final class Jvm {
      */
     public static void nanoPause() {
         if (onSpinWaitMH == null) {
-            if (isJava9Plus())
-                Safepoint.force(); // 1 ns on Java 11
-            else
-                //noinspection removal
-                Compiler.enable(); // 5 ns on Java 8
+            Safepoint.force();
         } else {
             try {
                 onSpinWaitMH.invokeExact();
@@ -925,12 +921,7 @@ public final class Jvm {
      */
     public static void safepoint() {
         if (SAFEPOINT_ENABLED) {
-            if (Bootstrap.isJava9Plus()) {
-                Safepoint.force(); // 1 ns on Java 11
-            } else {
-                //noinspection removal
-                Compiler.enable(); // 5 ns on Java 8
-            }
+            Safepoint.force();
         }
     }
 

--- a/src/main/java/net/openhft/chronicle/core/OS.java
+++ b/src/main/java/net/openhft/chronicle/core/OS.java
@@ -59,7 +59,7 @@ public final class OS {
         try {
             Method map0;
             if (Jvm.isJava20Plus()) {
-                Class<?> dispatcherClass = findClass("sun.nio.ch.UnixFileDispatcherImpl");
+                Class<?> dispatcherClass = OS.isWindows() ? findClass("sun.nio.ch.FileDispatcherImpl") : findClass("sun.nio.ch.UnixFileDispatcherImpl");
                 map0 = Jvm.getMethod(dispatcherClass, "map0", FileDescriptor.class, int.class, long.class, long.class, boolean.class);
             } else if (Jvm.isJava19Plus()) {
                 map0 = Jvm.getMethod(c, "map0", FileDescriptor.class, int.class, long.class, long.class, boolean.class);
@@ -97,7 +97,7 @@ public final class OS {
         try {
             Method unmap0;
             if (Jvm.isJava20Plus()) {
-                Class<?> dispatcherClass = findClass("sun.nio.ch.UnixFileDispatcherImpl");
+                Class<?> dispatcherClass = OS.isWindows() ? findClass("sun.nio.ch.FileDispatcherImpl") : findClass("sun.nio.ch.UnixFileDispatcherImpl");
                 unmap0 = Jvm.getMethod(dispatcherClass, "unmap0", long.class, long.class);
             } else {
                 unmap0 = Jvm.getMethod(FileChannelImpl.class, "unmap0", long.class, long.class);


### PR DESCRIPTION
Continuation of pull request #580 

There were a few changes needed to get this compiling - notably the java.lang.Compiler seems to not be present in java 21 anymore. it was flagged as deprecated before so I guess they have officially removed it.

Second, after speaking with some colleages it appears that not every OS build of the jdk will have FileDispatcherImpl so we've put an if-windows type check.

This is compiling and tests passing locally for me.