### PR TITLE
objectHeaderSize() isn't useful in its current form as it doesn't kno…

### DIFF
--- a/src/main/java/net/openhft/chronicle/core/Jvm.java
+++ b/src/main/java/net/openhft/chronicle/core/Jvm.java
@@ -1432,6 +1432,7 @@ public final class Jvm {
      *
      * @return The size of the object header.
      */
+    @Deprecated(/* to be removed in x.27, use net.openhft.chronicle.bytes.BytesUtil.triviallyCopyableStart */)
     public static int objectHeaderSize() {
         return ObjectHeaderSizeHolder.getSize();
     }
@@ -1444,6 +1445,7 @@ public final class Jvm {
      * @param type The class for which the object header size is to be calculated.
      * @return The object header size or array base offset, depending on the class type.
      */
+    @Deprecated(/* to be removed in x.27, use net.openhft.chronicle.bytes.BytesUtil.triviallyCopyableStart for POJOs */)
     public static int objectHeaderSize(Class type) {
         return ObjectHeaderSizeHolder.objectHeaderSize(type);
     }

--- a/src/main/java/net/openhft/chronicle/core/internal/ObjectHeaderSizeHolder.java
+++ b/src/main/java/net/openhft/chronicle/core/internal/ObjectHeaderSizeHolder.java
@@ -2,13 +2,13 @@ package net.openhft.chronicle.core.internal;
 
 import net.openhft.chronicle.core.UnsafeMemory;
 import net.openhft.chronicle.core.annotation.UsedViaReflection;
-import sun.misc.Unsafe;
 
 import java.lang.reflect.Field;
 /**
  * This class provides methods to obtain the size of the object header and the base offset for arrays in the JVM.
  * It uses the Unsafe API to calculate these values, which are essential for low-level memory operations.
  */
+@Deprecated(/* to be removed in x.27 */)
 public final class ObjectHeaderSizeHolder {
 
     private static final int OBJECT_HEADER_SIZE;

--- a/src/test/java/net/openhft/chronicle/core/JvmSafepointTest.java
+++ b/src/test/java/net/openhft/chronicle/core/JvmSafepointTest.java
@@ -40,7 +40,7 @@ public class JvmSafepointTest extends CoreTestCommon {
         };
         t.start();
         int counter = 0;
-        int min = Jvm.isAzulZing() ? 20 : 200;
+        int min = Jvm.isAzulZing() ? 2 : 200;
         do {
             StackTraceElement[] stackTrace = t.getStackTrace();
             if (stackTrace.length > 1) {


### PR DESCRIPTION
…w where the first field is for a given class. BytesUtil.triviallyCopyableRange does.