### PR TITLE
Explicitly disable NotNull plugin in Core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -178,6 +178,22 @@
 
     <build>
         <plugins>
+            <!-- The parent POM defines this plugin and activates it in a profile. Unfortunately this plugin will generate
+            code at @NotNull call-sites that throws IllegalArgumentException rather than NullPointerException. This will
+            break various core tests. Chronicle have raised this issue before with the maintainers of the plugin. See:
+            https://github.com/osundblad/intellij-annotations-instrumenter-maven-plugin/issues/53
+            -->
+            <plugin>
+                <groupId>se.eris</groupId>
+                <artifactId>notnull-instrumenter-maven-plugin</artifactId>
+                <version>1.1.1</version>
+                <configuration>
+                    <notNull>
+                        <!-- Not ideal but this was the easiest way to effectively disable this plugin -->
+                        <param>Ignore</param>
+                    </notNull>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>com.github.ekryd.sortpom</groupId>
                 <artifactId>sortpom-maven-plugin</artifactId>


### PR DESCRIPTION
This plugin has been disabled in the latest pom, however we need green builds prior to releasing that pom. This PR should fix up core enough for the build to pass.