### PR TITLE
StringUtils.equalsCaseIgnore optimisation fixes #683

### DIFF
--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -207,7 +207,7 @@
                         </configuration>
                         <executions>
                             <execution>
-                                <id>StringUtilsEqualsCaseIgnoreWorstCase</id>
+                                <id>StringUtilsEqualsCaseIgnoreWorstCaseJLBH</id>
                                 <phase>test</phase>
                                 <goals>
                                     <goal>exec</goal>
@@ -221,7 +221,7 @@
                                 </configuration>
                             </execution>
                             <execution>
-                                <id>StringUtilsEqualsCaseIgnoreBestCase</id>
+                                <id>StringUtilsEqualsCaseIgnoreBestCaseJLBH</id>
                                 <phase>test</phase>
                                 <goals>
                                     <goal>exec</goal>

--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -207,6 +207,19 @@
                         </configuration>
                         <executions>
                             <execution>
+                                <id>StringUtilsEqualsCaseIgnoreJLBH</id>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <executable>${java.home}/bin/java</executable>
+                                    <commandlineArgs>${jvm.requiredArgs} -Djvm.resource.tracing=false -classpath
+                                        %classpath net.openhft.chronicle.core.benchmark.StringUtilsEqualsCaseIgnoreJLBH
+                                    </commandlineArgs>
+                                </configuration>
+                            </execution>
+                            <execution>
                                 <id>copyMemory20</id>
                                 <phase>test</phase>
                                 <goals>

--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -207,7 +207,7 @@
                         </configuration>
                         <executions>
                             <execution>
-                                <id>StringUtilsEqualsCaseIgnoreJLBH</id>
+                                <id>StringUtilsEqualsCaseIgnoreWorstCase</id>
                                 <phase>test</phase>
                                 <goals>
                                     <goal>exec</goal>
@@ -215,7 +215,22 @@
                                 <configuration>
                                     <executable>${java.home}/bin/java</executable>
                                     <commandlineArgs>${jvm.requiredArgs} -Djvm.resource.tracing=false -classpath
-                                        %classpath net.openhft.chronicle.core.benchmark.StringUtilsEqualsCaseIgnoreJLBH
+                                        %classpath
+                                        net.openhft.chronicle.core.benchmark.StringUtilsEqualsCaseIgnoreWorstCaseJLBH
+                                    </commandlineArgs>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>StringUtilsEqualsCaseIgnoreBestCase</id>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <executable>${java.home}/bin/java</executable>
+                                    <commandlineArgs>${jvm.requiredArgs} -Djvm.resource.tracing=false -classpath
+                                        %classpath
+                                        net.openhft.chronicle.core.benchmark.StringUtilsEqualsCaseIgnoreBestCaseJLBH
                                     </commandlineArgs>
                                 </configuration>
                             </execution>

--- a/benchmarks/src/main/java/net/openhft/chronicle/core/benchmark/StringUtilsEqualsCaseIgnoreBaseJLBH.java
+++ b/benchmarks/src/main/java/net/openhft/chronicle/core/benchmark/StringUtilsEqualsCaseIgnoreBaseJLBH.java
@@ -11,12 +11,17 @@ import java.util.function.Supplier;
 
 public class StringUtilsEqualsCaseIgnoreBaseJLBH implements JLBHTask {
 
+    private final Class<?> klass;
     private final CharSequence left;
     private final CharSequence right;
     private final int iterations;
     private JLBH jlbh;
 
-    private StringUtilsEqualsCaseIgnoreBaseJLBH(CharSequence left, CharSequence right, int iterations) {
+    private StringUtilsEqualsCaseIgnoreBaseJLBH(Class<?> klass,
+                                                CharSequence left,
+                                                CharSequence right,
+                                                int iterations) {
+        this.klass = klass;
         this.left = left;
         this.right = right;
         this.iterations = iterations;
@@ -35,10 +40,12 @@ public class StringUtilsEqualsCaseIgnoreBaseJLBH implements JLBHTask {
 
     @Override
     public void complete() {
-        TeamCityHelper.teamCityStatsLastRun(this.getClass().getSimpleName(), jlbh, iterations, System.out);
+        TeamCityHelper.teamCityStatsLastRun(klass.getSimpleName(), jlbh, iterations, System.out);
     }
 
-    public static void run(Supplier<CharSequence> left, Supplier<CharSequence> right) {
+    public static void run(Class<?> klass,
+                           Supplier<CharSequence> left,
+                           Supplier<CharSequence> right) {
         System.setProperty("jvm.resource.tracing", "false");
         Jvm.init();
         final int throughput = Integer.getInteger("throughput", 500_000);
@@ -52,7 +59,7 @@ public class StringUtilsEqualsCaseIgnoreBaseJLBH implements JLBHTask {
                 iterations(iterations).
                 pauseAfterWarmupMS(100).
                 recordOSJitter(false).
-                jlbhTask(new StringUtilsEqualsCaseIgnoreBaseJLBH(left.get(), right.get(), iterations));
+                jlbhTask(new StringUtilsEqualsCaseIgnoreBaseJLBH(klass, left.get(), right.get(), iterations));
         JLBH jlbh = new JLBH(jlbhOptions);
         jlbh.start();
     }

--- a/benchmarks/src/main/java/net/openhft/chronicle/core/benchmark/StringUtilsEqualsCaseIgnoreBaseJLBH.java
+++ b/benchmarks/src/main/java/net/openhft/chronicle/core/benchmark/StringUtilsEqualsCaseIgnoreBaseJLBH.java
@@ -7,13 +7,18 @@ import net.openhft.chronicle.jlbh.JLBHOptions;
 import net.openhft.chronicle.jlbh.JLBHTask;
 import net.openhft.chronicle.jlbh.TeamCityHelper;
 
-public class StringUtilsEqualsCaseIgnoreJLBH implements JLBHTask {
+import java.util.function.Supplier;
 
-    private static String input;
+public class StringUtilsEqualsCaseIgnoreBaseJLBH implements JLBHTask {
+
+    private final CharSequence left;
+    private final CharSequence right;
     private final int iterations;
     private JLBH jlbh;
 
-    private StringUtilsEqualsCaseIgnoreJLBH(int iterations) {
+    private StringUtilsEqualsCaseIgnoreBaseJLBH(CharSequence left, CharSequence right, int iterations) {
+        this.left = left;
+        this.right = right;
         this.iterations = iterations;
     }
 
@@ -24,7 +29,7 @@ public class StringUtilsEqualsCaseIgnoreJLBH implements JLBHTask {
 
     @Override
     public void run(long startTimeNS) {
-        StringUtils.equalsCaseIgnore(input, input);
+        StringUtils.equalsCaseIgnore(left, right);
         jlbh.sample(System.nanoTime() - startTimeNS);
     }
 
@@ -33,14 +38,7 @@ public class StringUtilsEqualsCaseIgnoreJLBH implements JLBHTask {
         TeamCityHelper.teamCityStatsLastRun(this.getClass().getSimpleName(), jlbh, iterations, System.out);
     }
 
-    public static void main(String[] args) {
-
-        StringBuffer sb = new StringBuffer();
-        for (int i = 0; i < 1024; i++) {
-            sb.append((byte) 0);
-        }
-        input = sb.toString();
-
+    public static void run(Supplier<CharSequence> left, Supplier<CharSequence> right) {
         System.setProperty("jvm.resource.tracing", "false");
         Jvm.init();
         final int throughput = Integer.getInteger("throughput", 500_000);
@@ -54,9 +52,17 @@ public class StringUtilsEqualsCaseIgnoreJLBH implements JLBHTask {
                 iterations(iterations).
                 pauseAfterWarmupMS(100).
                 recordOSJitter(false).
-                jlbhTask(new StringUtilsEqualsCaseIgnoreJLBH(iterations));
+                jlbhTask(new StringUtilsEqualsCaseIgnoreBaseJLBH(left.get(), right.get(), iterations));
         JLBH jlbh = new JLBH(jlbhOptions);
         jlbh.start();
+    }
+
+    public static CharSequence generate(Supplier<Character> characterSupplier, int length) {
+        StringBuilder buffer = new StringBuilder();
+        for (int i = 0; i < length; i++) {
+            buffer.append(characterSupplier.get());
+        }
+        return buffer.toString();
     }
 
 }

--- a/benchmarks/src/main/java/net/openhft/chronicle/core/benchmark/StringUtilsEqualsCaseIgnoreBestCaseJLBH.java
+++ b/benchmarks/src/main/java/net/openhft/chronicle/core/benchmark/StringUtilsEqualsCaseIgnoreBestCaseJLBH.java
@@ -1,0 +1,12 @@
+package net.openhft.chronicle.core.benchmark;
+
+import static net.openhft.chronicle.core.benchmark.StringUtilsEqualsCaseIgnoreBaseJLBH.generate;
+
+public class StringUtilsEqualsCaseIgnoreBestCaseJLBH {
+    public static void main(String[] args) {
+        StringUtilsEqualsCaseIgnoreBaseJLBH.run(
+                () -> generate(() -> 'a', 100),
+                () -> generate(() -> 'a', 100)
+        );
+    }
+}

--- a/benchmarks/src/main/java/net/openhft/chronicle/core/benchmark/StringUtilsEqualsCaseIgnoreBestCaseJLBH.java
+++ b/benchmarks/src/main/java/net/openhft/chronicle/core/benchmark/StringUtilsEqualsCaseIgnoreBestCaseJLBH.java
@@ -5,6 +5,7 @@ import static net.openhft.chronicle.core.benchmark.StringUtilsEqualsCaseIgnoreBa
 public class StringUtilsEqualsCaseIgnoreBestCaseJLBH {
     public static void main(String[] args) {
         StringUtilsEqualsCaseIgnoreBaseJLBH.run(
+                StringUtilsEqualsCaseIgnoreBestCaseJLBH.class,
                 () -> generate(() -> 'a', 100),
                 () -> generate(() -> 'a', 100)
         );

--- a/benchmarks/src/main/java/net/openhft/chronicle/core/benchmark/StringUtilsEqualsCaseIgnoreJLBH.java
+++ b/benchmarks/src/main/java/net/openhft/chronicle/core/benchmark/StringUtilsEqualsCaseIgnoreJLBH.java
@@ -1,0 +1,62 @@
+package net.openhft.chronicle.core.benchmark;
+
+import net.openhft.chronicle.core.Jvm;
+import net.openhft.chronicle.core.util.StringUtils;
+import net.openhft.chronicle.jlbh.JLBH;
+import net.openhft.chronicle.jlbh.JLBHOptions;
+import net.openhft.chronicle.jlbh.JLBHTask;
+import net.openhft.chronicle.jlbh.TeamCityHelper;
+
+public class StringUtilsEqualsCaseIgnoreJLBH implements JLBHTask {
+
+    private static String input;
+    private final int iterations;
+    private JLBH jlbh;
+
+    private StringUtilsEqualsCaseIgnoreJLBH(int iterations) {
+        this.iterations = iterations;
+    }
+
+    @Override
+    public void init(JLBH jlbh) {
+        this.jlbh = jlbh;
+    }
+
+    @Override
+    public void run(long startTimeNS) {
+        StringUtils.equalsCaseIgnore(input, input);
+        jlbh.sample(System.nanoTime() - startTimeNS);
+    }
+
+    @Override
+    public void complete() {
+        TeamCityHelper.teamCityStatsLastRun(this.getClass().getSimpleName(), jlbh, iterations, System.out);
+    }
+
+    public static void main(String[] args) {
+
+        StringBuffer sb = new StringBuffer();
+        for (int i = 0; i < 1024; i++) {
+            sb.append((byte) 0);
+        }
+        input = sb.toString();
+
+        System.setProperty("jvm.resource.tracing", "false");
+        Jvm.init();
+        final int throughput = Integer.getInteger("throughput", 500_000);
+        final int iterations = Integer.getInteger("iterations", 10_000_000);
+        final int warmup = Integer.getInteger("warmup", 5_000_000);
+        final int runs = Integer.getInteger("runs", 4);
+        JLBHOptions jlbhOptions = new JLBHOptions().
+                runs(runs).
+                warmUpIterations(warmup).
+                throughput(throughput).
+                iterations(iterations).
+                pauseAfterWarmupMS(100).
+                recordOSJitter(false).
+                jlbhTask(new StringUtilsEqualsCaseIgnoreJLBH(iterations));
+        JLBH jlbh = new JLBH(jlbhOptions);
+        jlbh.start();
+    }
+
+}

--- a/benchmarks/src/main/java/net/openhft/chronicle/core/benchmark/StringUtilsEqualsCaseIgnoreWorstCaseJLBH.java
+++ b/benchmarks/src/main/java/net/openhft/chronicle/core/benchmark/StringUtilsEqualsCaseIgnoreWorstCaseJLBH.java
@@ -6,6 +6,7 @@ public class StringUtilsEqualsCaseIgnoreWorstCaseJLBH {
     public static void main(String[] args) {
         // Test two strings of entirely different case for their duration
         StringUtilsEqualsCaseIgnoreBaseJLBH.run(
+                StringUtilsEqualsCaseIgnoreWorstCaseJLBH.class,
                 () -> generate(() -> 'A', 100),
                 () -> generate(() -> 'a', 100)
         );

--- a/benchmarks/src/main/java/net/openhft/chronicle/core/benchmark/StringUtilsEqualsCaseIgnoreWorstCaseJLBH.java
+++ b/benchmarks/src/main/java/net/openhft/chronicle/core/benchmark/StringUtilsEqualsCaseIgnoreWorstCaseJLBH.java
@@ -1,0 +1,13 @@
+package net.openhft.chronicle.core.benchmark;
+
+import static net.openhft.chronicle.core.benchmark.StringUtilsEqualsCaseIgnoreBaseJLBH.generate;
+
+public class StringUtilsEqualsCaseIgnoreWorstCaseJLBH {
+    public static void main(String[] args) {
+        // Test two strings of entirely different case for their duration
+        StringUtilsEqualsCaseIgnoreBaseJLBH.run(
+                () -> generate(() -> 'A', 100),
+                () -> generate(() -> 'a', 100)
+        );
+    }
+}

--- a/src/main/java/net/openhft/chronicle/core/util/StringUtils.java
+++ b/src/main/java/net/openhft/chronicle/core/util/StringUtils.java
@@ -253,23 +253,19 @@ public final class StringUtils {
     }
 
     /**
-     * Compares two {@link CharSequence}s1 for equality ignoring case considerations.
+     * Compares two {@link CharSequence}s for equality ignoring case considerations.
      *
-     * @param s1  the first {@link CharSequence} to be compared.
-     * @param s2 the second {@link CharSequence} to be compared.
-     * @return {@code true} if the {@link CharSequence}s1 are equal irrespective of case, {@code false} otherwise.
+     * @param s  the first {@link CharSequence} to be compared.
+     * @param cs the second {@link CharSequence} to be compared.
+     * @return {@code true} if the {@link CharSequence}s are equal irrespective of case, {@code false} otherwise.
      */
-    public static boolean equalsCaseIgnore(@Nullable CharSequence s1, @NotNull CharSequence s2) {
-        if (s1 == null) return false;
-        if (s1.length() != s2.length()) return false;
-        for (int i = 0; i < s2.length(); i++) {
-            char c1 = charAt(s1, i);
-            char c2 = charAt(s2, i);
-            if (c1 == c2)
-                continue;
-            if (Character.toLowerCase(c1) != Character.toLowerCase(c2))
+    public static boolean equalsCaseIgnore(@Nullable CharSequence s, @NotNull CharSequence cs) {
+        if (s == null) return false;
+        if (s.length() != cs.length()) return false;
+        for (int i = 0; i < cs.length(); i++)
+            if (Character.toLowerCase(charAt(s, i)) !=
+                    Character.toLowerCase(charAt(cs, i)))
                 return false;
-        }
         return true;
     }
 

--- a/src/main/java/net/openhft/chronicle/core/util/StringUtils.java
+++ b/src/main/java/net/openhft/chronicle/core/util/StringUtils.java
@@ -253,19 +253,23 @@ public final class StringUtils {
     }
 
     /**
-     * Compares two {@link CharSequence}s for equality ignoring case considerations.
+     * Compares two {@link CharSequence}s1 for equality ignoring case considerations.
      *
-     * @param s  the first {@link CharSequence} to be compared.
-     * @param cs the second {@link CharSequence} to be compared.
-     * @return {@code true} if the {@link CharSequence}s are equal irrespective of case, {@code false} otherwise.
+     * @param s1  the first {@link CharSequence} to be compared.
+     * @param s2 the second {@link CharSequence} to be compared.
+     * @return {@code true} if the {@link CharSequence}s1 are equal irrespective of case, {@code false} otherwise.
      */
-    public static boolean equalsCaseIgnore(@Nullable CharSequence s, @NotNull CharSequence cs) {
-        if (s == null) return false;
-        if (s.length() != cs.length()) return false;
-        for (int i = 0; i < cs.length(); i++)
-            if (Character.toLowerCase(charAt(s, i)) !=
-                    Character.toLowerCase(charAt(cs, i)))
+    public static boolean equalsCaseIgnore(@Nullable CharSequence s1, @NotNull CharSequence s2) {
+        if (s1 == null) return false;
+        if (s1.length() != s2.length()) return false;
+        for (int i = 0; i < s2.length(); i++) {
+            char c1 = charAt(s1, i);
+            char c2 = charAt(s2, i);
+            if (c1 == c2)
+                continue;
+            if (Character.toLowerCase(c1) != Character.toLowerCase(c2))
                 return false;
+        }
         return true;
     }
 


### PR DESCRIPTION
StringUtils.equalsCaseIgnore can be optimised for the common case where both strings exactly match. See #683 

`equalsCaseIgnore` is used in wire during deserialisation - `net.openhft.chronicle.wire.TextWire#read(java.lang.CharSequence, int, java.lang.Object)`

Screenshot shows before and after:

<img width="1141" alt="image" src="https://github.com/user-attachments/assets/3725654c-1c1a-47d4-8e13-f89c8799f281" />
 