### PR TITLE
Make timestamp inclusion in stack trace optional

### DIFF
--- a/src/main/java/net/openhft/chronicle/core/StackTrace.java
+++ b/src/main/java/net/openhft/chronicle/core/StackTrace.java
@@ -80,7 +80,17 @@ public class StackTrace extends Throwable {
      * default message "stack trace".
      */
     public StackTrace() {
-        this("stack trace");
+        this("stack trace", false);
+    }
+
+    /**
+     * Constructs a new {@code StackTrace} for the current thread with the
+     * default message "stack trace", optionally including a timestamp in the stack trace message.
+     *
+     * @param addTimestamp whether to add a timestamp to the stack trace message
+     */
+    public StackTrace(boolean addTimestamp) {
+        this("stack trace", null, addTimestamp);
     }
 
     /**
@@ -93,13 +103,33 @@ public class StackTrace extends Throwable {
     }
 
     /**
+     * Constructs a new {@code StackTrace} for the current thread with the specified message, optionally including a timestamp in the stack trace message.
+     *
+     * @param message the detail message for this stack trace.
+     * @param addTimestamp whether to add a timestamp to the stack trace message*
+     */
+    public StackTrace(String message, boolean addTimestamp) { this(message, null, addTimestamp); }
+
+
+    /**
      * Constructs a new {@code StackTrace} with the specified message and cause.
      *
      * @param message the detail message for this stack trace.
      * @param cause   the cause of this stack trace, or {@code null} if the cause is unknown or nonexistent.
      */
     public StackTrace(String message, Throwable cause) {
-        super(message + " on " + Thread.currentThread().getName() + " at " + nanosAsZonedDateTime(), cause);
+        this(message, cause, false);
+    }
+
+    /**
+     * Constructs a new {@code StackTrace} with the specified message and cause, optionally including a timestamp in the stack trace message.
+     *
+     * @param message the detail message for this stack trace.
+     * @param cause   the cause of this stack trace, or {@code null} if the cause is unknown or nonexistent.
+     * @param addTimestamp whether to add a timestamp to the stack trace message
+     */
+    public StackTrace(String message, Throwable cause, boolean addTimestamp) {
+        super(message + " on " + Thread.currentThread().getName() + (addTimestamp ? " at " + nanosAsZonedDateTime() : ""), cause);
     }
 
     /**
@@ -152,7 +182,7 @@ public class StackTrace extends Throwable {
          * @param message the detail message for this stack trace.
          */
         public Less(String message) {
-            super(message);
+            super(message, true);
         }
 
         /**

--- a/src/test/java/net/openhft/chronicle/core/StackTraceTest.java
+++ b/src/test/java/net/openhft/chronicle/core/StackTraceTest.java
@@ -39,7 +39,7 @@ public class StackTraceTest extends CoreTestCommon {
 
     @Test
     public void testDefaultConstructor() {
-        StackTrace st = new StackTrace();
+        StackTrace st = new StackTrace(true);
         String currentThreadName = Thread.currentThread().getName();
         assertTrue(
                 String.format("%s must match regular expression expecting 'stack trace on %s at' with following timestamp", st.getMessage(), currentThreadName),
@@ -50,7 +50,7 @@ public class StackTraceTest extends CoreTestCommon {
     @Test
     public void testConstructorWithMessage() {
         String message = "test message";
-        StackTrace st = new StackTrace(message);
+        StackTrace st = new StackTrace(message, true);
 
         assertTrue(
                 String.format("%s must match regular expression expecting '%s on %s at' with following timestamp", st.getMessage(), message, Thread.currentThread().getName()),
@@ -62,7 +62,7 @@ public class StackTraceTest extends CoreTestCommon {
     public void testConstructorWithMessageAndCause() {
         String message = "test message";
         Throwable cause = new RuntimeException("cause");
-        StackTrace st = new StackTrace(message, cause);
+        StackTrace st = new StackTrace(message, cause, true);
 
         assertTrue(
                 String.format("%s must match regular expression expecting '%s on %s at' with following timestamp", st.getMessage(), message, Thread.currentThread().getName()),
@@ -133,7 +133,7 @@ public class StackTraceTest extends CoreTestCommon {
     @Test
     public void testTimeIsUTC() {
         // Confirm the appended timestamp is in UTC
-        StackTrace st = new StackTrace();
+        StackTrace st = new StackTrace(true);
         String msg = st.getMessage(); // e.g. "... at 2030-12-31T23:59:59.999999999Z"
         assertTrue("Timestamp should end with 'Z' for UTC", msg.endsWith("Z"));
     }


### PR DESCRIPTION
Default stack trace generation to not include stack trace, but allow optional inclusion of timestamp in stack trace.