### PR TITLE
Fix CPU detection on macOS

### DIFF
--- a/src/main/java/net/openhft/chronicle/core/internal/CpuClass.java
+++ b/src/main/java/net/openhft/chronicle/core/internal/CpuClass.java
@@ -52,15 +52,13 @@ public final class CpuClass {
 
             } else if (Bootstrap.IS_MAC) {
 
-                String cmd = "sysctl -a";
+                String cmd = "sysctl -n machdep.cpu.brand_string";
                 Process process = new ProcessBuilder(cmd.split(" "))
                         .redirectErrorStream(true)
                         .start();
                 try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
                     model = reader.lines()
                             .map(String::trim)
-                            .filter(s -> s.startsWith("machdep.cpu.brand_string"))
-                            .map(removingTag())
                             .findFirst().orElse(model);
                 }
                 try {

--- a/src/test/java/net/openhft/chronicle/core/internal/CpuClassTest.java
+++ b/src/test/java/net/openhft/chronicle/core/internal/CpuClassTest.java
@@ -29,8 +29,6 @@ public class CpuClassTest {
 
     @Test
     public void removingTag() {
-        // TODO FIX on MacOS. sysctl -a returned 141, https://github.com/OpenHFT/Chronicle-Core/issues/557
-        assumeFalse(net.openhft.chronicle.core.internal.Bootstrap.IS_MAC);
         final String actual = CpuClass.removingTag().apply("tag: value");
         assertEquals("value", actual);
     }


### PR DESCRIPTION
## Summary
- run `sysctl` with brand string flag to avoid SIGPIPE issues
- remove macOS assumption from removingTag test

## Testing
- `mvn -q test` *(fails: command not found)*