### PR TITLE
Replace Travis with GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: ["**"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [ '11', '17', '21' ]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: ${{ matrix.java }}
+      - name: Build with Maven
+        run: mvn --batch-mode --no-transfer-progress verify

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,0 @@
-language: java
-
-jdk:
-  - oraclejdk8

--- a/README.adoc
+++ b/README.adoc
@@ -11,6 +11,7 @@ image:https://javadoc.io/badge2/net.openhft/chronicle-core/javadoc.svg[link="htt
 image:https://img.shields.io/github/license/OpenHFT/Chronicle-Core[GitHub]
 image:https://img.shields.io/badge/release%20notes-subscribe-brightgreen[link="https://chronicle.software/release-notes/"]
 image:https://sonarcloud.io/api/project_badges/measure?project=OpenHFT_Chronicle-Core&metric=alert_status[link="https://sonarcloud.io/dashboard?id=OpenHFT_Chronicle-Core"]
+image:https://github.com/OpenHFT/Chronicle-Core/actions/workflows/ci.yml/badge.svg[link=https://github.com/OpenHFT/Chronicle-Core/actions/workflows/ci.yml]
 
 image::images/Core_line.png[width=20%]
 
@@ -618,3 +619,7 @@ JLBH has moved home and now lives in its own project, see https://github.com/Ope
 The tool to summarise the thread stack traces is here.
 
 `net.openhft.chronicle.core.threads.MonitorProfileAnalyserMain`
+
+== Continuous Integration
+
+This project uses GitHub Actions to build and test against JDK 11, 17 and 21 using Maven.


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow targeting JDK 11, 17 and 21
- remove obsolete `.travis.yml`
- document CI badge and section in README

## Testing
- `git status --short`