### PR TITLE
Fix resource tracing property key

### DIFF
--- a/systemProperties.adoc
+++ b/systemProperties.adoc
@@ -17,7 +17,7 @@ NOTE: All boolean properties listed in the table are read using https://javadoc.
 | `disable.resource.warning` | `false` | If enabled, returns that resource tracing is turned on | boolean
 | `disable.single.threaded.check` | `false` | Disables thread safety checks | boolean
 | `jfr` | `false` | Returns if the JVM is running in flight recorder mode | `IS_FLIGHT_RECORDER` (boolean)
-| `jvm.resources.tracing` | `false` | Returns if certain chronicle resources (such as memory regions) are traced. Reference counting can be enabled, which incurs slightly less performance, but it provides a means of detecting proper release of resources | RESOURCE_TRACING (boolean)
+| `jvm.resource.tracing` | `false` | Returns if certain chronicle resources (such as memory regions) are traced. Reference counting can be enabled, which incurs slightly less performance, but it provides a means of detecting proper release of resources | RESOURCE_TRACING (boolean)
 | `jvm.safepoint.enabled` | `false` | If enabled, inserts a low-cost Java safe-point, which can help to find blockages. Jvm.safepoint can also be added when monitoring the event loop in link:https://github.com/OpenHFT/Chronicle-Threads#monitoring-the-event-loop[Chronicle-Threads] to help identify hotspots in the code | `SAFEPOINT_ENABLED` (boolean)
 | `reference.warn.count` | unknown | If there is a high reserve count (relative to referenceCounted), warning is thrown stating the referenceName with the high reserve count | `WARN_COUNT` (int)
 | `reference.warn.secs` | 0.003 | If time of inThreadPerformanceRelease is greater than default, message is thrown to state the ms it takes to performRelease | `WARN_NS` (long)


### PR DESCRIPTION
## Summary
- standardize on `jvm.resource.tracing`
- update systemProperties.adoc to match code

## Testing
- `mvn -q test` *(fails: command not found)*