### PR TITLE
Relocate lifecycle helpers to concrete classes

### DIFF
--- a/src/main/java/net/openhft/chronicle/core/io/AbstractCloseableReferenceCounted.java
+++ b/src/main/java/net/openhft/chronicle/core/io/AbstractCloseableReferenceCounted.java
@@ -22,6 +22,8 @@ import net.openhft.chronicle.core.Jvm;
 import net.openhft.chronicle.core.StackTrace;
 import net.openhft.chronicle.core.internal.CloseableUtils;
 import net.openhft.chronicle.core.internal.ReferenceCountedUtils;
+import net.openhft.chronicle.core.onoes.ExceptionHandler;
+import net.openhft.chronicle.core.onoes.Slf4jExceptionHandler;
 
 /**
  * Represents a closeable resource with reference counting capabilities.
@@ -210,6 +212,22 @@ public abstract class AbstractCloseableReferenceCounted
     @Override
     public boolean isClosed() {
         return refCount() <= 0 || closed;
+    }
+
+    @Override
+    public void warnAndCloseIfNotClosed() {
+        if (!isClosing()) {
+            if (Jvm.isResourceTracing() && !AbstractCloseable.DISABLE_DISCARD_WARNING) {
+                ExceptionHandler warn = Jvm.getBoolean("warnAndCloseIfNotClosed") ? Jvm.warn() : Slf4jExceptionHandler.WARN;
+                warn.on(getClass(), "Discarded without closing " + this);
+            }
+            Closeable.closeQuietly(this);
+        }
+    }
+
+    @Override
+    public StackTrace createdHere() {
+        return null;
     }
 
     @Override

--- a/src/main/java/net/openhft/chronicle/core/io/ManagedCloseable.java
+++ b/src/main/java/net/openhft/chronicle/core/io/ManagedCloseable.java
@@ -43,6 +43,7 @@ public interface ManagedCloseable extends Closeable {
      * exception is thrown if an error occurs during the closing process.
      */
     // TODO move implementation to sub-classes in x.24
+    @Deprecated(/* to be removed in the next major release */)
     default void warnAndCloseIfNotClosed() {
         if (!isClosing()) {
             if (Jvm.isResourceTracing() && !DISABLE_DISCARD_WARNING) {
@@ -78,6 +79,7 @@ public interface ManagedCloseable extends Closeable {
      * @return The stack trace of the location where the resource was created, or {@code null} if the information is not available.
      */
     // TODO move implementation to sub-classes in x.24
+    @Deprecated(/* to be removed in the next major release */)
     default StackTrace createdHere() {
         return null;
     }

--- a/src/main/java/net/openhft/chronicle/core/io/ReferenceCounted.java
+++ b/src/main/java/net/openhft/chronicle/core/io/ReferenceCounted.java
@@ -47,6 +47,7 @@ public interface ReferenceCounted extends ReferenceOwner {
      * @throws ThreadingIllegalStateException If this resource was accessed by multiple threads in an unsafe way
      */
     // TODO move implementation to sub-classes in x.24
+    @Deprecated(/* to be removed in the next major release */)
     default void reserveTransfer(ReferenceOwner from, ReferenceOwner to) throws ClosedIllegalStateException, ThreadingIllegalStateException {
         reserve(to);
         release(from);

--- a/src/main/java/net/openhft/chronicle/core/io/ReferenceCountedTracer.java
+++ b/src/main/java/net/openhft/chronicle/core/io/ReferenceCountedTracer.java
@@ -54,6 +54,7 @@ public interface ReferenceCountedTracer extends ReferenceCounted {
      * @throws ClosedIllegalStateException If the resource has been released or closed.
      */
     // TODO move implementation to sub-classes in x.24
+    @Deprecated(/* to be removed in the next major release */)
     default void throwExceptionIfReleased() throws ClosedIllegalStateException {
         if (refCount() <= 0)
             throw new ClosedIllegalStateException("Released");

--- a/src/main/java/net/openhft/chronicle/core/io/VanillaReferenceCounted.java
+++ b/src/main/java/net/openhft/chronicle/core/io/VanillaReferenceCounted.java
@@ -194,6 +194,12 @@ public final class VanillaReferenceCounted implements MonitorReferenceCounted {
     }
 
     @Override
+    public void throwExceptionIfReleased() throws ClosedIllegalStateException {
+        if (refCount() <= 0)
+            throw new ClosedIllegalStateException(type.getName() + " released", releasedHere);
+    }
+
+    @Override
     public void throwExceptionIfNotReleased() throws IllegalStateException {
         if (refCount() > 0)
             throw new IllegalStateException(type.getName() + " still reserved, count=" + refCount());


### PR DESCRIPTION
## Summary
- deprecate helper defaults in interfaces
- implement throwExceptionIfReleased in `VanillaReferenceCounted`
- implement warn-and-close helpers in `AbstractCloseableReferenceCounted`

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*