### PR TITLE
Add STARTUP log level

### DIFF
--- a/src/main/java/net/openhft/chronicle/core/Jvm.java
+++ b/src/main/java/net/openhft/chronicle/core/Jvm.java
@@ -77,6 +77,7 @@ public final class Jvm {
     private static final ExceptionHandler DEFAULT_ERROR_EXCEPTION_HANDLER = Slf4jExceptionHandler.ERROR;
     private static final ExceptionHandler DEFAULT_WARN_EXCEPTION_HANDLER = Slf4jExceptionHandler.WARN;
     private static final ExceptionHandler DEFAULT_PERF_EXCEPTION_HANDLER = Slf4jExceptionHandler.PERF;
+    private static final ExceptionHandler DEFAULT_STARTUP_EXCEPTION_HANDLER = Slf4jExceptionHandler.STARTUP;
     private static final ExceptionHandler DEFAULT_DEBUG_EXCEPTION_HANDLER = Slf4jExceptionHandler.DEBUG;
     private static final String PROC = "/proc";
     private static final List<String> INPUT_ARGUMENTS = getRuntimeMXBean().getInputArguments();
@@ -95,6 +96,8 @@ public final class Jvm {
     private static final ThreadLocalisedExceptionHandler WARN = new ThreadLocalisedExceptionHandler(DEFAULT_WARN_EXCEPTION_HANDLER);
     @NotNull
     private static final ThreadLocalisedExceptionHandler PERF = new ThreadLocalisedExceptionHandler(DEFAULT_PERF_EXCEPTION_HANDLER);
+    @NotNull
+    private static final ThreadLocalisedExceptionHandler STARTUP = new ThreadLocalisedExceptionHandler(DEFAULT_STARTUP_EXCEPTION_HANDLER);
     @NotNull
     private static final ExceptionHandler DEBUG;
     private static final long MAX_DIRECT_MEMORY;
@@ -697,6 +700,7 @@ public final class Jvm {
     public static void resetExceptionHandlers() {
         setErrorExceptionHandler(DEFAULT_ERROR_EXCEPTION_HANDLER);
         setWarnExceptionHandler(DEFAULT_WARN_EXCEPTION_HANDLER);
+        setStartupExceptionHandler(DEFAULT_STARTUP_EXCEPTION_HANDLER);
         setDebugExceptionHandler(DEFAULT_DEBUG_EXCEPTION_HANDLER);
         setPerfExceptionHandler(DEFAULT_PERF_EXCEPTION_HANDLER);
     }
@@ -707,6 +711,10 @@ public final class Jvm {
 
     public static void setWarnExceptionHandler(ExceptionHandler exceptionHandler) {
         WARN.defaultHandler(exceptionHandler).resetThreadLocalHandler();
+    }
+
+    public static void setStartupExceptionHandler(ExceptionHandler exceptionHandler) {
+        STARTUP.defaultHandler(exceptionHandler).resetThreadLocalHandler();
     }
 
     public static void setDebugExceptionHandler(ExceptionHandler exceptionHandler) {
@@ -724,6 +732,10 @@ public final class Jvm {
 
     public static void disablePerfHandler() {
         setPerfExceptionHandler(null);
+    }
+
+    public static void disableStartupHandler() {
+        setStartupExceptionHandler(null);
     }
 
     public static void disableWarnHandler() {
@@ -776,7 +788,7 @@ public final class Jvm {
         final Iterator<ExceptionKey> iterator = exceptions.keySet().iterator();
         while (iterator.hasNext()) {
             final ExceptionKey k = iterator.next();
-            if (k.level() != LogLevel.DEBUG && k.level() != LogLevel.PERF)
+            if (k.level() != LogLevel.DEBUG && k.level() != LogLevel.PERF && k.level() != LogLevel.STARTUP)
                 return true;
         }
 
@@ -848,8 +860,7 @@ public final class Jvm {
      */
     @NotNull
     public static ExceptionHandler startup() {
-        // TODO, add a startup level?
-        return PERF;
+        return STARTUP;
     }
 
     /**

--- a/src/main/java/net/openhft/chronicle/core/onoes/LogLevel.java
+++ b/src/main/java/net/openhft/chronicle/core/onoes/LogLevel.java
@@ -26,6 +26,7 @@ package net.openhft.chronicle.core.onoes;
  * <ul>
  *     <li>{@link #ERROR} - Designates error events that might still allow the application to continue running.</li>
  *     <li>{@link #WARN} - Designates potentially harmful situations which should still allow the application to continue.</li>
+ *     <li>{@link #STARTUP} - Designates informational messages printed during application start-up.</li>
  *     <li>{@link #PERF} - Designates performance events that could be used for performance optimization and diagnosis.</li>
  *     <li>{@link #DEBUG} - Designates fine-grained informational events that are most useful to debug an application.</li>
  * </ul>
@@ -33,6 +34,7 @@ package net.openhft.chronicle.core.onoes;
 public enum LogLevel {
     ERROR,
     WARN,
+    STARTUP,
     PERF,
     DEBUG
 }

--- a/src/main/java/net/openhft/chronicle/core/onoes/Slf4jExceptionHandler.java
+++ b/src/main/java/net/openhft/chronicle/core/onoes/Slf4jExceptionHandler.java
@@ -28,7 +28,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Slf4jExceptionHandler is an enum implementation of the ExceptionHandler interface.
  * It uses SLF4J (Simple Logging Facade for Java) to handle exceptions based on the level of logging severity.
- * It supports four levels of logging severity: ERROR, WARN, PERF and DEBUG.
+ * It supports five levels of logging severity: ERROR, WARN, STARTUP, PERF and DEBUG.
  * <p>
  * Each instance of Slf4jExceptionHandler logs at a specific level and corresponds to a LogLevel enum.
  * This is used to map LogLevel enums to their corresponding Slf4jExceptionHandler instances via the valueOf(LogLevel logLevel) method.
@@ -40,6 +40,7 @@ import org.slf4j.LoggerFactory;
 public enum Slf4jExceptionHandler implements ExceptionHandler {
     ERROR(Logger::error),
     WARN(Logger::warn),
+    STARTUP(Logger::info),
     PERF(Logger::info),
     DEBUG(Logger::debug) {
         @Override
@@ -99,6 +100,8 @@ public enum Slf4jExceptionHandler implements ExceptionHandler {
             return ERROR;
         if (logLevel == LogLevel.WARN)
             return WARN;
+        if (logLevel == LogLevel.STARTUP)
+            return STARTUP;
         if (logLevel == LogLevel.PERF)
             return PERF;
         return DEBUG;

--- a/src/test/java/net/openhft/chronicle/core/JvmTest.java
+++ b/src/test/java/net/openhft/chronicle/core/JvmTest.java
@@ -92,6 +92,7 @@ public class JvmTest extends CoreTestCommon {
         Jvm.resetExceptionHandlers();
         assertSame(Jvm.getField(Jvm.class, "DEFAULT_PERF_EXCEPTION_HANDLER").get(null), Jvm.perf().defaultHandler());
         assertSame(Jvm.getField(Jvm.class, "DEFAULT_WARN_EXCEPTION_HANDLER").get(null), Jvm.warn().defaultHandler());
+        assertSame(Jvm.getField(Jvm.class, "DEFAULT_STARTUP_EXCEPTION_HANDLER").get(null), Jvm.startup().defaultHandler());
         assertSame(Jvm.getField(Jvm.class, "DEFAULT_ERROR_EXCEPTION_HANDLER").get(null), Jvm.error().defaultHandler());
         assertSame(Jvm.getField(Jvm.class, "DEFAULT_DEBUG_EXCEPTION_HANDLER").get(null), Jvm.debug().defaultHandler());
     }

--- a/src/test/java/net/openhft/chronicle/core/internal/JvmExceptionTracker.java
+++ b/src/test/java/net/openhft/chronicle/core/internal/JvmExceptionTracker.java
@@ -37,7 +37,7 @@ import static net.openhft.chronicle.core.onoes.LogLevel.PERF;
 public enum JvmExceptionTracker {
     ;
 
-    private static final Set<LogLevel> IGNORED_LOG_LEVELS = EnumSet.of(DEBUG, PERF);
+    private static final Set<LogLevel> IGNORED_LOG_LEVELS = EnumSet.of(DEBUG, PERF, LogLevel.STARTUP);
 
     /**
      * Create a JvmExceptionTracker

--- a/src/test/java/net/openhft/chronicle/core/onoes/Slf4jExceptionHandlerTest.java
+++ b/src/test/java/net/openhft/chronicle/core/onoes/Slf4jExceptionHandlerTest.java
@@ -39,6 +39,14 @@ class Slf4jExceptionHandlerTest {
     }
 
     @Test
+    void testStartupLogLevel() {
+        Throwable throwable = new RuntimeException("Test exception");
+        Slf4jExceptionHandler.STARTUP.on(logger, "Startup message", throwable);
+
+        verify(logger).info("Startup message", throwable);
+    }
+
+    @Test
     void testDebugLogLevel() {
         Throwable throwable = new RuntimeException("Test exception");
         Slf4jExceptionHandler.DEBUG.on(logger, "Debug message", throwable);
@@ -50,6 +58,7 @@ class Slf4jExceptionHandlerTest {
     void testValueOfLogLevel() {
         assertEquals(Slf4jExceptionHandler.ERROR, Slf4jExceptionHandler.valueOf(LogLevel.ERROR));
         assertEquals(Slf4jExceptionHandler.WARN, Slf4jExceptionHandler.valueOf(LogLevel.WARN));
+        assertEquals(Slf4jExceptionHandler.STARTUP, Slf4jExceptionHandler.valueOf(LogLevel.STARTUP));
         assertEquals(Slf4jExceptionHandler.PERF, Slf4jExceptionHandler.valueOf(LogLevel.PERF));
         assertEquals(Slf4jExceptionHandler.DEBUG, Slf4jExceptionHandler.valueOf(LogLevel.DEBUG));
     }


### PR DESCRIPTION
## Summary
- extend the logging levels with `STARTUP`
- map `STARTUP` to a new slf4j handler
- return this handler from `Jvm.startup()`
- ignore STARTUP events in the test exception tracker
- update unit tests for the new level

## Testing
- `mvn -q test` *(fails: `mvn` not found)*