### PR TITLE
Add CPU model consistency test

### DIFF
--- a/src/test/java/net/openhft/chronicle/core/internal/CpuClassTest.java
+++ b/src/test/java/net/openhft/chronicle/core/internal/CpuClassTest.java
@@ -44,4 +44,12 @@ public class CpuClassTest {
     public void getCpuModelShouldReturnNonEmptyValue() {
         assertNotEquals("", CpuClass.getCpuModel(), "CPU model should not be an empty string");
     }
+
+    @Test
+    public void getCpuModelShouldRemainConstantAcrossCalls() {
+        final String cpuModel = CpuClass.getCpuModel();
+        for (int i = 0; i < 3; i++) {
+            assertEquals("CPU model should remain constant across calls", cpuModel, CpuClass.getCpuModel());
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- verify `CpuClass.getCpuModel()` returns the same string across invocations

## Testing
- `mvn -q test` *(fails: `mvn` not found)*