### PR TITLE
Handle multiple tag prefixes

### DIFF
--- a/src/main/java/net/openhft/chronicle/core/internal/CpuClass.java
+++ b/src/main/java/net/openhft/chronicle/core/internal/CpuClass.java
@@ -93,6 +93,6 @@ public final class CpuClass {
     @SuppressWarnings("java:S5852") // Possessive quantifiers (*+) are used preventing catastrophic backtracking
     @NotNull
     static Function<String, String> removingTag() {
-        return line -> line.replaceFirst("[^:]*+: ", "");
+        return line -> line.replaceFirst("^(?:[^:]+:\\s*)+", "");
     }
 }

--- a/src/test/java/net/openhft/chronicle/core/internal/CpuClassTest.java
+++ b/src/test/java/net/openhft/chronicle/core/internal/CpuClassTest.java
@@ -31,8 +31,10 @@ public class CpuClassTest {
     public void removingTag() {
         // TODO FIX on MacOS. sysctl -a returned 141, https://github.com/OpenHFT/Chronicle-Core/issues/557
         assumeFalse(net.openhft.chronicle.core.internal.Bootstrap.IS_MAC);
-        final String actual = CpuClass.removingTag().apply("tag: value");
-        assertEquals("value", actual);
+        assertEquals("value", CpuClass.removingTag().apply("tag: value"));
+        assertEquals("value", CpuClass.removingTag().apply("tag1: tag2: value"));
+        assertEquals("value", CpuClass.removingTag().apply("tag1:tag2:value"));
+        assertEquals("value", CpuClass.removingTag().apply("tag1:   tag2 :  value"));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- support removing multiple prefixes from CPU model tag lines
- test removing multiple tags and whitespace

## Testing
- `mvn -q test` *(fails: `mvn` not found)*