### PR TITLE
Add multi-thread test for disabled asserter

### DIFF
--- a/src/test/java/net/openhft/chronicle/core/util/ThreadConfinementAsserterTest.java
+++ b/src/test/java/net/openhft/chronicle/core/util/ThreadConfinementAsserterTest.java
@@ -47,4 +47,22 @@ class ThreadConfinementAsserterTest {
         assertNotNull(asserter);
         // Further testing of functionality.
     }
+
+    @Test
+    void nopAsserterAllowsCallsFromMultipleThreads() throws InterruptedException {
+        ThreadConfinementAsserter asserter = ThreadConfinementAsserter.create();
+        int threadCount = 3;
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        for (int i = 0; i < threadCount; i++) {
+            executorService.execute(() -> {
+                assertDoesNotThrow(asserter::assertThreadConfined);
+                latch.countDown();
+            });
+        }
+
+        latch.await();
+        executorService.shutdown();
+    }
 }


### PR DESCRIPTION
## Summary
- verify ThreadConfinementAsserter.create() works safely across threads
- add test demonstrating disabled asserter ignores thread confinement

## Testing
- `mvn -q test` *(fails: `mvn` not found)*