### PR TITLE
Add test for thread confinement across threads

### DIFF
--- a/src/test/java/net/openhft/chronicle/core/util/ThreadConfinementAsserterTest.java
+++ b/src/test/java/net/openhft/chronicle/core/util/ThreadConfinementAsserterTest.java
@@ -35,6 +35,20 @@ class ThreadConfinementAsserterTest {
     }
 
     @Test
+    void assertThreadSafeFromTwoThreadsThrowsException() throws InterruptedException {
+        ThreadConfinementAsserter asserter = ThreadConfinementAsserter.createEnabled();
+
+        // first thread initializes the asserter
+        asserter.assertThreadConfined();
+
+        Thread other = new Thread(() ->
+                assertThrows(IllegalStateException.class, asserter::assertThreadConfined));
+
+        other.start();
+        other.join();
+    }
+
+    @Test
     void createShouldReturnCorrectTypeBasedOnAssertions() {
         // This test's behavior will depend on whether assertions are enabled in the JVM.
         ThreadConfinementAsserter asserter = ThreadConfinementAsserter.create();


### PR DESCRIPTION
## Summary
- add an extra test verifying that `ThreadConfinementAsserter` throws when used from two threads

## Testing
- ❌ `mvn test` *(failed: `mvn` not installed)*