### PR TITLE
Add mapAlignment consistency test

### DIFF
--- a/src/test/java/net/openhft/chronicle/core/OSTest.java
+++ b/src/test/java/net/openhft/chronicle/core/OSTest.java
@@ -372,4 +372,13 @@ public class OSTest extends CoreTestCommon {
 
         assertEquals(expectedHostName, OS.HostnameHolder.HOST_NAME);
     }
+
+    @Test
+    public void testMapAlignmentConsistentAndPositive() {
+        long alignment1 = OS.mapAlignment();
+        long alignment2 = OS.mapAlignment();
+
+        assertTrue(alignment1 > 0);
+        assertEquals(alignment1, alignment2);
+    }
 }


### PR DESCRIPTION
## Summary
- add a test to ensure `OS.mapAlignment()` returns a positive value
- verify subsequent calls to `OS.mapAlignment()` return the same value

## Testing
- `mvn -q -Dtest=OSTest#testMapAlignmentConsistentAndPositive test` *(fails: `mvn` not found)*