### PR TITLE
Add reflection test for MaxBytes

### DIFF
--- a/src/test/java/net/openhft/chronicle/core/values/MaxBytesAnnotationTest.java
+++ b/src/test/java/net/openhft/chronicle/core/values/MaxBytesAnnotationTest.java
@@ -1,0 +1,25 @@
+package net.openhft.chronicle.core.values;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class MaxBytesAnnotationTest {
+
+    static class Example {
+        void annotatedMethod(@MaxBytes CharSequence text) {
+        }
+    }
+
+    @Test
+    void defaultValueIsSixtyFour() throws NoSuchMethodException {
+        Method method = Example.class.getDeclaredMethod("annotatedMethod", CharSequence.class);
+        Parameter parameter = method.getParameters()[0];
+        MaxBytes annotation = parameter.getAnnotation(MaxBytes.class);
+        assertNotNull(annotation, "@MaxBytes annotation should be present");
+        assertEquals(64, annotation.value());
+    }
+}


### PR DESCRIPTION
## Summary
- add a test verifying that `@MaxBytes` retains a default value of 64 at runtime

## Testing
- `mvn -q test` *(fails: command not found)*