### PR TITLE
Fix debug handler disable test

### DIFF
--- a/src/test/java/net/openhft/chronicle/core/JvmTest.java
+++ b/src/test/java/net/openhft/chronicle/core/JvmTest.java
@@ -379,6 +379,7 @@ public class JvmTest extends CoreTestCommon {
     @Test
     public void testDisableDebugHandler() {
         Jvm.disableDebugHandler();
+        assertTrue(Jvm.debug().defaultHandler() instanceof net.openhft.chronicle.core.onoes.NullExceptionHandler);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- verify that disabling the debug handler results in a NullExceptionHandler

## Testing
- `mvn -q -Dtest=JvmTest test` *(fails: `mvn` not found)*