### PR TITLE
Add property init runnable test

### DIFF
--- a/src/main/java/net/openhft/chronicle/core/ChronicleInit.java
+++ b/src/main/java/net/openhft/chronicle/core/ChronicleInit.java
@@ -115,4 +115,22 @@ public final class ChronicleInit {
             ex.printStackTrace();
         }
     }
+
+    /**
+     * Entry point used for simple verification of the initialisation hooks. It
+     * triggers {@link Jvm#init()} and prints the value of the system property
+     * supplied as the first argument.
+     *
+     * @param args first element is the property key to print
+     */
+    public static void main(String[] args) {
+        String key = args.length > 0 ? args[0] : "";
+        Jvm.init();
+        if (!key.isEmpty()) {
+            String value = System.getProperty(key);
+            if (value != null) {
+                System.out.println(key + "=" + value);
+            }
+        }
+    }
 }

--- a/src/test/java/net/openhft/chronicle/core/ChronicleInitMainTest.java
+++ b/src/test/java/net/openhft/chronicle/core/ChronicleInitMainTest.java
@@ -1,0 +1,37 @@
+package net.openhft.chronicle.core;
+
+import net.openhft.chronicle.testframework.process.JavaProcessBuilder;
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class ChronicleInitMainTest extends CoreTestCommon {
+
+    public static class UniquePropertyRunnable implements Runnable {
+        @Override
+        public void run() {
+            System.setProperty("unique.test.property", "expectedValue");
+        }
+    }
+
+    @Test
+    public void propertySetViaInitRunnableIsVisibleInSubprocess() throws Exception {
+        Process process = JavaProcessBuilder.create(ChronicleInit.class)
+                .withProgramArguments("unique.test.property")
+                .withJvmArguments("-Dchronicle.init.runnable=" + UniquePropertyRunnable.class.getName())
+                .start();
+
+        String output;
+        try {
+            assertEquals(0, process.waitFor());
+            output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+        } finally {
+            JavaProcessBuilder.printProcessOutput("ChronicleInitMainTest", process);
+        }
+
+        assertTrue(output.contains("unique.test.property=expectedValue"));
+    }
+}


### PR DESCRIPTION
## Summary
- add a `main` entry point in `ChronicleInit`
- add a test that runs `ChronicleInit.main` via a subprocess and verifies that an init runnable sets a property

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*