### PR TITLE
Add off-heap memory allocation test

### DIFF
--- a/src/test/java/net/openhft/chronicle/core/MemoryTest.java
+++ b/src/test/java/net/openhft/chronicle/core/MemoryTest.java
@@ -54,4 +54,19 @@ public class MemoryTest extends CoreTestCommon {
         assertEquals(Unsafe.ARRAY_LONG_INDEX_SCALE, Memory.sizeOf(long.class));
         assertEquals(Unsafe.ARRAY_OBJECT_INDEX_SCALE, Memory.sizeOf(Long.class));
     }
+
+    @Test
+    public void allocateSetAndFree() {
+        Memory memory = OS.memory();
+        long address = memory.allocate(16);
+        byte val = (byte) 0x5A;
+        try {
+            memory.setMemory(address, 16, val);
+            for (int i = 0; i < 16; i++) {
+                assertEquals(val, memory.readByte(address + i));
+            }
+        } finally {
+            memory.freeMemory(address, 16);
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- test allocating and filling memory with `OS.memory()`

## Testing
- `mvn -q -Dtest=MemoryTest test` *(fails: `mvn: command not found`)*