### PR TITLE
Add HostnameHolder.execHostname mocking test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -143,6 +143,13 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <repositories>

--- a/src/test/java/net/openhft/chronicle/core/HostnameHolderExecTest.java
+++ b/src/test/java/net/openhft/chronicle/core/HostnameHolderExecTest.java
@@ -1,0 +1,53 @@
+package net.openhft.chronicle.core;
+
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import net.openhft.chronicle.core.OS;
+import net.openhft.chronicle.core.Jvm;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+public class HostnameHolderExecTest {
+
+    @Test
+    public void execHostnameReadsProvidedValue() throws Exception {
+        Assumptions.assumeTrue(Jvm.majorVersion() <= 17);
+
+        Process process = mock(Process.class);
+        InputStream is = new ByteArrayInputStream("my-test-host\n".getBytes());
+        when(process.getInputStream()).thenReturn(is);
+
+        Runtime runtime = mock(Runtime.class);
+        when(runtime.exec("hostname")).thenReturn(process);
+
+        try (MockedStatic<Runtime> mocked = mockStatic(Runtime.class)) {
+            mocked.when(Runtime::getRuntime).thenReturn(runtime);
+            String hostname = OS.HostnameHolder.execHostname();
+            assertEquals("my-test-host", hostname);
+        }
+    }
+
+    @Test
+    public void execHostnameReadsLocalhost() throws Exception {
+        Assumptions.assumeTrue(Jvm.majorVersion() <= 17);
+
+        Process process = mock(Process.class);
+        InputStream is = new ByteArrayInputStream("localhost\n".getBytes());
+        when(process.getInputStream()).thenReturn(is);
+
+        Runtime runtime = mock(Runtime.class);
+        when(runtime.exec("hostname")).thenReturn(process);
+
+        try (MockedStatic<Runtime> mocked = mockStatic(Runtime.class)) {
+            mocked.when(Runtime::getRuntime).thenReturn(runtime);
+            String hostname = OS.HostnameHolder.execHostname();
+            assertEquals("localhost", hostname);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add tests for HostnameHolder.execHostname using Mockito
- enable Mockito inline mocking

## Testing
- `mvn -version` *(fails: command not found)*