### PR TITLE
Add InternalPomProperties unknown version test

### DIFF
--- a/src/test/java/net/openhft/chronicle/core/internal/pom/InternalPomPropertiesTest.java
+++ b/src/test/java/net/openhft/chronicle/core/internal/pom/InternalPomPropertiesTest.java
@@ -1,0 +1,14 @@
+package net.openhft.chronicle.core.internal.pom;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class InternalPomPropertiesTest {
+
+    @Test
+    void versionShouldReturnUnknownForMissingArtifact() {
+        String version = InternalPomProperties.version("non.existent", "artifact");
+        assertEquals("unknown", version);
+    }
+}


### PR DESCRIPTION
## Summary
- add a test for `InternalPomProperties.version` when called with a nonexistent artifact

## Testing
- `mvn -q test` *(fails: `mvn` not found)*