### PR TITLE
Add close() behaviour test

### DIFF
--- a/src/test/java/net/openhft/chronicle/core/io/AbstractCloseableReferenceCountedCloseTest.java
+++ b/src/test/java/net/openhft/chronicle/core/io/AbstractCloseableReferenceCountedCloseTest.java
@@ -1,0 +1,39 @@
+package net.openhft.chronicle.core.io;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests for {@link AbstractCloseableReferenceCounted#close()}.
+ */
+public class AbstractCloseableReferenceCountedCloseTest {
+
+    static class TestCloseableReferenceCounted extends AbstractCloseableReferenceCounted {
+        int releaseCount;
+
+        @Override
+        protected void performRelease() {
+            releaseCount++;
+        }
+    }
+
+    @Test
+    public void closeCallsPerformReleaseOnceAndMarksClosed() {
+        TestCloseableReferenceCounted rc = new TestCloseableReferenceCounted();
+        assertEquals(1, rc.refCount());
+        assertFalse(rc.isClosed());
+        assertEquals(0, rc.releaseCount);
+
+        rc.close();
+        assertTrue(rc.isClosed());
+        assertEquals(0, rc.refCount());
+        assertEquals(1, rc.releaseCount);
+
+        // subsequent closes should have no effect
+        rc.close();
+        assertTrue(rc.isClosed());
+        assertEquals(1, rc.releaseCount);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add a minimal subclass of `AbstractCloseableReferenceCounted`
- verify `close()` triggers `performRelease` exactly once
- confirm that `isClosed()` becomes true after `close()`

## Testing
- `mvn -q test` *(fails: `mvn` command not found)*