### PR TITLE
Improve annotation Javadoc

### DIFF
--- a/src/main/java/net/openhft/chronicle/core/annotation/ChronicleFeature.java
+++ b/src/main/java/net/openhft/chronicle/core/annotation/ChronicleFeature.java
@@ -5,6 +5,22 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * {@code @ChronicleFeature} indicates a compile-time switch recognised by
+ * Chronicle libraries. It is aimed at library maintainers configuring optional
+ * behaviour.
+ *
+ * <p><b>Retention and effect:</b> Retained in the class file and discarded by
+ * the Java runtime. It has no runtime effect unless Chronicle tooling
+ * recognises the value.</p>
+ *
+ * <pre>
+ * {@code @ChronicleFeature(1)}
+ * public interface CustomFeature { }
+ * </pre>
+ *
+ * @see TargetMajorVersion
+ */
 @Target({ElementType.TYPE})
 @Retention(RetentionPolicy.CLASS)
 public @interface ChronicleFeature {

--- a/src/main/java/net/openhft/chronicle/core/annotation/DontChain.java
+++ b/src/main/java/net/openhft/chronicle/core/annotation/DontChain.java
@@ -21,8 +21,19 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * This annotation, when applied to an interface, instructs that the interface should not be considered when MethodReaders and MethodWriters
- * are exploring interfaces to implement. It provides a mechanism to exclude certain interfaces from being processed by these components.
+ * {@code @DontChain} indicates that an interface should be ignored by
+ * Chronicle method readers and writers. It is intended for library maintainers
+ * when excluding ancillary APIs from tooling.
+ *
+ * <p><b>Retention and effect:</b> Retained at runtime but only acted upon by
+ * Chronicle tooling. It has no direct runtime behaviour.</p>
+ *
+ * <pre>
+ * {@code @DontChain}
+ * interface Helper { }
+ * </pre>
+ *
+ * @see UsedViaReflection
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)

--- a/src/main/java/net/openhft/chronicle/core/annotation/ForceInline.java
+++ b/src/main/java/net/openhft/chronicle/core/annotation/ForceInline.java
@@ -22,9 +22,19 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Marker annotation for some methods and constructors in the JSR 292 implementation.
- * <p>
- * To utilise this annotation see Chronicle Enterprise Warmup module.
+ * {@code @ForceInline} requests that a method or constructor be inlined where
+ * possible. It targets library maintainers controlling performance
+ * characteristics.
+ *
+ * <p><b>Retention and effect:</b> Retained at runtime but has no direct effect
+ * unless recognised by Chronicle warm-up tooling.</p>
+ *
+ * <pre>
+ * {@code @ForceInline}
+ * void busyLoop() { }
+ * </pre>
+ *
+ * @see HotMethod
  */
 @Target({ElementType.METHOD, ElementType.CONSTRUCTOR})
 @Retention(RetentionPolicy.RUNTIME)

--- a/src/main/java/net/openhft/chronicle/core/annotation/HotMethod.java
+++ b/src/main/java/net/openhft/chronicle/core/annotation/HotMethod.java
@@ -23,6 +23,20 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * {@code @HotMethod} marks a method that is expected to be performance
+ * critical. It guides library maintainers and tooling on optimisation targets.
+ *
+ * <p><b>Retention and effect:</b> Retained at runtime with no behavioural
+ * impact unless recognised by Chronicle tooling.</p>
+ *
+ * <pre>
+ * {@code @HotMethod}
+ * void parseMessage();
+ * </pre>
+ *
+ * @see ForceInline
+ */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
 public @interface HotMethod {

--- a/src/main/java/net/openhft/chronicle/core/annotation/Java9.java
+++ b/src/main/java/net/openhft/chronicle/core/annotation/Java9.java
@@ -21,7 +21,18 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Marker annotation to label methods that are expected to be called by java-9+ specific code paths.
+ * {@code @Java9} marks a method that is only used when running on Java&nbsp;9
+ * or later. It is primarily for tooling authors and library maintainers.
+ *
+ * <p><b>Retention and effect:</b> Present only in the source and discarded by
+ * the compiler. It has no runtime effect unless recognised by build tooling.</p>
+ *
+ * <pre>
+ * {@code @Java9}
+ * void newApiCall();
+ * </pre>
+ *
+ * @see TargetMajorVersion
  */
 @Retention(RetentionPolicy.SOURCE)
 @Target(ElementType.METHOD)

--- a/src/main/java/net/openhft/chronicle/core/annotation/Negative.java
+++ b/src/main/java/net/openhft/chronicle/core/annotation/Negative.java
@@ -22,9 +22,16 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Annotation that indicates the annotated element is expected to hold a negative value (i.e. {@code val < 0}).
- * This can be applied to methods, fields, parameters, local variables, and types to specify constraints
- * or document the intended usage.
+ * {@code @Negative} indicates that the annotated value must be strictly below
+ * zero. It is intended for library maintainers and tooling that check numeric
+ * contracts.
+ *
+ * <p><b>Retention and effect:</b> Stored in the class file with no direct
+ * runtime effect unless Chronicle tooling interprets it.</p>
+ *
+ * <pre>
+ * {@code @Negative} int errorCode;
+ * </pre>
  *
  * @see NonNegative
  * @see NonPositive

--- a/src/main/java/net/openhft/chronicle/core/annotation/NonNegative.java
+++ b/src/main/java/net/openhft/chronicle/core/annotation/NonNegative.java
@@ -22,9 +22,16 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Annotation that indicates the annotated element is expected to hold a non-negative value (i.e. {@code val >= 0}).
- * This can be applied to methods, fields, parameters, local variables, and types to specify constraints
- * or document the intended usage.
+ * {@code @NonNegative} declares that the annotated value must be zero or
+ * positive. It aids library maintainers and analysis tools in enforcing
+ * numerical contracts.
+ *
+ * <p><b>Retention and effect:</b> Stored in the class file but ignored by the
+ * runtime unless Chronicle tooling checks it.</p>
+ *
+ * <pre>
+ * {@code @NonNegative} long size;
+ * </pre>
  *
  * @see Negative
  * @see NonPositive

--- a/src/main/java/net/openhft/chronicle/core/annotation/NonPositive.java
+++ b/src/main/java/net/openhft/chronicle/core/annotation/NonPositive.java
@@ -22,13 +22,20 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Annotation that indicates the annotated element is expected to hold a non-positive value (i.e. {@code val <= 0}).
- * This can be applied to methods, fields, parameters, local variables, and types to specify constraints
- * or document the intended usage.
+ * {@code @NonPositive} signals that the annotated value must be zero or below.
+ * Library maintainers may use it to declare numeric constraints.
+ *
+ * <p><b>Retention and effect:</b> Persisted in the class file but ignored by
+ * the runtime unless Chronicle tooling enforces it.</p>
+ *
+ * <pre>
+ * {@code @NonPositive} int offset;
+ * </pre>
  *
  * @see Negative
  * @see NonNegative
  * @see Positive
+ * @see Range
  */
 @Retention(RetentionPolicy.CLASS)
 @Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE, ElementType.TYPE_USE})

--- a/src/main/java/net/openhft/chronicle/core/annotation/PackageLocal.java
+++ b/src/main/java/net/openhft/chronicle/core/annotation/PackageLocal.java
@@ -23,9 +23,17 @@ import static java.lang.annotation.ElementType.*;
 import static java.lang.annotation.RetentionPolicy.SOURCE;
 
 /**
- * Annotation to indicate that the annotated element has package-local visibility
- * intentionally, usually to avoid accessor methods. This annotation serves as
- * documentation to inform others of the deliberate design choice.
+ * {@code @PackageLocal} marks an element as intentionally package scoped. The
+ * audience is library maintainers documenting visibility choices.
+ *
+ * <p><b>Retention and effect:</b> Retained only in the source and discarded by
+ * the compiler. There is no runtime effect unless tooling inspects the source.</p>
+ *
+ * <pre>
+ * {@code @PackageLocal} class Helper { }
+ * </pre>
+ *
+ * @see UsedViaReflection
  */
 @Documented
 @Retention(SOURCE)

--- a/src/main/java/net/openhft/chronicle/core/annotation/Positive.java
+++ b/src/main/java/net/openhft/chronicle/core/annotation/Positive.java
@@ -22,13 +22,20 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Annotation that indicates the annotated element is expected to hold a positive value (i.e. {@code val > 0}).
- * This can be applied to methods, fields, parameters, local variables, and types to specify constraints
- * or document the intended usage.
+ * {@code @Positive} states that the annotated value must be greater than zero.
+ * It helps library maintainers and tools document numeric expectations.
+ *
+ * <p><b>Retention and effect:</b> Persisted in the class file with no direct
+ * runtime effect unless Chronicle tooling interprets it.</p>
+ *
+ * <pre>
+ * {@code @Positive} long count;
+ * </pre>
  *
  * @see Negative
  * @see NonNegative
  * @see NonPositive
+ * @see Range
  */
 @Retention(RetentionPolicy.CLASS)
 @Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE, ElementType.TYPE_USE})

--- a/src/main/java/net/openhft/chronicle/core/annotation/Range.java
+++ b/src/main/java/net/openhft/chronicle/core/annotation/Range.java
@@ -22,13 +22,22 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Indicates that the annotated element is expected to hold a value within a specified range [from, to),
- * where the "from" value is inclusive and the "to" value is exclusive (i.e. {@code from <= val < to}).
- * <p>
- * Note that this annotation cannot be used to represent an inclusive upper bound of {@link Long#MAX_VALUE}.
- * <p>
- * This annotation can be applied to methods, fields, parameters, local variables, and types to enforce
- * or document the range constraints for the values they hold.
+ * {@code @Range} asserts that a value falls within {@code [from, to)}. It is
+ * aimed at library maintainers and static analysis tools that verify argument
+ * ranges.
+ *
+ * <p><b>Retention and effect:</b> Stored in the class file. There is no runtime
+ * impact unless Chronicle tooling reads the metadata.</p>
+ *
+ * <pre>
+ * {@code @Range(from = 0, to = 10)}
+ * int level;
+ * </pre>
+ *
+ * @see Positive
+ * @see Negative
+ * @see NonNegative
+ * @see NonPositive
  */
 @Retention(RetentionPolicy.CLASS)
 @Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE, ElementType.TYPE_USE})

--- a/src/main/java/net/openhft/chronicle/core/annotation/RequiredForClient.java
+++ b/src/main/java/net/openhft/chronicle/core/annotation/RequiredForClient.java
@@ -19,9 +19,17 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
 /**
- * Indicates that modifications to the annotated class should be made with caution
- * as it is known to be used by a client. This annotation serves as a warning to
- * developers, reminding them of the implications of changes to the annotated element.
+ * {@code @RequiredForClient} warns that the annotated class is relied upon by
+ * external code. Its audience is library maintainers reviewing potential
+ * breaking changes.
+ *
+ * <p><b>Retention and effect:</b> Kept in the source only. There is no runtime
+ * effect unless build tooling checks for it.</p>
+ *
+ * <pre>
+ * {@code @RequiredForClient}
+ * public class ApiEntry { }
+ * </pre>
  */
 @Retention(RetentionPolicy.SOURCE)
 public @interface RequiredForClient {

--- a/src/main/java/net/openhft/chronicle/core/annotation/ScopeConfined.java
+++ b/src/main/java/net/openhft/chronicle/core/annotation/ScopeConfined.java
@@ -19,17 +19,17 @@ package net.openhft.chronicle.core.annotation;
 import java.lang.annotation.*;
 
 /**
- * Indicates that the value consumer, value mapper, structure etc. should not make the object available outside
- * the annotated scope. The meaning of "the object" should also be construed to include any and all descendant
- * non-immutable Object properties recursively dereferenced from the original object.
- * <p>
- * <em>
- * In other words, object contents would be purposely overwritten after they are passed to the receiver and
- * consequently cannot be kept after the invocation.
- * </em>
- * <p>
- * This annotation can be used for entities that are dealing with reused-objects.
- * The term make available also includes making the object or any of its descendant objects available to another Thread.
+ * {@code @ScopeConfined} signals that an object must not escape the annotated
+ * scope. It is aimed at tooling and library maintainers dealing with
+ * reused objects.
+ *
+ * <p><b>Retention and effect:</b> Retained at runtime but only meaningful if
+ * Chronicle tooling enforces the confinement.</p>
+ *
+ * <pre>
+ * {@code @ScopeConfined}
+ * void accept(Buffer b) { }
+ * </pre>
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)

--- a/src/main/java/net/openhft/chronicle/core/annotation/SingleThreaded.java
+++ b/src/main/java/net/openhft/chronicle/core/annotation/SingleThreaded.java
@@ -22,11 +22,17 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Annotation to document that a class is intended to be used in a single-threaded context.
- * Classes marked with this annotation are not designed for concurrent access and should
- * be accessed by only one thread at a time.
- * <p>
- * Created by Peter Lawrey on 18/05/2015.
+ * {@code @SingleThreaded} documents that a class is not thread-safe and should
+ * be used by one thread only. Library maintainers can employ it to flag
+ * non-concurrent designs.
+ *
+ * <p><b>Retention and effect:</b> Retained at runtime but imposes no automatic
+ * restrictions unless Chronicle tooling validates it.</p>
+ *
+ * <pre>
+ * {@code @SingleThreaded}
+ * final class IdGenerator { }
+ * </pre>
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)

--- a/src/main/java/net/openhft/chronicle/core/annotation/TargetMajorVersion.java
+++ b/src/main/java/net/openhft/chronicle/core/annotation/TargetMajorVersion.java
@@ -21,9 +21,19 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Annotation to specify the target major version for the annotated type. It allows
- * defining a range of major versions including, excluding, or specific to the provided
- * version.
+ * {@code @TargetMajorVersion} specifies which Java major version a type targets.
+ * It is useful for library maintainers managing backwards compatibility.
+ *
+ * <p><b>Retention and effect:</b> Retained at runtime but has no behaviour
+ * unless tooling inspects it.</p>
+ *
+ * <pre>
+ * {@code @TargetMajorVersion(11)}
+ * class ModernOnly { }
+ * </pre>
+ *
+ * @see Java9
+ * @see ChronicleFeature
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)

--- a/src/main/java/net/openhft/chronicle/core/annotation/UsedViaReflection.java
+++ b/src/main/java/net/openhft/chronicle/core/annotation/UsedViaReflection.java
@@ -24,9 +24,19 @@ import static java.lang.annotation.ElementType.*;
 import static java.lang.annotation.RetentionPolicy.CLASS;
 
 /**
- * Annotation to indicate that the annotated member is accessed via reflection, or
- * that it must be public for tests to work. This annotation can be used as a marker
- * to prevent accidental removal or modification of elements that are used dynamically.
+ * {@code @UsedViaReflection} notes that an element is accessed through
+ * reflection or tests. It warns library maintainers against removing or hiding
+ * the member.
+ *
+ * <p><b>Retention and effect:</b> Retained in the class file and ignored at
+ * runtime unless tooling looks for it.</p>
+ *
+ * <pre>
+ * {@code @UsedViaReflection}
+ * public void setAccessible() { }
+ * </pre>
+ *
+ * @see PackageLocal
  */
 @Documented
 @Retention(CLASS)

--- a/src/main/java/net/openhft/chronicle/core/annotation/package-info.java
+++ b/src/main/java/net/openhft/chronicle/core/annotation/package-info.java
@@ -1,24 +1,7 @@
 /**
- * Provides annotations for specifying and documenting constraints, expected behavior, and
- * meta-information for elements within the Chronicle Core library.
- * <p>
- * The annotations in this package can be used for a range of purposes such as:
- * <ul>
- *     <li>Specifying expected value ranges or conditions for variables and parameters.</li>
- *     <li>Documenting intended usage scenarios, such as single-threaded access.</li>
- *     <li>Conveying information about the design decisions, such as package-local access.</li>
- *     <li>Indicating implications of modifying elements referred to by clients or accessed through reflection.</li>
- * </ul>
- * <p>
- * Examples of annotations provided in this package include:
- * <ul>
- *     <li>{@link net.openhft.chronicle.core.annotation.Negative}</li>
- *     <li>{@link net.openhft.chronicle.core.annotation.NonNegative}</li>
- *     <li>{@link net.openhft.chronicle.core.annotation.SingleThreaded}</li>
- *     <li>{@link net.openhft.chronicle.core.annotation.PackageLocal}</li>
- * </ul>
- * <p>
- * These annotations may be used to convey intentions, constraints, and additional information
- * about elements in the codebase which can be beneficial for documentation, analysis or runtime behavior.
+ * Chronicle Core provides annotations describing constraints and design intent.
+ * They help library maintainers and tooling reason about code usage.
+ * <p><b>Retention and effect:</b> Each annotation declares its own retention; none
+ * has inherent runtime behaviour unless Chronicle tools act upon it.</p>
  */
 package net.openhft.chronicle.core.annotation;


### PR DESCRIPTION
## Summary
- document all annotations with unified style

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*