### PR TITLE
Clarify closeable hierarchy

### DIFF
--- a/src/main/java/net/openhft/chronicle/core/io/AbstractCloseable.java
+++ b/src/main/java/net/openhft/chronicle/core/io/AbstractCloseable.java
@@ -26,31 +26,13 @@ import net.openhft.chronicle.core.onoes.Slf4jExceptionHandler;
 import static net.openhft.chronicle.core.io.BackgroundResourceReleaser.BG_RELEASER;
 
 /**
- * An abstract class that represents a closeable resource with additional utilities for managing the resource lifecycle.
+ * Base class for Chronicle components that need deterministic shutdown.
+ * It implements {@link ManagedCloseable} and performs thread-safety checks.
+ * Concrete subclasses implement their clean-up in {@link #performClose()}.
  * <p>
- * The class provides base functionalities for resources that require proper management, especially when being closed.
- * This includes ensuring that close operations are thread-safe, providing hooks for custom cleanup logic, and supporting
- * diagnostic features for tracking resource usage. It supports resource tracing, thread safety checks, and ensures that
- * close operations are performed properly.
- *
- * <p>
- * The {@code AbstractCloseable} class implements the {@link ReferenceOwner}, {@link ManagedCloseable}, and {@link SingleThreadedChecked} interfaces.
- * The {@link ReferenceOwner} interface allows the class to have a unique reference identifier.
- * The {@link ManagedCloseable} interface ensures that this class provides mechanisms for proper resource management during close operations.
- * The {@link SingleThreadedChecked} interface ensures that the close operation is executed in a thread-safe manner.
- *
- * <p>
- * Implementations of this abstract class should override the {@link #performClose()} method to include the specific
- * cleanup logic needed for the resource. This ensures that custom cleanup logic is executed exactly once during the
- * closing of the resource.
- *
- * <p>
- * Additionally, {@code AbstractCloseable} supports resource tracing, which can be enabled or disabled to monitor and
- * diagnose resource allocation and deallocation. Resource tracing can help in identifying resource leaks and ensure
- * resources are properly managed.
- *
- * <p>
- * Subclasses can also control the behavior of thread safety checks and background closing through provided methods.
+ * Resource tracing and optional background closing are provided for debugging
+ * and performance tuning. See {@link Closeable#closeQuietly(Object)} for a
+ * helper that ignores exceptions from {@link #performClose()}.
  */
 public abstract class AbstractCloseable implements ReferenceOwner, ManagedCloseable, SingleThreadedChecked, Monitorable {
 
@@ -174,7 +156,8 @@ public abstract class AbstractCloseable implements ReferenceOwner, ManagedClosea
     }
 
     /**
-     * Closes this resource and releases any associated system resources.
+     * Idempotent close entry point used by try-with-resources. Delegates to
+     * {@link #performClose()}.
      */
     @Override
     public final void close() {
@@ -284,11 +267,8 @@ public abstract class AbstractCloseable implements ReferenceOwner, ManagedClosea
     }
 
     /**
-     * Checks if the resource is not closed, and if so, logs a warning and closes it.
-     * This method is typically called from the finalizer to ensure that resources are not
-     * garbage collected without being properly closed.
-     * <p>
-     * Called from finalise() implementations.
+     * If the resource is still open a warning is logged and it is closed using
+     * {@link Closeable#closeQuietly(Object)}. Intended for use from finalisers.
      */
     @Override
     public void warnAndCloseIfNotClosed() {
@@ -302,16 +282,14 @@ public abstract class AbstractCloseable implements ReferenceOwner, ManagedClosea
     }
 
     /**
-     * Contains the actual logic for closing the resource. This method is intended to be
-     * overridden by subclasses to provide specific close logic.
-     * <p>
-     * Note: This method is called exactly once through {@code callPerformClose()}.
+     * Implement the clean-up logic. {@code close()} invokes this method exactly
+     * once via {@link #callPerformClose()}.
      */
     protected abstract void performClose();
 
     /**
-     * Calls {@link #performClose()} and ensures that it is executed exactly once.
-     * Any exceptions thrown by {@link #performClose()} are caught and logged.
+     * Invoked by {@link #close()}. Ensures {@link #performClose()} runs once and
+     * swallows any exception by logging it.
      */
     void callPerformClose() {
         try {

--- a/src/main/java/net/openhft/chronicle/core/io/Closeable.java
+++ b/src/main/java/net/openhft/chronicle/core/io/Closeable.java
@@ -20,33 +20,27 @@ import net.openhft.chronicle.core.internal.CloseableUtils;
 import org.jetbrains.annotations.Nullable;
 
 /**
- * A {@code Closeable} is a source or destination of data that can be closed. The close method
- * is invoked to release resources that the object is holding (such as open files).
- * This interface is an extension of {@link java.io.Closeable} and {@link QueryCloseable},
- * adding functionality for handling more resource types and closing them quietly without
- * throwing exceptions.
+ * Extension of {@link java.io.Closeable} that participates in the Chronicle
+ * resource lifecycle.
  * <p>
- * It is encouraged to use this interface in a try-with-resources statement.
- * 
+ * Typical usage is via <em>try-with-resources</em> where {@link #close()} is
+ * invoked automatically. Implementations normally extend
+ * {@link AbstractCloseable} to delegate their cleanup to
+ * {@link AbstractCloseable#performClose()}.
  * <p>
- * Implementations of this interface should also consider extending {@link AbstractCloseable}
- * which provides common functionalities for closeable resources.
- * 
+ * Thread safety is implementation specific; callers should assume instances are
+ * not thread-safe unless stated otherwise.
  */
 public interface Closeable extends java.io.Closeable, QueryCloseable {
 
     /**
-     * Closes multiple closeable objects quietly, without throwing exceptions.
-     * If a closeable object is a collection or an array, all the elements within it are closed.
-     * If a closeable object is a ServerSocketChannel, it is closed quietly.
-     * <p>
-     * Example:
+     * Close the supplied resources without propagating any exception.
+     * Elements of arrays or collections are closed recursively.
      * <pre>
-     * Closeable.closeQuietly(fileInputStream, socketChannel, listOfStreams);
+     * Closeable.closeQuietly(in, socket);
      * </pre>
-     * 
      *
-     * @param closeables the array of objects to be closed
+     * @param closeables resources to close
      * @see AbstractCloseable#performClose()
      */
     static void closeQuietly(@Nullable Object... closeables) {
@@ -54,17 +48,11 @@ public interface Closeable extends java.io.Closeable, QueryCloseable {
     }
 
     /**
-     * Closes a single closeable object quietly, without throwing exceptions.
-     * If the closeable object is a collection or an array, all the elements within it are closed.
-     * If the closeable object is a ServerSocketChannel, it is closed quietly.
-     * <p>
-     * Example:
-     * <pre>
-     * Closeable.closeQuietly(fileInputStream);
-     * </pre>
-     * 
+     * Variant for a single resource.
+     * Arrays, collections and {@link java.nio.channels.ServerSocketChannel}
+     * are handled transparently.
      *
-     * @param o the object to be closed
+     * @param o resource to close
      * @see AbstractCloseable#performClose()
      */
     static void closeQuietly(@Nullable Object o) {
@@ -72,15 +60,10 @@ public interface Closeable extends java.io.Closeable, QueryCloseable {
     }
 
     /**
-     * Closes this resource, releasing any system resources associated with it.
-     * If the resource is already closed, then invoking this method has no effect.
-     * This method should be idempotent.
-     * <p>
-     * Subclasses should override {@link AbstractCloseable#performClose()} to provide
-     * the actual close logic.
-     * 
+     * Release any underlying resources. The call is idempotent and may be made
+     * from a try-with-resources block.
      *
-     * @throws IllegalStateException if the resource cannot be closed.
+     * @throws IllegalStateException if the resource refuses to close
      * @see AbstractCloseable#performClose()
      */
     @Override

--- a/src/main/java/net/openhft/chronicle/core/io/ManagedCloseable.java
+++ b/src/main/java/net/openhft/chronicle/core/io/ManagedCloseable.java
@@ -24,11 +24,12 @@ import net.openhft.chronicle.core.onoes.Slf4jExceptionHandler;
 import static net.openhft.chronicle.core.io.AbstractCloseable.DISABLE_DISCARD_WARNING;
 
 /**
- * The {@code ManagedCloseable} interface extends the {@link Closeable} interface and provides additional methods
- * that are primarily intended for expert use cases involving resource lifecycle management.
+ * Adds expert lifecycle hooks to {@link Closeable}.
+ * Implementations may inspect their creation site and warn when discarded
+ * without being closed. Users typically interact with such resources via
+ * {@code try}-with-resources.
  * <p>
- * This interface is designed for scenarios where more fine-grained control over the closing process of a resource
- * is needed, or where it is necessary to perform advanced operations based on the state of the resource.
+ * Thread safety is left to the concrete implementation.
  */
 public interface ManagedCloseable extends Closeable {
 

--- a/src/main/java/net/openhft/chronicle/core/io/QueryCloseable.java
+++ b/src/main/java/net/openhft/chronicle/core/io/QueryCloseable.java
@@ -15,26 +15,25 @@
  */
 package net.openhft.chronicle.core.io;
 /**
- * An interface for querying the closeable state of an object.
- * Provides methods to check if the object is closed or in the process of closing.
+ * Minimal contract to query the closing state of a resource.
+ * It is used by {@link Closeable} and {@link ManagedCloseable}.
  */
 public interface QueryCloseable {
 
     /**
-     * Checks if this object is in the process of closing.
-     * <p>
-     * This method should always return true if {@link #isClosed()} returns true.
+     * Indicates whether the resource is in the process of closing.
+     * This method should return {@code true} once {@link #isClosed()} does.
      *
-     * @return true if the {@code close()} method has been called (but not necessarily completed)
+     * @return {@code true} if {@code close()} has been invoked
      */
     default boolean isClosing() {
         return isClosed();
     }
 
     /**
-     * Checks if this object is closed.
+     * Reports whether the resource has finished closing.
      *
-     * @return true if the {@code close()} method has completed, false otherwise
+     * @return {@code true} once the resource is closed
      */
     boolean isClosed();
 }

--- a/src/main/java/net/openhft/chronicle/core/io/SimpleCloseable.java
+++ b/src/main/java/net/openhft/chronicle/core/io/SimpleCloseable.java
@@ -16,8 +16,8 @@
 package net.openhft.chronicle.core.io;
 
 /**
- * An abstract class providing a basic implementation of the {@link Closeable}, {@link ReferenceOwner}, and {@link ManagedCloseable} interfaces.
- * It maintains a flag to track the closed state of the resource and provides methods for closing the resource.
+ * Lightweight helper implementing {@link Closeable} and {@link ManagedCloseable}.
+ * A boolean tracks the closed state. Override {@link #performClose()} for custom clean-up.
  */
 public abstract class SimpleCloseable implements Closeable, ReferenceOwner, ManagedCloseable {
     private transient volatile boolean closed;
@@ -30,8 +30,7 @@ public abstract class SimpleCloseable implements Closeable, ReferenceOwner, Mana
     }
 
     /**
-     * Closes the resource so that it cannot be used again.
-     * Once closed, subsequent calls to this method will have no effect.
+     * Idempotent close for use with try-with-resources.
      */
     @Override
     public final void close() {
@@ -42,11 +41,7 @@ public abstract class SimpleCloseable implements Closeable, ReferenceOwner, Mana
     }
 
     /**
-     * Performs the actual close operation.
-     * Subclasses can override this method to provide custom close logic.
-     * The default implementation does nothing.
-     * <p>
-     * Call close() to ensure this is called exactly once.
+     * Hook for subclasses to release resources. Called once from {@link #close()}.
      */
     protected void performClose() {
         // might be nothing.

--- a/src/main/java/net/openhft/chronicle/core/io/UnsafeCloseable.java
+++ b/src/main/java/net/openhft/chronicle/core/io/UnsafeCloseable.java
@@ -20,8 +20,9 @@ import net.openhft.chronicle.core.UnsafeMemory;
 import sun.misc.Unsafe;
 
 /**
- * An abstract base class for resources that use the {@link Unsafe} class for low-level memory operations.
- * Provides methods for manipulating long values stored at a specific memory address.
+ * Convenience base for memory backed resources using {@link Unsafe}.
+ * Not thread-safe. The memory address is set via {@link #address(long)} and the
+ * clean-up is performed in {@link #performClose()}.
  */
 public abstract class UnsafeCloseable extends AbstractCloseable {
 
@@ -29,8 +30,8 @@ public abstract class UnsafeCloseable extends AbstractCloseable {
     protected Unsafe unsafe = null;
 
     /**
-     * Constructs a new UnsafeCloseable instance.
-     * Disables the single-threaded check for thread safety.
+     * Disable the single-threaded check because these resources are typically
+     * accessed from multiple threads.
      */
     @SuppressWarnings("this-escape")
     protected UnsafeCloseable() {
@@ -38,9 +39,7 @@ public abstract class UnsafeCloseable extends AbstractCloseable {
     }
 
     /**
-     * Sets the memory address for this resource.
-     *
-     * @param address The memory address.
+     * Assign the backing memory address.
      */
     protected void address(long address) {
         this.address = address;


### PR DESCRIPTION
## Summary
- tidy up Javadoc for the closeable classes
- note typical usage via try-with-resources
- document thread-safety expectations
- add examples for `closeQuietly` and cross-link to `performClose`

## Testing
- `mvn -q verify` *(fails: command not found)*