### PR TITLE
Document reference counting lifecycle

### DIFF
--- a/src/main/java/net/openhft/chronicle/core/io/AbstractCloseableReferenceCounted.java
+++ b/src/main/java/net/openhft/chronicle/core/io/AbstractCloseableReferenceCounted.java
@@ -22,21 +22,13 @@ import net.openhft.chronicle.core.internal.CloseableUtils;
 import net.openhft.chronicle.core.internal.ReferenceCountedUtils;
 
 /**
- * Represents a closeable resource with reference counting capabilities.
+ * Represents a closeable resource with reference counting.
  * <p>
- * This abstract class extends {@link AbstractReferenceCounted} and implements {@link ManagedCloseable},
- * and is designed to manage a resource that requires reference counting to ensure proper cleanup
- * once it is no longer in use.
- *
- * <p>
- * Reference counting allows multiple users to share a single resource and ensures that the resource
- * is only closed when all references are released. Each user of the resource increments the reference
- * count upon acquiring the resource and decrements it upon releasing.
- *
- * <p>
- * This class integrates reference counting with the ability to close the resource. When the reference
- * count reaches zero, or if an explicit call to close is made, the resource transitions to the closed state
- * and cannot be used any further.
+ * The resource starts reserved by {@link ReferenceOwner#INIT}. Once all calls
+ * to {@link #release(ReferenceOwner)} (or {@link #releaseLast(ReferenceOwner)})
+ * have balanced earlier {@link #reserve(ReferenceOwner)} calls the resource is
+ * closed. If {@link #canReleaseInBackground()} is {@code true} the cleanup is
+ * delegated to {@link BackgroundResourceReleaser}.
  */
 public abstract class AbstractCloseableReferenceCounted
         extends AbstractReferenceCounted

--- a/src/main/java/net/openhft/chronicle/core/io/AbstractReferenceCounted.java
+++ b/src/main/java/net/openhft/chronicle/core/io/AbstractReferenceCounted.java
@@ -26,11 +26,17 @@ import java.util.Set;
 import static net.openhft.chronicle.core.io.BackgroundResourceReleaser.BG_RELEASER;
 
 /**
- * Abstract base class for managing reference-counted resources.
+ * Abstract base class for managing reference counted resources.
  * <p>
- * This class provides the common functionality required for implementing
- * reference counting mechanisms in resources, such as managing the number of
- * references and releasing resources when they are no longer needed.
+ * Subclasses hold the actual resource and implement {@link #performRelease()}
+ * which is invoked when the reference count reaches zero. Release may occur on
+ * the thread calling {@link #release(ReferenceOwner)} or on a background thread
+ * via {@link BackgroundResourceReleaser} if {@link #canReleaseInBackground()}
+ * returns {@code true}.
+ * <p>
+ * Any attempt to reserve or release after the resource has been freed results
+ * in {@link ClosedIllegalStateException}. Using a subclass from more than one
+ * thread without synchronisation can cause {@link ThreadingIllegalStateException}.
  */
 public abstract class AbstractReferenceCounted implements ReferenceCountedTracer, ReferenceOwner, SingleThreadedChecked, Monitorable {
     // Constants

--- a/src/main/java/net/openhft/chronicle/core/io/MonitorReferenceCounted.java
+++ b/src/main/java/net/openhft/chronicle/core/io/MonitorReferenceCounted.java
@@ -16,7 +16,10 @@
 
 package net.openhft.chronicle.core.io;
 /**
- * This interface extends {@link ReferenceCountedTracer} and provides methods for monitoring the reference counted object.
+ * Extends {@link ReferenceCountedTracer} with the ability to suppress discard
+ * warnings. When a resource is marked as unmonitored the
+ * {@link ReferenceCountedTracer#warnAndReleaseIfNotReleased()} path will not log
+ * a warning if the user forgets to release a reservation.
  */
 public interface MonitorReferenceCounted extends ReferenceCountedTracer {
 

--- a/src/main/java/net/openhft/chronicle/core/io/ReferenceCounted.java
+++ b/src/main/java/net/openhft/chronicle/core/io/ReferenceCounted.java
@@ -17,9 +17,37 @@
 package net.openhft.chronicle.core.io;
 
 /**
- * Represents a resource that is reference counted. The resource is freed when the reference count drops to 0.
- * This can be used for efficiently managing resources, such as memory buffers or file handles,
- * by ensuring that they are not released until they are no longer in use.
+ * Represents a resource that is reference counted. The resource is freed when
+ * the reference count drops to zero.
+ * <p>
+ * <h2>Lifecycle</h2>
+ * <ul>
+ *     <li>{@link #reserve(ReferenceOwner)} increments the reference count.</li>
+ *     <li>{@link #tryReserve(ReferenceOwner)} conditionally increments without
+ *     throwing if the resource has already been released.</li>
+ *     <li>{@link #release(ReferenceOwner)} decrements the reference count and
+ *     frees the resource when it reaches zero.</li>
+ *     <li>{@link #releaseLast(ReferenceOwner)} asserts that the caller holds the
+ *     final reference.</li>
+ * </ul>
+ * Calling any of these methods on a resource that is already released or closed
+ * results in {@link ClosedIllegalStateException}. If a resource is used from an
+ * unexpected thread, implementations may throw
+ * {@link ThreadingIllegalStateException}.
+ * <p>
+ * Cleanup may occur on a background thread managed by
+ * {@link BackgroundResourceReleaser}.
+ * <p>
+ * <h3>Example</h3>
+ * <pre>{@code
+ * ReferenceOwner owner = ReferenceOwner.INIT;
+ * resource.reserve(owner);
+ * try {
+ *     // use resource
+ * } finally {
+ *     resource.release(owner);
+ * }
+ * }</pre>
  */
 public interface ReferenceCounted extends ReferenceOwner {
 

--- a/src/main/java/net/openhft/chronicle/core/io/ReferenceCountedTracer.java
+++ b/src/main/java/net/openhft/chronicle/core/io/ReferenceCountedTracer.java
@@ -23,9 +23,11 @@ import org.jetbrains.annotations.NotNull;
 import java.util.function.Supplier;
 
 /**
- * An interface for monitoring and tracing the reference counting of objects. It extends the {@link ReferenceCounted}
- * interface by providing additional methods for tracing and throwing exceptions in certain conditions.
- * This can be helpful in debugging and identifying issues related to resource management and reference counting.
+ * Extends {@link ReferenceCounted} with tracing utilities.
+ * Implementations record which {@link ReferenceOwner} reserved or released a
+ * resource and can report where an unexpected release occurred. Tracing is
+ * useful when diagnosing {@link ClosedIllegalStateException} or
+ * {@link ThreadingIllegalStateException} thrown by misused resources.
  */
 public interface ReferenceCountedTracer extends ReferenceCounted {
 

--- a/src/main/java/net/openhft/chronicle/core/io/ReferenceOwner.java
+++ b/src/main/java/net/openhft/chronicle/core/io/ReferenceOwner.java
@@ -19,16 +19,15 @@ package net.openhft.chronicle.core.io;
 import net.openhft.chronicle.core.Jvm;
 
 /**
- * Represents an entity that owns a reference, typically for resource management. This interface
- * provides default methods for generating unique reference IDs and human-readable names for reference owners.
+ * Represents an entity that owns a reference, typically for resource management.
+ * Implementations supply a stable identity used when reserving or releasing a
+ * {@link ReferenceCounted} resource.
  * <p>
- * This can be useful, for example, in scenarios where it's necessary to track the owners of resources
- * such as file handles, network sockets, or any other entities that need to be managed throughout their lifecycle.
- * 
- * <p>
- * Implementations of this interface can be used to associate owners with references,
- * making it easier to monitor, debug, and manage resource ownership and ensure that resources are released properly.
- * 
+ * A {@code ReferenceOwner} is often passed to
+ * {@link ReferenceCounted#reserve(ReferenceOwner)} and later to
+ * {@link ReferenceCounted#release(ReferenceOwner)}. It enables tools such as
+ * {@link BackgroundResourceReleaser} to identify which owner failed to release
+ * its reservation.
  */
 public interface ReferenceOwner {
 

--- a/src/main/java/net/openhft/chronicle/core/io/TracingReferenceCounted.java
+++ b/src/main/java/net/openhft/chronicle/core/io/TracingReferenceCounted.java
@@ -29,6 +29,10 @@ import java.util.stream.Collectors;
 
 import static net.openhft.chronicle.core.internal.CloseableUtils.asString;
 
+/**
+ * Records each reservation and release with a {@link StackTrace} so incorrect
+ * usage can be diagnosed. Used when resource tracing is switched on.
+ */
 public final class TracingReferenceCounted implements MonitorReferenceCounted {
     private final Map<ReferenceOwner, StackTrace> references = Collections.synchronizedMap(new IdentityHashMap<>());
     private final Map<ReferenceOwner, StackTrace> releases = Collections.synchronizedMap(new IdentityHashMap<>());

--- a/src/main/java/net/openhft/chronicle/core/io/VanillaReferenceCounted.java
+++ b/src/main/java/net/openhft/chronicle/core/io/VanillaReferenceCounted.java
@@ -22,9 +22,9 @@ import net.openhft.chronicle.core.UnsafeMemory;
 import net.openhft.chronicle.core.annotation.UsedViaReflection;
 
 /**
- * This class provides a basic implementation of the {@link MonitorReferenceCounted} interface.
- * It is responsible for keeping track of reference counts and releasing resources
- * once they are no longer needed.
+ * Lightweight implementation of {@link MonitorReferenceCounted} used when
+ * resource tracing is disabled. It simply counts references and runs the given
+ * {@link Runnable} when the count reaches zero.
  */
 public final class VanillaReferenceCounted implements MonitorReferenceCounted {
 

--- a/src/main/java/net/openhft/chronicle/core/io/VanillaReferenceOwner.java
+++ b/src/main/java/net/openhft/chronicle/core/io/VanillaReferenceOwner.java
@@ -17,9 +17,9 @@
 package net.openhft.chronicle.core.io;
 
 /**
- * A simple implementation of the {@link ReferenceOwner} and {@link QueryCloseable} interfaces.
- * This class represents an object that can own references, but is not closeable.
- * It holds a name for identification purposes.
+ * Simple {@link ReferenceOwner} that carries a name. It is not closeable and is
+ * typically used in examples or tests to demonstrate {@link ReferenceCounted}
+ * usage.
  */
 public class VanillaReferenceOwner implements ReferenceOwner, QueryCloseable {
 


### PR DESCRIPTION
## Summary
- detail the lifecycle of reference counted resources
- mention when ClosedIllegalStateException and ThreadingIllegalStateException occur
- refer to BackgroundResourceReleaser for asynchronous cleanup
- tighten Javadoc on reference owner implementations

## Testing
- `mvn -q verify` *(fails: mvn not found)*