### PR TITLE
Improve reference change listener docs

### DIFF
--- a/src/main/java/net/openhft/chronicle/core/io/ReferenceChangeListener.java
+++ b/src/main/java/net/openhft/chronicle/core/io/ReferenceChangeListener.java
@@ -18,44 +18,55 @@ package net.openhft.chronicle.core.io;
 import org.jetbrains.annotations.Nullable;
 
 /**
- * An interface to be notified when references to a {@link ReferenceCounted} are added, removed, or transferred.
- * Implement this interface to receive notifications about changes in the reference counts of objects.
+ * Receives callbacks whenever the reference count of a {@link ReferenceCounted}
+ * changes. Typical uses include tracking resource ownership and diagnosing
+ * reference leaks during development.
+ * <p>
+ * Callbacks are invoked by {@link ReferenceCounted} implementations via
+ * {@link ReferenceChangeListenerManager} in the order that listeners were
+ * registered. Implementations must avoid long or blocking work as callbacks can
+ * be triggered while the owning object is holding internal locks, risking
+ * deadlock.
  */
 public interface ReferenceChangeListener {
 
     /**
-     * Called when a reference is added to a {@link ReferenceCounted} object.
+     * Invoked immediately after a reservation is made on the supplied
+     * {@link ReferenceCounted} instance.
      * <p>
-     * WARNING: This may be called from a synchronized block in DualReferenceCounted, so be careful
-     * what you do here that might introduce a deadlock!
+     * The call may occur while the owner object is synchronized. Keep the
+     * implementation short and non-blocking to avoid deadlock.
      *
-     * @param referenceCounted The ReferenceCounted to which the reference was added
-     * @param referenceOwner   The owner of the reference added
+     * @param referenceCounted the resource whose reference count increased
+     * @param referenceOwner   the owner of the new reference
      */
     default void onReferenceAdded(ReferenceCounted referenceCounted, ReferenceOwner referenceOwner) {
     }
 
     /**
-     * Called when a reference is removed from a {@link ReferenceCounted} object.
+     * Invoked after a reservation is released from the supplied
+     * {@link ReferenceCounted} instance.
      * <p>
-     * WARNING: This may be called from a synchronized block in DualReferenceCounted, so be careful
-     * what you do here that might introduce a deadlock!
+     * As above, the call can happen whilst the owner is holding locks, so avoid
+     * blocking operations.
      *
-     * @param referenceCounted The ReferenceCounted to which the reference was removed
-     * @param referenceOwner   The owner whose reference was removed, or null if that is not known
+     * @param referenceCounted the resource whose reference count decreased
+     * @param referenceOwner   the owner whose reference was removed or {@code null}
+     *                         if unknown
      */
     default void onReferenceRemoved(@Nullable ReferenceCounted referenceCounted, ReferenceOwner referenceOwner) {
     }
 
     /**
-     * Called when a reference is transferred from one owner to another for a {@link ReferenceCounted} object.
+     * Invoked after a reservation is moved from one owner to another on the
+     * supplied {@link ReferenceCounted} instance.
      * <p>
-     * WARNING: This may be called from a synchronized block in DualReferenceCounted, so be careful
-     * what you do here that might introduce a deadlock!
+     * Implementations should again avoid lengthy work as the call may be made
+     * within the {@code ReferenceCounted}'s critical section.
      *
-     * @param referenceCounted The ReferenceCounted object on which the reference was transferred.
-     * @param fromOwner        The previous owner from whom the reference was transferred.
-     * @param toOwner          The new owner to whom the reference was transferred.
+     * @param referenceCounted the resource whose reference was transferred
+     * @param fromOwner        the previous owner of the reference
+     * @param toOwner          the new owner of the reference
      */
     default void onReferenceTransferred(ReferenceCounted referenceCounted, ReferenceOwner fromOwner, ReferenceOwner toOwner) {
     }

--- a/src/main/java/net/openhft/chronicle/core/io/ReferenceChangeListenerManager.java
+++ b/src/main/java/net/openhft/chronicle/core/io/ReferenceChangeListenerManager.java
@@ -21,8 +21,13 @@ import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
- * Manages the reference change listeners for a {@link ReferenceCounted} object.
- * It allows adding, removing, and notifying the listeners about reference changes.
+ * Utility that invokes {@link ReferenceChangeListener} callbacks for a
+ * particular {@link ReferenceCounted} instance. Listeners are stored in a
+ * {@link CopyOnWriteArrayList}, so callbacks execute sequentially in the order
+ * they were added. This avoids holding locks during notification and ensures
+ * predictable ordering even when listeners are added or removed concurrently.
+ * Typical usage is for a {@link ReferenceCounted} implementation to delegate to
+ * this manager after each change to its reference count.
  */
 class ReferenceChangeListenerManager {
 
@@ -40,27 +45,31 @@ class ReferenceChangeListenerManager {
     }
 
     /**
-     * Adds a ReferenceChangeListener to this manager.
+     * Registers a {@link ReferenceChangeListener}. Listeners are kept in the
+     * order added so that notifications occur predictably.
      *
-     * @param referenceChangeListener The ReferenceChangeListener to add.
+     * @param referenceChangeListener the listener to add
      */
     void add(ReferenceChangeListener referenceChangeListener) {
         referenceChangeListeners.add(referenceChangeListener);
     }
 
     /**
-     * Removes a ReferenceChangeListener from this manager.
+     * Deregisters a {@link ReferenceChangeListener} previously added with
+     * {@link #add(ReferenceChangeListener)}.
      *
-     * @param referenceChangeListener The ReferenceChangeListener to remove.
+     * @param referenceChangeListener the listener to remove
      */
     void remove(ReferenceChangeListener referenceChangeListener) {
         referenceChangeListeners.remove(referenceChangeListener);
     }
 
     /**
-     * Notifies the reference change listeners about a reference being added.
+     * Invokes {@link ReferenceChangeListener#onReferenceAdded(ReferenceCounted,
+     * ReferenceOwner)} on each registered listener. This should be called once
+     * the underlying reference count has been incremented.
      *
-     * @param referenceOwner The owner of the added reference.
+     * @param referenceOwner the owner of the added reference
      */
     void notifyAdded(ReferenceOwner referenceOwner) {
         this.callReferenceChangeListeners(
@@ -69,9 +78,11 @@ class ReferenceChangeListenerManager {
     }
 
     /**
-     * Notifies the reference change listeners about a reference being removed.
+     * Invokes {@link ReferenceChangeListener#onReferenceRemoved(ReferenceCounted,
+     * ReferenceOwner)} on each registered listener. Call after the reference
+     * count has been decremented.
      *
-     * @param referenceOwner The owner of the removed reference, or null if not known.
+     * @param referenceOwner the owner of the removed reference, or {@code null} if unknown
      */
     void notifyRemoved(@Nullable ReferenceOwner referenceOwner) {
         this.callReferenceChangeListeners(
@@ -80,10 +91,11 @@ class ReferenceChangeListenerManager {
     }
 
     /**
-     * Notifies the reference change listeners about a reference being transferred.
+     * Invokes {@link ReferenceChangeListener#onReferenceTransferred(ReferenceCounted,
+     * ReferenceOwner, ReferenceOwner)} on each registered listener.
      *
-     * @param from The owner from whom the reference was transferred.
-     * @param to   The owner to whom the reference was transferred.
+     * @param from the owner from whom the reference was transferred
+     * @param to   the owner to whom the reference was transferred
      */
     void notifyTransferred(ReferenceOwner from, ReferenceOwner to) {
         this.callReferenceChangeListeners(ReferenceChangeListener::onReferenceTransferred, from, to);


### PR DESCRIPTION
## Summary
- document usage of `ReferenceChangeListener`
- warn about deadlocks and ordering in `ReferenceChangeListenerManager`

## Testing
- `mvn -q verify` *(fails: mvn not found)*