### PR TITLE
Clarify BackgroundResourceReleaser usage

### DIFF
--- a/src/main/java/net/openhft/chronicle/core/io/BackgroundResourceReleaser.java
+++ b/src/main/java/net/openhft/chronicle/core/io/BackgroundResourceReleaser.java
@@ -25,12 +25,23 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
- * Utility class for managing reference counted resources and related operations.
+ * Performs close and release operations on a background thread.
  * <p>
- * This class helps in releasing the resources in the background when they are no longer needed.
- * It internally uses a background thread to perform the releasing operations. The background
- * thread can be disabled if needed by using system properties.
- * 
+ * Closing in the background reduces worst case pause times because the caller
+ * does not have to perform the tidy up work. The behaviour is controlled by two
+ * system properties:
+ * <ul>
+ *   <li>{@code background.releaser} &mdash; set to {@code false} to disable
+ *   queuing and release resources on the caller's thread.</li>
+ *   <li>{@code background.releaser.thread} &mdash; set to {@code false} to queue
+ *   work but require manual calls to {@link #releasePendingResources()}.</li>
+ * </ul>
+ * <p>
+ * Example usage:
+ * <pre>{@code
+ * MyCloseable closeable = new MyCloseable();
+ * BackgroundResourceReleaser.release(closeable);
+ * }</pre>
  */
 public final class BackgroundResourceReleaser {
 


### PR DESCRIPTION
## Summary
- javadoc update for BackgroundResourceReleaser

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*