### PR TITLE
Improve documentation for validation and sync helpers

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -475,6 +475,14 @@ To make sure the shutdown hook does not prevent classes from unloading, deregist
 | X | `false` | Resources are not queued and are released synchronously.
 |===
 
+=== Syncing Data
+
+Some resources implement `net.openhft.chronicle.core.io.Syncable`. After
+writing to a memory-mapped file or similar structure you can call
+`Syncable.sync()` to flush changes to the backing store. When operating on an
+object that may or may not implement this interface use
+`Syncable.syncIfAvailable(obj)`.
+
 == Thread Safety Checks
 
 Classes that are designed for single-threaded use can implement `net.openhft.chronicle.core.io.SingleThreadedChecked`.
@@ -530,6 +538,13 @@ public void singleThreadedCheckReset() {
     this.bytes.singleThreadedCheckReset();
 }
 ```
+
+== Object Validation
+
+Some DTOs implement `net.openhft.chronicle.core.io.Validatable`. Call
+`ValidatableUtil.validate(obj)` before serialising or logging to ensure the
+object is consistent. Validation can be suppressed using
+`ValidatableUtil.startValidateDisabled()`.
 
 == Object Pooling
 

--- a/src/main/java/net/openhft/chronicle/core/io/ClosedState.java
+++ b/src/main/java/net/openhft/chronicle/core/io/ClosedState.java
@@ -17,8 +17,8 @@
 
 package net.openhft.chronicle.core.io;
 /**
- * Functional interface representing a closed state.
- * This interface provides a method to check if an object is in a closed state.
+ * Functional interface used to query whether a resource has been closed.  It is
+ * typically implemented with a lambda or method reference.
  */
 @FunctionalInterface
 public interface ClosedState {

--- a/src/main/java/net/openhft/chronicle/core/io/Monitorable.java
+++ b/src/main/java/net/openhft/chronicle/core/io/Monitorable.java
@@ -17,10 +17,9 @@
 package net.openhft.chronicle.core.io;
 
 /**
- * Interface for objects that can be monitored and unmonitored.
- * <p>
- * This is useful for managing resources that need to be tracked and potentially cleaned up
- * when they are no longer needed.
+ * Implement for resources that may be tracked by tooling such as
+ * {@code CloseableUtils}. Calling {@link #unmonitor()} stops that tracking and
+ * is typically used just before a resource is discarded.
  */
 public interface Monitorable {
 

--- a/src/main/java/net/openhft/chronicle/core/io/Resettable.java
+++ b/src/main/java/net/openhft/chronicle/core/io/Resettable.java
@@ -16,14 +16,13 @@
 package net.openhft.chronicle.core.io;
 
 /**
- * An interface representing a DTO (Data Transfer Object) or component that can be reset to its initial state.
- * Implementations of this interface provide a {@code reset()} method to reset the state of the object.
+ * An interface for components that support reuse by resetting their state.
+ * Typical implementations are simple DTOs used in object pools.
  */
 public interface Resettable {
     /**
-     * Resets the state of the object to its initial state.
-     * Implementations should restore the object's internal fields or properties
-     * to their default values or the values set during initialization.
+     * Restore the object to its initial state. Called before returning an object
+     * to a pool or when reusing the instance for another operation.
      */
     void reset();
 }

--- a/src/main/java/net/openhft/chronicle/core/io/SingleThreadedChecked.java
+++ b/src/main/java/net/openhft/chronicle/core/io/SingleThreadedChecked.java
@@ -19,8 +19,8 @@ package net.openhft.chronicle.core.io;
 import net.openhft.chronicle.core.Jvm;
 
 /**
- * An interface indicating that the implementing resource supports single-threaded access checking.
- * It provides methods to reset the check and disable the single-threaded check.
+ * Implement for components that are intended for single-threaded use.  The
+ * checks help diagnose accidental sharing between threads.
  */
 public interface SingleThreadedChecked {
 
@@ -34,8 +34,9 @@ public interface SingleThreadedChecked {
             Jvm.getBoolean("disable.single.threaded.check", false);
 
     /**
-     * Resets the single-threaded check, forgetting about previous accesses.
-     * Subsequent accesses will be checked from the point of this reset.
+     * Forget the thread that last used this component. Call when ownership is
+     * transferred, for example after constructing an object on one thread and
+     * handing it to another.
      */
     void singleThreadedCheckReset();
 

--- a/src/main/java/net/openhft/chronicle/core/io/Syncable.java
+++ b/src/main/java/net/openhft/chronicle/core/io/Syncable.java
@@ -17,16 +17,18 @@
 package net.openhft.chronicle.core.io;
 
 /**
- * An interface for objects that can be synced to underlying media if supported.
- * Implementations can perform a sync operation to ensure data is flushed to the underlying media.
+ * Implement for resources that are able to flush data to the underlying
+ * medium.  Memory-mapped files and some {@code Bytes} implementations provide
+ * this facility.
  */
 public interface Syncable {
 
     /**
-     * Performs a sync operation if the given object implements the {@code Syncable} interface.
-     * This method provides a convenient way to invoke the sync operation on an object without explicitly checking its type.
+     * Performs a sync operation if the supplied object implements
+     * {@code Syncable}.  Use when the concrete type may or may not support
+     * syncing.
      *
-     * @param o The object to sync, if it implements the {@code Syncable} interface.
+     * @param o object to sync if possible
      */
     static void syncIfAvailable(Object o) {
         if (o instanceof Syncable)
@@ -34,10 +36,8 @@ public interface Syncable {
     }
 
     /**
-     * Performs a sync operation up to the point that this handle has read or written.
-     * The behavior of this method depends on whether syncing is supported and the underlying implementation.
-     * There might be data beyond this point that isn't synced.
-     * It may not perform any action if syncing is not supported or has been turned off through configuration.
+     * Flush data to the backing store up to the point that this handle has read
+     * or written. Some implementations may ignore this call.
      */
     void sync();
 }

--- a/src/main/java/net/openhft/chronicle/core/io/Validatable.java
+++ b/src/main/java/net/openhft/chronicle/core/io/Validatable.java
@@ -17,13 +17,13 @@
 package net.openhft.chronicle.core.io;
 
 /**
- * The {@code Validatable} interface should be implemented by classes that require
- * validation of their state before being written through a method writer.
+ * Implement to provide a validation hook for the object.
  * <p>
- * Implementing this interface indicates that the object is capable of self-validation,
- * which is essential in contexts like serialization or communication where the integrity
- * and correctness of an object's state are crucial.
- * 
+ * Chronicle libraries call {@link ValidatableUtil#validate(Object)} before
+ * serialising method-writer arguments and it is common to invoke it from
+ * {@code toString()} whilst debugging. Validation can be temporarily disabled
+ * by wrapping the call in {@link ValidatableUtil#startValidateDisabled()} and
+ * {@link ValidatableUtil#endValidateDisabled()}.
  * <p>
  * Example usage:
  * <pre>
@@ -35,16 +35,13 @@ package net.openhft.chronicle.core.io;
  *
  *     {@literal @}Override
  *     public void validate() throws InvalidMarshallableException {
- *         if (name == null || name.isEmpty()) {
+ *         if (name == null || name.isEmpty())
  *             throw new InvalidMarshallableException("Name cannot be null or empty");
- *         }
- *         if (age == null || age &lt; 0) {
+ *         if (age == null || age &lt; 0)
  *             throw new InvalidMarshallableException("Age cannot be null or negative");
- *         }
  *     }
  * }
  * </pre>
- * 
  */
 public interface Validatable {
 

--- a/src/main/java/net/openhft/chronicle/core/io/ValidatableUtil.java
+++ b/src/main/java/net/openhft/chronicle/core/io/ValidatableUtil.java
@@ -17,7 +17,8 @@
 package net.openhft.chronicle.core.io;
 
 /**
- * Utility class for validating objects and managing validation settings.
+ * Utility methods to validate {@link Validatable} objects and control when the
+ * checks occur.
  */
 public class ValidatableUtil {
     static final ThreadLocal<int[]> VALIDATE_DISABLED = ThreadLocal.withInitial(() -> new int[1]);
@@ -32,15 +33,16 @@ public class ValidatableUtil {
     }
 
     /**
-     * Starts a nestable block where validation is disabled.
-     * This method can be used to temporarily disable validation for a specific code block.
+     * Starts a nestable block where validation is disabled. Use this around
+     * logging or diagnostic code that might operate on a partially initialised
+     * object.
      */
     public static void startValidateDisabled() {
         VALIDATE_DISABLED.get()[0]++;
     }
 
     /**
-     * End a nestable block where validation is disabled
+     * Ends the block started with {@link #startValidateDisabled()}.
      */
     public static void endValidateDisabled() {
         int[] val = VALIDATE_DISABLED.get();
@@ -49,9 +51,10 @@ public class ValidatableUtil {
     }
 
     /**
-     * Check an object is valid, if it is Validatable, do nothing
+     * Check an object is valid if it implements {@link Validatable}.
      * <p>
-     * For logging purposes validate() can be turned off e.g. for toString() with the following patten
+     * For logging purposes validation can be turned off e.g. for {@code toString()}
+     * with the following pattern
      * <pre>
      * ValidatableUtil.startValidatableDisabled();
      * try {
@@ -61,8 +64,8 @@ public class ValidatableUtil {
      * }
      * </pre>
      *
-     * @param t   to test
-     * @param <T> the original object
+     * @param t   object to validate
+     * @param <T> type of object
      * @return the same object
      * @throws InvalidMarshallableException if validate() method fails
      */


### PR DESCRIPTION
## Summary
- elaborate JavaDoc for various io helper interfaces
- explain temporary validation disable and data sync semantics
- document when validation runs and helper methods in README

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*