### PR TITLE
Clarify ExceptionKey thread-safety

### DIFF
--- a/src/main/java/net/openhft/chronicle/core/onoes/ExceptionKey.java
+++ b/src/main/java/net/openhft/chronicle/core/onoes/ExceptionKey.java
@@ -24,14 +24,14 @@ import java.io.StringWriter;
 import java.util.Objects;
 
 /**
- * Represents a unique key for an exception event. This key includes the log level,
- * the class where the exception occurred, a message associated with the exception,
- * and the Throwable instance. This key can be used to identify unique exceptions
- * for logging, monitoring, or other purposes.
- * <p>
- * The {@code ExceptionKey} class implements custom {@code equals} and {@code hashCode}
- * methods ensuring that two keys are equal if and only if all their fields are equal.
- * 
+ * Immutable key for an exception event.
+ * This class is thread-safe because all its fields are final.
+ * It encapsulates the log level, the originating class, a message and the
+ * associated {@link Throwable}.
+ *
+ * @implNote The {@link #toString()} method builds a stack trace string and may
+ * be expensive.
+ * @since 3.25ea
  */
 public class ExceptionKey {
 


### PR DESCRIPTION
## Summary
- document ExceptionKey thread-safety and toString cost
- add since tag for 3.25ea

## Testing
- `mvn -q verify` *(fails: mvn not found)*