### PR TITLE
Document thread safety for RecordingExceptionHandler

### DIFF
--- a/src/main/java/net/openhft/chronicle/core/onoes/RecordingExceptionHandler.java
+++ b/src/main/java/net/openhft/chronicle/core/onoes/RecordingExceptionHandler.java
@@ -23,14 +23,17 @@ import org.slf4j.Logger;
 
 import java.util.Map;
 /**
- * RecordingExceptionHandler is a concrete implementation of the ExceptionHandler interface.
- * It records each exception by incrementing a count in a provided map, using an ExceptionKey as the key.
+ * Records each exception by incrementing a count in a provided map keyed by
+ * {@link ExceptionKey}.
  * <p>
- * Each ExceptionKey is constructed using a LogLevel, the Class where the exception happened, a custom message,
- * and the Throwable object representing the exception. The LogLevel is provided at instantiation, while
- * the rest are provided when an exception occurs.
- * <p>
- * If the exceptionsOnly flag is set, the handler will ignore errors that are not associated with a Throwable.
+ * The supplied {@code exceptionKeyCountMap} <em>must</em> be thread-safe - for
+ * example a {@link java.util.concurrent.ConcurrentHashMap}. The handler itself
+ * is thread-safe.
+ *
+ * @apiNote The map may grow without bound if unique keys keep being added.
+ * Periodically evict infrequently used entries to control memory usage.
+ *
+ * @since 3.25ea
  */
 public class RecordingExceptionHandler implements ExceptionHandler {
     private final LogLevel level;
@@ -38,11 +41,13 @@ public class RecordingExceptionHandler implements ExceptionHandler {
     private final boolean exceptionsOnly;
 
     /**
-     * Constructs an instance of RecordingExceptionHandler with the specified LogLevel, map for exception counts, and exceptionsOnly flag.
+     * Creates a handler that records exceptions in the supplied map.
      *
-     * @param level                the LogLevel for the ExceptionKeys.
-     * @param exceptionKeyCountMap the map where the count of each ExceptionKey will be stored.
-     * @param exceptionsOnly       a flag indicating if the handler should ignore errors that are not associated with a Throwable.
+     * @param level                the {@link LogLevel} used in the {@link ExceptionKey}.
+     * @param exceptionKeyCountMap thread-safe map where counts are stored, for example a
+     *                             {@link java.util.concurrent.ConcurrentHashMap}.
+     * @param exceptionsOnly       when {@code true}, only errors with a {@link Throwable}
+     *                             are recorded.
      */
     public RecordingExceptionHandler(LogLevel level, Map<ExceptionKey, Integer> exceptionKeyCountMap, boolean exceptionsOnly) {
         this.level = level;


### PR DESCRIPTION
## Summary
- improve Javadoc for `RecordingExceptionHandler`
- explain that the map must be thread safe
- add memory usage note and mark class thread safe

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*