### PR TITLE
Document SLF4J fallback for exception handler

### DIFF
--- a/src/main/java/net/openhft/chronicle/core/onoes/Slf4jExceptionHandler.java
+++ b/src/main/java/net/openhft/chronicle/core/onoes/Slf4jExceptionHandler.java
@@ -24,16 +24,19 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Slf4jExceptionHandler is an enum implementation of the ExceptionHandler interface.
- * It uses SLF4J (Simple Logging Facade for Java) to handle exceptions based on the level of logging severity.
- * It supports four levels of logging severity: ERROR, WARN, PERF and DEBUG.
- * <p>
- * Each instance of Slf4jExceptionHandler logs at a specific level and corresponds to a LogLevel enum.
- * This is used to map LogLevel enums to their corresponding Slf4jExceptionHandler instances via the valueOf(LogLevel logLevel) method.
- * <p>
- * The DEBUG instance also overrides the {@code isEnabled(Class clazz)} method, using the isDebugEnabled() method from SLF4J's Logger class.
- * <p>
- * There's also a utility method isJUnitTest() which is used to detect if the current execution context is a JUnit test.
+ * Exception handler that logs using the SLF4J API.
+ *
+ * <p>Each enum constant represents a logging level and calls the matching
+ * method on the SLF4J {@link Logger}. When SLF4J fails to initialise, or
+ * the logger throws at runtime, the implementation writes to
+ * {@code System.err} instead. This dynamic fallback is demonstrated in
+ * {@link ExceptionHandlerFallbackTest}.
+ *
+ * <p>The {@link #DEBUG} constant overrides
+ * {@link #isEnabled(Class)} and only logs when the underlying logger has
+ * debug level enabled. Every constant is a singleton within the JVM.
+ *
+ * @since 3.25ea
  */
 public enum Slf4jExceptionHandler implements ExceptionHandler {
     ERROR(Logger::error),


### PR DESCRIPTION
## Summary
- expand Slf4jExceptionHandler Javadoc

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*