### PR TITLE
Update onoes package-info

### DIFF
--- a/src/main/java/net/openhft/chronicle/core/onoes/package-info.java
+++ b/src/main/java/net/openhft/chronicle/core/onoes/package-info.java
@@ -1,29 +1,33 @@
 /**
- * Provides classes and interfaces for exception handling, logging, and associated utilities.
- * <p>
- * This package contains classes and interfaces that enable handling exceptions
- * in a uniform manner throughout an application. This includes mechanisms for
- * chaining multiple exception handlers together, logging exceptions, handling
- * exceptions on a per-thread basis, and recording exceptions.
- * <p>
- * The core of this package is the {@link net.openhft.chronicle.core.onoes.ExceptionHandler}
- * interface which allows for custom logic to be defined for handling different
- * types of exceptions.
- * <p>
- * Other classes and enumerations within the package include:
- * 
- * <ul>
- *     <li>{@link net.openhft.chronicle.core.onoes.ChainedExceptionHandler} - Chains multiple ExceptionHandler objects for sequential invocation.</li>
- *     <li>{@link net.openhft.chronicle.core.onoes.ExceptionKey} - Represents a unique key for an exception event.</li>
- *     <li>{@link net.openhft.chronicle.core.onoes.LogLevel} - Defines various levels of logging severity.</li>
- *     <li>{@link net.openhft.chronicle.core.onoes.NullExceptionHandler} - Implements ExceptionHandler as a null object.</li>
- *     <li>{@link net.openhft.chronicle.core.onoes.RecordingExceptionHandler} - Records exceptions by incrementing counts in a map.</li>
- *     <li>{@link net.openhft.chronicle.core.onoes.Slf4jExceptionHandler} - Uses SLF4J for logging exceptions based on severity levels.</li>
- *     <li>{@link net.openhft.chronicle.core.onoes.ThreadLocalisedExceptionHandler} - Provides thread-localized exception handling.</li>
- * </ul>
- * <p>
- * This package is part of the Chronicle-Core library by OpenHFT.
+ * Exception-handling and logging utilities.
  *
+ * This package contains classes that enable handling exceptions in a uniform way
+ * throughout an application. This includes mechanisms for chaining handlers,
+ * logging, per-thread handling and recording exceptions.
+ *
+ * The core of this package is the {@link net.openhft.chronicle.core.onoes.ExceptionHandler}
+ * interface which allows custom logic for dealing with different exception types.
+ *
+ * Other classes and enumerations within the package include:
+ * <ul>
+ *     <li>{@link net.openhft.chronicle.core.onoes.ChainedExceptionHandler} - chains multiple ExceptionHandler objects for sequential invocation.</li>
+ *     <li>{@link net.openhft.chronicle.core.onoes.ExceptionKey} - represents a unique key for an exception event.</li>
+ *     <li>{@link net.openhft.chronicle.core.onoes.LogLevel} - defines levels of logging severity.</li>
+ *     <li>{@link net.openhft.chronicle.core.onoes.NullExceptionHandler} - implements ExceptionHandler as a null object.</li>
+ *     <li>{@link net.openhft.chronicle.core.onoes.RecordingExceptionHandler} - records exceptions by incrementing counts in a map.</li>
+ *     <li>{@link net.openhft.chronicle.core.onoes.Slf4jExceptionHandler} - uses SLF4J for logging based on severity levels.</li>
+ *     <li>{@link net.openhft.chronicle.core.onoes.ThreadLocalisedExceptionHandler} - provides thread-localised exception handling.</li>
+ * </ul>
+ *
+ * Example usage for switching to {@link net.openhft.chronicle.core.onoes.RecordingExceptionHandler}:
+ * <pre>{@code
+ * Map<ExceptionKey, Integer> counts = Jvm.recordExceptions();
+ * // run code that generates exceptions
+ * Jvm.resetExceptionHandlers();
+ * }</pre>
+ *
+ * @author OpenHFT - part of Chronicle-Core
+ * @since 3.25ea
  * @see net.openhft.chronicle.core.onoes.ExceptionHandler
  */
 package net.openhft.chronicle.core.onoes;


### PR DESCRIPTION
## Notes
- Running `mvn -q verify` failed because Maven is not installed in this environment.

## Summary
- document onoes package with one-sentence summary
- remove `<p>` tags and add example using `RecordingExceptionHandler`
- move Chronicle-Core note to author line
- mark since version 3.25ea
