### PR TITLE
documentation-only sweep across net.openhft.chronicle.core.onoes.

### DIFF
--- a/src/main/java/net/openhft/chronicle/core/onoes/ChainedExceptionHandler.java
+++ b/src/main/java/net/openhft/chronicle/core/onoes/ChainedExceptionHandler.java
@@ -29,23 +29,36 @@ import java.util.stream.Stream;
 import static net.openhft.chronicle.core.util.ObjectUtils.requireNonNull;
 
 /**
- * An implementation of {@link ExceptionHandler} that chains multiple {@link ExceptionHandler} objects
- * to be invoked in sequence.
+ * Chains exception handlers.
+ * <p>
+ * Handlers are evaluated left to right. If a handler throws, the failure is
+ * logged at error level and the next handler is called.
+ * <p>
+ * Construction prunes instances of {@link IgnoresEverything} and unwraps any
+ * {@link ThreadLocalisedExceptionHandler}.
  *
- * <p>This class encapsulates an ordered collection of {@code ExceptionHandler} instances and calls
- * each of them in turn when an exception occurs. If an {@code ExceptionHandler} in the chain
- * itself throws an exception, this exception will be logged and the next {@code ExceptionHandler}
- * in the chain will be called.
+ * @implNote The chain is immutable and has no internal synchronisation. It is
+ * thread-safe provided the supplied handlers are thread-safe.
  *
- * <p>When constructing a new instance, all {@code ExceptionHandler}s that are instances of
- * {@link IgnoresEverything} will be filtered out. Furthermore, any {@code ExceptionHandler} that
- * is an instance of {@link ThreadLocalisedExceptionHandler} will be unwrapped to its underlying
- * {@code ExceptionHandler}.
+ * <pre>
+ * ExceptionHandler chain = new ChainedExceptionHandler(
+ *     Slf4jExceptionHandler.ERROR,
+ *     new RecordingExceptionHandler(LogLevel.ERROR, map, true)
+ * );
+ * </pre>
+ *
+ * @since 3.25ea
  */
 public class ChainedExceptionHandler implements ExceptionHandler {
     @NotNull
     private final ExceptionHandler[] chain;
 
+    /**
+     * Creates a new chain of handlers.
+     *
+     * @param chain the handlers to evaluate from left to right
+     * @throws NullPointerException if {@code chain} or any element is null
+     */
     public ChainedExceptionHandler(@NotNull ExceptionHandler... chain) {
         requireNonNull(chain);
         this.chain = Stream.of(chain)
@@ -55,6 +68,15 @@ public class ChainedExceptionHandler implements ExceptionHandler {
                 .toArray(ExceptionHandler[]::new);
     }
 
+    /**
+     * Passes the event to each handler.
+     *
+     * @param clazz   the originating class, not null
+     * @param message an optional message
+     * @param thrown  an optional throwable
+     * @return void
+     * @throws NullPointerException if {@code clazz} is null
+     */
     @Override
     public void on(@NotNull Class<?> clazz, @Nullable String message, @Nullable Throwable thrown) {
         for (ExceptionHandler eh : chain) {
@@ -66,6 +88,15 @@ public class ChainedExceptionHandler implements ExceptionHandler {
         }
     }
 
+    /**
+     * Passes the event to each handler.
+     *
+     * @param logger  the logger to use, not null
+     * @param message an optional message
+     * @param thrown  an optional throwable
+     * @return void
+     * @throws NullPointerException if {@code logger} is null
+     */
     @Override
     public void on(@NotNull Logger logger, @Nullable String message, Throwable thrown) {
         for (ExceptionHandler eh : chain)
@@ -76,6 +107,11 @@ public class ChainedExceptionHandler implements ExceptionHandler {
             }
     }
 
+    /**
+     * Returns the handlers in evaluation order.
+     *
+     * @return the immutable handler array
+     */
     public @NotNull ExceptionHandler[] chain() {
         return chain;
     }

--- a/src/main/java/net/openhft/chronicle/core/onoes/ChainedExceptionHandler.java
+++ b/src/main/java/net/openhft/chronicle/core/onoes/ChainedExceptionHandler.java
@@ -46,8 +46,6 @@ import static net.openhft.chronicle.core.util.ObjectUtils.requireNonNull;
  *     new RecordingExceptionHandler(LogLevel.ERROR, map, true)
  * );
  * </pre>
- *
- * @since 3.25ea
  */
 public class ChainedExceptionHandler implements ExceptionHandler {
     @NotNull

--- a/src/main/java/net/openhft/chronicle/core/onoes/ChainedExceptionHandler.java
+++ b/src/main/java/net/openhft/chronicle/core/onoes/ChainedExceptionHandler.java
@@ -37,7 +37,7 @@ import static net.openhft.chronicle.core.util.ObjectUtils.requireNonNull;
  * Construction prunes instances of {@link IgnoresEverything} and unwraps any
  * {@link ThreadLocalisedExceptionHandler}.
  *
- * @implNote The chain is immutable and has no internal synchronisation. It is
+ * <p> The chain is immutable and has no internal synchronisation. It is
  * thread-safe provided the supplied handlers are thread-safe.
  *
  * <pre>
@@ -72,7 +72,6 @@ public class ChainedExceptionHandler implements ExceptionHandler {
      * @param clazz   the originating class, not null
      * @param message an optional message
      * @param thrown  an optional throwable
-     * @return void
      * @throws NullPointerException if {@code clazz} is null
      */
     @Override
@@ -92,7 +91,6 @@ public class ChainedExceptionHandler implements ExceptionHandler {
      * @param logger  the logger to use, not null
      * @param message an optional message
      * @param thrown  an optional throwable
-     * @return void
      * @throws NullPointerException if {@code logger} is null
      */
     @Override

--- a/src/main/java/net/openhft/chronicle/core/onoes/ExceptionHandler.java
+++ b/src/main/java/net/openhft/chronicle/core/onoes/ExceptionHandler.java
@@ -25,15 +25,14 @@ import org.slf4j.LoggerFactory;
 import static net.openhft.chronicle.core.util.ObjectUtils.requireNonNull;
 
 /**
- * {@code ExceptionHandler} is a functional interface that provides a mechanism
- * for handling exceptions in a uniform way throughout an application.
- * It allows defining custom logic for exception handling depending on different levels and types
- * of exceptions. This can be particularly useful for logging or taking corrective action based on specific exceptions.
+ * Strategy interface for pluggable exception handling, suitable for use with lambdas.
  *
- * <p>Implementations of this interface can provide custom strategies for handling exceptions,
- * such as logging them, ignoring them, or throwing them.
+ * <p>The overloads delegate to {@link #on(Class, String, Throwable)}. Implementations must
+ * be non-blocking and re-entrant.</p>
  *
- * <p>By default, exceptions are logged using SLF4J logging framework, however, this behavior can be overridden.
+ * @see NullExceptionHandler
+ * @see Slf4jExceptionHandler
+ * @since 3.25ea
  */
 @FunctionalInterface
 public interface ExceptionHandler {
@@ -42,38 +41,45 @@ public interface ExceptionHandler {
      * Creates an {@code ExceptionHandler} that ignores all exceptions.
      *
      * @return an instance of {@link NullExceptionHandler} which ignores all exceptions.
+     * @since 3.25ea
      */
     static ExceptionHandler ignoresEverything() {
         return NullExceptionHandler.NOTHING;
     }
 
     /**
-     * Handles an exception occurred in a specific class, with a specific message.
+     * Convenience overload delegating to {@link #on(Class, String, Throwable)} with an empty message.
      *
-     * @param clazz  the class where the error occurred. Must not be null.
-     * @param thrown the throwable instance representing the error.
+     * @param clazz  the class where the error occurred
+     * @param thrown the throwable instance representing the error, may be {@code null}
+     * @throws NullPointerException if {@code clazz} is {@code null}
+     * @since 3.25ea
      */
     default void on(@NotNull final Class<?> clazz, final Throwable thrown) {
         on(clazz, "", thrown);
     }
 
     /**
-     * Handles an exception occurred in a specific class, with a specific message.
+     * Convenience overload delegating to {@link #on(Class, String, Throwable)} with a {@code null} throwable.
      *
-     * @param clazz   the class where the error occurred. Must not be null.
-     * @param message a custom message detailing the error.
+     * @param clazz   the class where the error occurred
+     * @param message a custom message detailing the error, may be {@code null}
+     * @throws NullPointerException if {@code clazz} is {@code null}
+     * @since 3.25ea
      */
     default void on(@NotNull final Class<?> clazz, final String message) {
         on(clazz, message, null);
     }
 
     /**
-     * The default method to call when an exception occurs.
-     * It attempts to log the exception using SLF4J, and if this fails, it falls back to a secondary logging mechanism.
+     * Handles an exception for the given class, message and throwable.
+     * If logging fails this method attempts to log again at {@link Slf4jExceptionHandler#ERROR} level.
      *
-     * @param clazz   the class where the exception occurred. Must not be null.
-     * @param message a custom message providing additional information about the exception, or an empty string if not available.
-     * @param thrown  the exception that needs to be handled, or null if there is no exception.
+     * @param clazz   the class where the exception occurred
+     * @param message a custom message providing additional information or {@code null}
+     * @param thrown  the exception that needs to be handled, may be {@code null}
+     * @throws NullPointerException if {@code clazz} is {@code null}
+     * @since 3.25ea
      */
     default void on(@NotNull Class<?> clazz, @Nullable String message, @Nullable Throwable thrown) {
         requireNonNull(clazz);
@@ -90,19 +96,23 @@ public interface ExceptionHandler {
     }
 
     /**
-     * Handles an exception occurred with a specific logger, message and throwable.
+     * Handles an exception with the given logger, message and throwable.
      *
-     * @param logger  the logger instance to log the error. Must not be null.
-     * @param message a custom message detailing the error, or null.
-     * @param thrown  the throwable instance representing the error, or null.
+     * @param logger  the logger used to record the error
+     * @param message a custom message detailing the error, may be {@code null}
+     * @param thrown  the throwable instance representing the error, may be {@code null}
+     * @throws NullPointerException if {@code logger} is {@code null}
+     * @since 3.25ea
      */
     void on(@NotNull Logger logger, @Nullable String message, @Nullable Throwable thrown);
 
     /**
-     * Handles an exception occurred with a specific logger and message.
+     * Convenience overload delegating to {@link #on(Logger, String, Throwable)} with a {@code null} throwable.
      *
-     * @param logger  the logger instance to log the error. Must not be null.
-     * @param message a custom message detailing the error, or null.
+     * @param logger  the logger used to record the error
+     * @param message a custom message detailing the error, may be {@code null}
+     * @throws NullPointerException if {@code logger} is {@code null}
+     * @since 3.25ea
      */
     default void on(@NotNull Logger logger, @Nullable String message) {
         on(logger, message, null);
@@ -111,8 +121,10 @@ public interface ExceptionHandler {
     /**
      * Checks if the exception handler is enabled for the given class.
      *
-     * @param aClass the class to check if the exception handler is enabled for. Must not be null.
-     * @return true, as the exception handler is enabled by default for all classes.
+     * @param aClass the class to test
+     * @return {@code true} if this handler should be invoked for the class
+     * @throws NullPointerException if {@code aClass} is {@code null}
+     * @since 3.25ea
      */
     default boolean isEnabled(@NotNull Class<?> aClass) {
         requireNonNull(aClass);
@@ -122,7 +134,8 @@ public interface ExceptionHandler {
     /**
      * Retrieves the default underlying exception handler.
      *
-     * @return the default exception handler, which is the current instance by default.
+     * @return the default exception handler, usually {@code this}
+     * @since 3.25ea
      */
     default ExceptionHandler defaultHandler() {
         return this;

--- a/src/main/java/net/openhft/chronicle/core/onoes/ExceptionHandler.java
+++ b/src/main/java/net/openhft/chronicle/core/onoes/ExceptionHandler.java
@@ -32,7 +32,6 @@ import static net.openhft.chronicle.core.util.ObjectUtils.requireNonNull;
  *
  * @see NullExceptionHandler
  * @see Slf4jExceptionHandler
- * @since 3.25ea
  */
 @FunctionalInterface
 public interface ExceptionHandler {
@@ -41,7 +40,6 @@ public interface ExceptionHandler {
      * Creates an {@code ExceptionHandler} that ignores all exceptions.
      *
      * @return an instance of {@link NullExceptionHandler} which ignores all exceptions.
-     * @since 3.25ea
      */
     static ExceptionHandler ignoresEverything() {
         return NullExceptionHandler.NOTHING;
@@ -53,7 +51,6 @@ public interface ExceptionHandler {
      * @param clazz  the class where the error occurred
      * @param thrown the throwable instance representing the error, may be {@code null}
      * @throws NullPointerException if {@code clazz} is {@code null}
-     * @since 3.25ea
      */
     default void on(@NotNull final Class<?> clazz, final Throwable thrown) {
         on(clazz, "", thrown);
@@ -65,7 +62,6 @@ public interface ExceptionHandler {
      * @param clazz   the class where the error occurred
      * @param message a custom message detailing the error, may be {@code null}
      * @throws NullPointerException if {@code clazz} is {@code null}
-     * @since 3.25ea
      */
     default void on(@NotNull final Class<?> clazz, final String message) {
         on(clazz, message, null);
@@ -79,7 +75,6 @@ public interface ExceptionHandler {
      * @param message a custom message providing additional information or {@code null}
      * @param thrown  the exception that needs to be handled, may be {@code null}
      * @throws NullPointerException if {@code clazz} is {@code null}
-     * @since 3.25ea
      */
     default void on(@NotNull Class<?> clazz, @Nullable String message, @Nullable Throwable thrown) {
         requireNonNull(clazz);
@@ -102,7 +97,6 @@ public interface ExceptionHandler {
      * @param message a custom message detailing the error, may be {@code null}
      * @param thrown  the throwable instance representing the error, may be {@code null}
      * @throws NullPointerException if {@code logger} is {@code null}
-     * @since 3.25ea
      */
     void on(@NotNull Logger logger, @Nullable String message, @Nullable Throwable thrown);
 
@@ -112,7 +106,6 @@ public interface ExceptionHandler {
      * @param logger  the logger used to record the error
      * @param message a custom message detailing the error, may be {@code null}
      * @throws NullPointerException if {@code logger} is {@code null}
-     * @since 3.25ea
      */
     default void on(@NotNull Logger logger, @Nullable String message) {
         on(logger, message, null);
@@ -124,7 +117,6 @@ public interface ExceptionHandler {
      * @param aClass the class to test
      * @return {@code true} if this handler should be invoked for the class
      * @throws NullPointerException if {@code aClass} is {@code null}
-     * @since 3.25ea
      */
     default boolean isEnabled(@NotNull Class<?> aClass) {
         requireNonNull(aClass);
@@ -135,7 +127,6 @@ public interface ExceptionHandler {
      * Retrieves the default underlying exception handler.
      *
      * @return the default exception handler, usually {@code this}
-     * @since 3.25ea
      */
     default ExceptionHandler defaultHandler() {
         return this;

--- a/src/main/java/net/openhft/chronicle/core/onoes/ExceptionKey.java
+++ b/src/main/java/net/openhft/chronicle/core/onoes/ExceptionKey.java
@@ -29,7 +29,7 @@ import java.util.Objects;
  * It encapsulates the log level, the originating class, a message and the
  * associated {@link Throwable}.
  *
- * @implNote The {@link #toString()} method builds a stack trace string and may
+ * <p> The {@link #toString()} method builds a stack trace string and may
  * be expensive.
  */
 public class ExceptionKey {

--- a/src/main/java/net/openhft/chronicle/core/onoes/ExceptionKey.java
+++ b/src/main/java/net/openhft/chronicle/core/onoes/ExceptionKey.java
@@ -31,7 +31,6 @@ import java.util.Objects;
  *
  * @implNote The {@link #toString()} method builds a stack trace string and may
  * be expensive.
- * @since 3.25ea
  */
 public class ExceptionKey {
 

--- a/src/main/java/net/openhft/chronicle/core/onoes/ExceptionKey.java
+++ b/src/main/java/net/openhft/chronicle/core/onoes/ExceptionKey.java
@@ -24,14 +24,14 @@ import java.io.StringWriter;
 import java.util.Objects;
 
 /**
- * Represents a unique key for an exception event. This key includes the log level,
- * the class where the exception occurred, a message associated with the exception,
- * and the Throwable instance. This key can be used to identify unique exceptions
- * for logging, monitoring, or other purposes.
- * <p>
- * The {@code ExceptionKey} class implements custom {@code equals} and {@code hashCode}
- * methods ensuring that two keys are equal if and only if all their fields are equal.
- * 
+ * Immutable key for an exception event.
+ * This class is thread-safe because all its fields are final.
+ * It encapsulates the log level, the originating class, a message and the
+ * associated {@link Throwable}.
+ *
+ * @implNote The {@link #toString()} method builds a stack trace string and may
+ * be expensive.
+ * @since 3.25ea
  */
 public class ExceptionKey {
 

--- a/src/main/java/net/openhft/chronicle/core/onoes/LogLevel.java
+++ b/src/main/java/net/openhft/chronicle/core/onoes/LogLevel.java
@@ -18,15 +18,20 @@
 package net.openhft.chronicle.core.onoes;
 
 /**
- * LogLevel is an enumeration that defines various levels of logging within an application.
- * These levels allow for granularity and control over what types of messages should be logged.
+ * Levels used by Chronicle when reporting messages.
  *
- * <ul>
- *     <li>{@link #ERROR} - Designates error events that might still allow the application to continue running.</li>
- *     <li>{@link #WARN} - Designates potentially harmful situations which should still allow the application to continue.</li>
- *     <li>{@link #PERF} - Designates performance events that could be used for performance optimization and diagnosis.</li>
- *     <li>{@link #DEBUG} - Designates fine-grained informational events that are most useful to debug an application.</li>
- * </ul>
+ * <table>
+ *     <caption>Usage and SLF4J mapping</caption>
+ *     <tr><th>Level</th><th>When to use</th><th>SLF4J level</th></tr>
+ *     <tr><td>{@link #ERROR}</td><td>Something failed and may impact progress.</td><td>{@code error}</td></tr>
+ *     <tr><td>{@link #WARN}</td><td>An unexpected condition that does not stop work.</td><td>{@code warn}</td></tr>
+ *     <tr><td>{@link #PERF}</td><td>Performance event.</td><td>{@code info}</td></tr>
+ *     <tr><td>{@link #DEBUG}</td><td>Diagnostic detail for developers.</td><td>{@code debug}</td></tr>
+ * </table>
+ *
+ * Used by {@link Slf4jExceptionHandler}.
+ *
+ * @since 3.25ea
  */
 public enum LogLevel {
     ERROR,

--- a/src/main/java/net/openhft/chronicle/core/onoes/LogLevel.java
+++ b/src/main/java/net/openhft/chronicle/core/onoes/LogLevel.java
@@ -30,8 +30,6 @@ package net.openhft.chronicle.core.onoes;
  * </table>
  *
  * Used by {@link Slf4jExceptionHandler}.
- *
- * @since 3.25ea
  */
 public enum LogLevel {
     ERROR,

--- a/src/main/java/net/openhft/chronicle/core/onoes/NullExceptionHandler.java
+++ b/src/main/java/net/openhft/chronicle/core/onoes/NullExceptionHandler.java
@@ -23,37 +23,34 @@ import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 
 /**
- * NullExceptionHandler is an enumeration implementing the ExceptionHandler and IgnoresEverything interfaces.
- * It serves as a null object for the ExceptionHandler, providing default behavior that essentially does nothing
- * when an exception occurs. This is often used as a safer alternative to null.
+ * Null-Object implementation of {@link ExceptionHandler} that ignores every event.
+ * <p>{@code isEnabled} always returns {@code false}.</p>
  *
- * <ul>
- *     <li>{@link #NOTHING} - An ExceptionHandler that does nothing when an exception occurs and is not enabled for any class.</li>
- * </ul>
+ * @since 3.25ea
+ * @see ExceptionHandler
  */
 public enum NullExceptionHandler implements ExceptionHandler, IgnoresEverything {
     /**
-     * The NOTHING instance of this enumeration represents a no-op implementation of the ExceptionHandler.
+     * A no-op handler that is always disabled.
      */
     NOTHING {
         /**
-         * This implementation of {@link ExceptionHandler#on(Logger, String, Throwable)} does nothing.
+         * Ignores the supplied event.
          *
-         * @param logger  the logger instance. Must not be null.
-         * @param message a custom message detailing the error, or null.
-         * @param thrown  the throwable instance representing the error, or null.
+         * @param logger  ignored
+         * @param message ignored
+         * @param thrown  ignored
          */
         @Override
         public void on(@NotNull Logger logger, @Nullable String message, Throwable thrown) {
-            // Do nothing
+            // ignored
         }
 
         /**
-         * This implementation of {@link ExceptionHandler#isEnabled(Class)} always returns false,
-         * indicating that this handler is not enabled for any class.
+         * Always returns {@code false}.
          *
-         * @param aClass the class to check if the exception handler is enabled for. Must not be null.
-         * @return false, as this handler is not enabled for any class.
+         * @param aClass the class being checked
+         * @return {@code false}
          */
         @Override
         public boolean isEnabled(@NotNull Class<?> aClass) {

--- a/src/main/java/net/openhft/chronicle/core/onoes/NullExceptionHandler.java
+++ b/src/main/java/net/openhft/chronicle/core/onoes/NullExceptionHandler.java
@@ -25,8 +25,6 @@ import org.slf4j.Logger;
 /**
  * Null-Object implementation of {@link ExceptionHandler} that ignores every event.
  * <p>{@code isEnabled} always returns {@code false}.</p>
- *
- * @since 3.25ea
  * @see ExceptionHandler
  */
 public enum NullExceptionHandler implements ExceptionHandler, IgnoresEverything {

--- a/src/main/java/net/openhft/chronicle/core/onoes/RecordingExceptionHandler.java
+++ b/src/main/java/net/openhft/chronicle/core/onoes/RecordingExceptionHandler.java
@@ -23,14 +23,17 @@ import org.slf4j.Logger;
 
 import java.util.Map;
 /**
- * RecordingExceptionHandler is a concrete implementation of the ExceptionHandler interface.
- * It records each exception by incrementing a count in a provided map, using an ExceptionKey as the key.
+ * Records each exception by incrementing a count in a provided map keyed by
+ * {@link ExceptionKey}.
  * <p>
- * Each ExceptionKey is constructed using a LogLevel, the Class where the exception happened, a custom message,
- * and the Throwable object representing the exception. The LogLevel is provided at instantiation, while
- * the rest are provided when an exception occurs.
- * <p>
- * If the exceptionsOnly flag is set, the handler will ignore errors that are not associated with a Throwable.
+ * The supplied {@code exceptionKeyCountMap} <em>must</em> be thread-safe - for
+ * example a {@link java.util.concurrent.ConcurrentHashMap}. The handler itself
+ * is thread-safe.
+ *
+ * @apiNote The map may grow without bound if unique keys keep being added.
+ * Periodically evict infrequently used entries to control memory usage.
+ *
+ * @since 3.25ea
  */
 public class RecordingExceptionHandler implements ExceptionHandler {
     private final LogLevel level;
@@ -38,11 +41,13 @@ public class RecordingExceptionHandler implements ExceptionHandler {
     private final boolean exceptionsOnly;
 
     /**
-     * Constructs an instance of RecordingExceptionHandler with the specified LogLevel, map for exception counts, and exceptionsOnly flag.
+     * Creates a handler that records exceptions in the supplied map.
      *
-     * @param level                the LogLevel for the ExceptionKeys.
-     * @param exceptionKeyCountMap the map where the count of each ExceptionKey will be stored.
-     * @param exceptionsOnly       a flag indicating if the handler should ignore errors that are not associated with a Throwable.
+     * @param level                the {@link LogLevel} used in the {@link ExceptionKey}.
+     * @param exceptionKeyCountMap thread-safe map where counts are stored, for example a
+     *                             {@link java.util.concurrent.ConcurrentHashMap}.
+     * @param exceptionsOnly       when {@code true}, only errors with a {@link Throwable}
+     *                             are recorded.
      */
     public RecordingExceptionHandler(LogLevel level, Map<ExceptionKey, Integer> exceptionKeyCountMap, boolean exceptionsOnly) {
         this.level = level;

--- a/src/main/java/net/openhft/chronicle/core/onoes/RecordingExceptionHandler.java
+++ b/src/main/java/net/openhft/chronicle/core/onoes/RecordingExceptionHandler.java
@@ -32,8 +32,6 @@ import java.util.Map;
  *
  * @apiNote The map may grow without bound if unique keys keep being added.
  * Periodically evict infrequently used entries to control memory usage.
- *
- * @since 3.25ea
  */
 public class RecordingExceptionHandler implements ExceptionHandler {
     private final LogLevel level;

--- a/src/main/java/net/openhft/chronicle/core/onoes/RecordingExceptionHandler.java
+++ b/src/main/java/net/openhft/chronicle/core/onoes/RecordingExceptionHandler.java
@@ -29,8 +29,8 @@ import java.util.Map;
  * The supplied {@code exceptionKeyCountMap} <em>must</em> be thread-safe - for
  * example a {@link java.util.concurrent.ConcurrentHashMap}. The handler itself
  * is thread-safe.
- *
- * @apiNote The map may grow without bound if unique keys keep being added.
+ * <p>
+ * The map may grow without bound if unique keys keep being added.
  * Periodically evict infrequently used entries to control memory usage.
  */
 public class RecordingExceptionHandler implements ExceptionHandler {

--- a/src/main/java/net/openhft/chronicle/core/onoes/Slf4jExceptionHandler.java
+++ b/src/main/java/net/openhft/chronicle/core/onoes/Slf4jExceptionHandler.java
@@ -29,8 +29,7 @@ import org.slf4j.LoggerFactory;
  * <p>Each enum constant represents a logging level and calls the matching
  * method on the SLF4J {@link Logger}. When SLF4J fails to initialise, or
  * the logger throws at runtime, the implementation writes to
- * {@code System.err} instead. This dynamic fallback is demonstrated in
- * {@link ExceptionHandlerFallbackTest}.
+ * {@code System.err} instead.
  *
  * <p>The {@link #DEBUG} constant overrides
  * {@link #isEnabled(Class)} and only logs when the underlying logger has

--- a/src/main/java/net/openhft/chronicle/core/onoes/Slf4jExceptionHandler.java
+++ b/src/main/java/net/openhft/chronicle/core/onoes/Slf4jExceptionHandler.java
@@ -35,8 +35,6 @@ import org.slf4j.LoggerFactory;
  * <p>The {@link #DEBUG} constant overrides
  * {@link #isEnabled(Class)} and only logs when the underlying logger has
  * debug level enabled. Every constant is a singleton within the JVM.
- *
- * @since 3.25ea
  */
 public enum Slf4jExceptionHandler implements ExceptionHandler {
     ERROR(Logger::error),

--- a/src/main/java/net/openhft/chronicle/core/onoes/Slf4jExceptionHandler.java
+++ b/src/main/java/net/openhft/chronicle/core/onoes/Slf4jExceptionHandler.java
@@ -24,16 +24,19 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Slf4jExceptionHandler is an enum implementation of the ExceptionHandler interface.
- * It uses SLF4J (Simple Logging Facade for Java) to handle exceptions based on the level of logging severity.
- * It supports four levels of logging severity: ERROR, WARN, PERF and DEBUG.
- * <p>
- * Each instance of Slf4jExceptionHandler logs at a specific level and corresponds to a LogLevel enum.
- * This is used to map LogLevel enums to their corresponding Slf4jExceptionHandler instances via the valueOf(LogLevel logLevel) method.
- * <p>
- * The DEBUG instance also overrides the {@code isEnabled(Class clazz)} method, using the isDebugEnabled() method from SLF4J's Logger class.
- * <p>
- * There's also a utility method isJUnitTest() which is used to detect if the current execution context is a JUnit test.
+ * Exception handler that logs using the SLF4J API.
+ *
+ * <p>Each enum constant represents a logging level and calls the matching
+ * method on the SLF4J {@link Logger}. When SLF4J fails to initialise, or
+ * the logger throws at runtime, the implementation writes to
+ * {@code System.err} instead. This dynamic fallback is demonstrated in
+ * {@link ExceptionHandlerFallbackTest}.
+ *
+ * <p>The {@link #DEBUG} constant overrides
+ * {@link #isEnabled(Class)} and only logs when the underlying logger has
+ * debug level enabled. Every constant is a singleton within the JVM.
+ *
+ * @since 3.25ea
  */
 public enum Slf4jExceptionHandler implements ExceptionHandler {
     ERROR(Logger::error),

--- a/src/main/java/net/openhft/chronicle/core/onoes/ThreadLocalisedExceptionHandler.java
+++ b/src/main/java/net/openhft/chronicle/core/onoes/ThreadLocalisedExceptionHandler.java
@@ -33,7 +33,6 @@ import org.slf4j.Logger;
  * per-thread handlers are isolated using {@link ThreadLocal}.
  *
  * @see ChainedExceptionHandler
- * @since 3.25ea
  */
 public class ThreadLocalisedExceptionHandler implements ExceptionHandler {
     private ExceptionHandler eh;

--- a/src/main/java/net/openhft/chronicle/core/onoes/ThreadLocalisedExceptionHandler.java
+++ b/src/main/java/net/openhft/chronicle/core/onoes/ThreadLocalisedExceptionHandler.java
@@ -50,11 +50,6 @@ public class ThreadLocalisedExceptionHandler implements ExceptionHandler {
         resetThreadLocalHandler();
     }
 
-    /**
-     * {@inheritDoc}
-     *
-     * @implSpec The interrupt status is cleared before delegation and restored afterwards.
-     */
     @Override
     public void on(@NotNull Class<?> clazz, @Nullable String message, @Nullable Throwable thrown) {
         ExceptionHandler exceptionHandler = exceptionHandler();
@@ -69,11 +64,6 @@ public class ThreadLocalisedExceptionHandler implements ExceptionHandler {
         }
     }
 
-    /**
-     * {@inheritDoc}
-     *
-     * @implSpec The interrupt status is cleared before delegation and restored afterwards.
-     */
     @Override
     public void on(@NotNull Logger logger, @Nullable String message, Throwable thrown) {
         ExceptionHandler exceptionHandler = exceptionHandler();

--- a/src/main/java/net/openhft/chronicle/core/onoes/ThreadLocalisedExceptionHandler.java
+++ b/src/main/java/net/openhft/chronicle/core/onoes/ThreadLocalisedExceptionHandler.java
@@ -21,23 +21,40 @@ import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 
 /**
- * This class provides a thread-localized ExceptionHandler. The actual ExceptionHandler used for handling
- * exceptions can vary per thread and can be configured using the threadLocalHandler method.
- * If no thread-local ExceptionHandler has been set, it will fall back to a default ExceptionHandler.
- * <p>
- * The default ExceptionHandler can be set using the defaultHandler method, and is initially passed to
- * the constructor when creating a new instance of this class.
+ * Provides a per-thread {@link ExceptionHandler}.
+ *
+ * <p>The handler supplied to the constructor becomes the default. Each thread may
+ * override this via {@link #threadLocalHandler(ExceptionHandler)} and the override can
+ * be removed with {@link #resetThreadLocalHandler()}.
+ * Nested {@link ChainedExceptionHandler} instances are rejected by
+ * {@link #defaultHandler(ExceptionHandler)}.
+ *
+ * <p>This class is <em>conditionally thread-safe</em>: the default handler is shared while
+ * per-thread handlers are isolated using {@link ThreadLocal}.
+ *
+ * @see ChainedExceptionHandler
+ * @since 3.25ea
  */
 public class ThreadLocalisedExceptionHandler implements ExceptionHandler {
     private ExceptionHandler eh;
     private ThreadLocal<ExceptionHandler> handlerTL;
 
+    /**
+     * Creates a new instance using the supplied handler as the default.
+     *
+     * @param handler the handler used when no thread-local handler is present
+     */
     @SuppressWarnings("this-escape")
     public ThreadLocalisedExceptionHandler(ExceptionHandler handler) {
         eh = handler;
         resetThreadLocalHandler();
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * @implSpec The interrupt status is cleared before delegation and restored afterwards.
+     */
     @Override
     public void on(@NotNull Class<?> clazz, @Nullable String message, @Nullable Throwable thrown) {
         ExceptionHandler exceptionHandler = exceptionHandler();
@@ -52,6 +69,11 @@ public class ThreadLocalisedExceptionHandler implements ExceptionHandler {
         }
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * @implSpec The interrupt status is cleared before delegation and restored afterwards.
+     */
     @Override
     public void on(@NotNull Logger logger, @Nullable String message, Throwable thrown) {
         ExceptionHandler exceptionHandler = exceptionHandler();
@@ -73,42 +95,78 @@ public class ThreadLocalisedExceptionHandler implements ExceptionHandler {
         return exceptionHandler;
     }
 
+    /**
+     * Returns the current default handler.
+     *
+     * @return the default handler in use
+     */
     public ExceptionHandler defaultHandler() {
         return eh;
     }
 
+    /**
+     * Unwraps the supplied handler if it is an instance of this class.
+     *
+     * @param eh the handler to unwrap
+     * @return the underlying handler or the supplied instance if it is not wrapped
+     */
     public static ExceptionHandler unwrap(ExceptionHandler eh) {
         if (eh instanceof ThreadLocalisedExceptionHandler)
             return ((ThreadLocalisedExceptionHandler) eh).exceptionHandler();
         return eh;
     }
 
+    /**
+     * Sets the default handler to use when no thread-local handler is present.
+     * Nested {@link ChainedExceptionHandler} instances are rejected.
+     *
+     * @param defaultHandler the new default handler, or {@code null} to use
+     *                       {@link NullExceptionHandler#NOTHING}
+     * @return {@code this} for chaining
+     */
     public ThreadLocalisedExceptionHandler defaultHandler(ExceptionHandler defaultHandler) {
         defaultHandler = unwrap(defaultHandler);
         if (defaultHandler instanceof ChainedExceptionHandler) {
             ChainedExceptionHandler ceh = (ChainedExceptionHandler) defaultHandler;
             for (ExceptionHandler handler : ceh.chain()) {
                 if (handler instanceof ThreadLocalisedExceptionHandler)
-                    throw new AssertionError("Recursive used of "+getClass());
+                    throw new AssertionError("Recursive used of " + getClass());
             }
         }
         this.eh = defaultHandler == null ? NullExceptionHandler.NOTHING : defaultHandler;
         return this;
     }
 
+    /**
+     * Returns the handler specific to the current thread or {@code null} if none is set.
+     *
+     * @return the thread-local handler or {@code null}
+     */
     public ExceptionHandler threadLocalHandler() {
         return handlerTL.get();
     }
 
+    /**
+     * Overrides the handler for the current thread.
+     *
+     * @param handler the handler to install for this thread, may be {@code null}
+     * @return {@code this} for chaining
+     */
     public ThreadLocalisedExceptionHandler threadLocalHandler(ExceptionHandler handler) {
         handlerTL.set(handler);
         return this;
     }
 
+    /**
+     * Clears any thread specific handler so the default will be used.
+     */
     public void resetThreadLocalHandler() {
         handlerTL = new InheritableThreadLocal<>();
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public boolean isEnabled(@NotNull Class<?> aClass) {
         ExceptionHandler exceptionHandler = exceptionHandler();

--- a/src/main/java/net/openhft/chronicle/core/onoes/package-info.java
+++ b/src/main/java/net/openhft/chronicle/core/onoes/package-info.java
@@ -27,7 +27,6 @@
  * }</pre>
  *
  * @author OpenHFT - part of Chronicle-Core
- * @since 3.25ea
  * @see net.openhft.chronicle.core.onoes.ExceptionHandler
  */
 package net.openhft.chronicle.core.onoes;

--- a/src/main/java/net/openhft/chronicle/core/onoes/package-info.java
+++ b/src/main/java/net/openhft/chronicle/core/onoes/package-info.java
@@ -5,12 +5,10 @@
  * in a uniform manner throughout an application. This includes mechanisms for
  * chaining multiple exception handlers together, logging exceptions, handling
  * exceptions on a per-thread basis, and recording exceptions.
- * 
  * <p>
  * The core of this package is the {@link net.openhft.chronicle.core.onoes.ExceptionHandler}
  * interface which allows for custom logic to be defined for handling different
  * types of exceptions.
- * 
  * <p>
  * Other classes and enumerations within the package include:
  * 
@@ -25,7 +23,6 @@
  * </ul>
  * <p>
  * This package is part of the Chronicle-Core library by OpenHFT.
- * 
  *
  * @see net.openhft.chronicle.core.onoes.ExceptionHandler
  */

--- a/src/main/java/net/openhft/chronicle/core/onoes/package-info.java
+++ b/src/main/java/net/openhft/chronicle/core/onoes/package-info.java
@@ -1,29 +1,33 @@
 /**
- * Provides classes and interfaces for exception handling, logging, and associated utilities.
- * <p>
- * This package contains classes and interfaces that enable handling exceptions
- * in a uniform manner throughout an application. This includes mechanisms for
- * chaining multiple exception handlers together, logging exceptions, handling
- * exceptions on a per-thread basis, and recording exceptions.
- * <p>
- * The core of this package is the {@link net.openhft.chronicle.core.onoes.ExceptionHandler}
- * interface which allows for custom logic to be defined for handling different
- * types of exceptions.
- * <p>
- * Other classes and enumerations within the package include:
- * 
- * <ul>
- *     <li>{@link net.openhft.chronicle.core.onoes.ChainedExceptionHandler} - Chains multiple ExceptionHandler objects for sequential invocation.</li>
- *     <li>{@link net.openhft.chronicle.core.onoes.ExceptionKey} - Represents a unique key for an exception event.</li>
- *     <li>{@link net.openhft.chronicle.core.onoes.LogLevel} - Defines various levels of logging severity.</li>
- *     <li>{@link net.openhft.chronicle.core.onoes.NullExceptionHandler} - Implements ExceptionHandler as a null object.</li>
- *     <li>{@link net.openhft.chronicle.core.onoes.RecordingExceptionHandler} - Records exceptions by incrementing counts in a map.</li>
- *     <li>{@link net.openhft.chronicle.core.onoes.Slf4jExceptionHandler} - Uses SLF4J for logging exceptions based on severity levels.</li>
- *     <li>{@link net.openhft.chronicle.core.onoes.ThreadLocalisedExceptionHandler} - Provides thread-localized exception handling.</li>
- * </ul>
- * <p>
- * This package is part of the Chronicle-Core library by OpenHFT.
+ * Exception-handling and logging utilities.
  *
+ * This package contains classes that enable handling exceptions in a uniform way
+ * throughout an application. This includes mechanisms for chaining handlers,
+ * logging, per-thread handling and recording exceptions.
+ *
+ * The core of this package is the {@link net.openhft.chronicle.core.onoes.ExceptionHandler}
+ * interface which allows custom logic for dealing with different exception types.
+ *
+ * Other classes and enumerations within the package include:
+ * <ul>
+ *     <li>{@link net.openhft.chronicle.core.onoes.ChainedExceptionHandler} - chains multiple ExceptionHandler objects for sequential invocation.</li>
+ *     <li>{@link net.openhft.chronicle.core.onoes.ExceptionKey} - represents a unique key for an exception event.</li>
+ *     <li>{@link net.openhft.chronicle.core.onoes.LogLevel} - defines levels of logging severity.</li>
+ *     <li>{@link net.openhft.chronicle.core.onoes.NullExceptionHandler} - implements ExceptionHandler as a null object.</li>
+ *     <li>{@link net.openhft.chronicle.core.onoes.RecordingExceptionHandler} - records exceptions by incrementing counts in a map.</li>
+ *     <li>{@link net.openhft.chronicle.core.onoes.Slf4jExceptionHandler} - uses SLF4J for logging based on severity levels.</li>
+ *     <li>{@link net.openhft.chronicle.core.onoes.ThreadLocalisedExceptionHandler} - provides thread-localised exception handling.</li>
+ * </ul>
+ *
+ * Example usage for switching to {@link net.openhft.chronicle.core.onoes.RecordingExceptionHandler}:
+ * <pre>{@code
+ * Map<ExceptionKey, Integer> counts = Jvm.recordExceptions();
+ * // run code that generates exceptions
+ * Jvm.resetExceptionHandlers();
+ * }</pre>
+ *
+ * @author OpenHFT - part of Chronicle-Core
+ * @since 3.25ea
  * @see net.openhft.chronicle.core.onoes.ExceptionHandler
  */
 package net.openhft.chronicle.core.onoes;

--- a/src/main/java/net/openhft/chronicle/core/onoes/package-info.java
+++ b/src/main/java/net/openhft/chronicle/core/onoes/package-info.java
@@ -1,13 +1,13 @@
 /**
  * Exception-handling and logging utilities.
- *
+ * <p>
  * This package contains classes that enable handling exceptions in a uniform way
  * throughout an application. This includes mechanisms for chaining handlers,
  * logging, per-thread handling and recording exceptions.
- *
+ * <p>
  * The core of this package is the {@link net.openhft.chronicle.core.onoes.ExceptionHandler}
  * interface which allows custom logic for dealing with different exception types.
- *
+ * <p>
  * Other classes and enumerations within the package include:
  * <ul>
  *     <li>{@link net.openhft.chronicle.core.onoes.ChainedExceptionHandler} - chains multiple ExceptionHandler objects for sequential invocation.</li>

--- a/src/main/java/net/openhft/chronicle/core/onoes/package-info.java
+++ b/src/main/java/net/openhft/chronicle/core/onoes/package-info.java
@@ -26,7 +26,6 @@
  * Jvm.resetExceptionHandlers();
  * }</pre>
  *
- * @author OpenHFT - part of Chronicle-Core
  * @see net.openhft.chronicle.core.onoes.ExceptionHandler
  */
 package net.openhft.chronicle.core.onoes;


### PR DESCRIPTION
This pull request is a **documentation-only** sweep across *net.openhft.chronicle.core.onoes*.  
It finishes the work started in #751-#759, then removes a few items that review feedback flagged as noise.

| Patch | Theme | Notes |
|-------|-------|-------|
| 01/13 | **Whitespace** | Strip stray blanks from `package-info.java` to stop AsciiDoc paragraph drift. |
| 02-10/13 | **Javadoc overhaul** | Add or rewrite comments for every public type:<br>• crisp first-sentence summaries<br>• full `@param/@return/@throws` sets<br>• explicit thread-safety statements<br>• SLF4J mapping table in `LogLevel`<br>• examples and `@implNote/@apiNote`s<br>• modernised package overview. |
| 11-12/13 | **Noise removal** | Delete boiler-plate `{@inheritDoc}` blocks introduced during earlier iterations – the methods are self-explanatory. |
| 13/13 | **Tag hygiene** | Drop the `@since 3.25ea` markers that were making the docs verbose |

### Why we need it
* **Cleaner generated docs** – IDE tool-tips and the public site no longer italicise parameter names or show duplicated text.  
* **Accurate contracts** – Users now see thread-safety guarantees and fallback behaviour explicitly called out.  
* **Maintenance** – The codebase no longer carries superfluous tags, so future contributors have less clutter to maintain.  

There are **no code-path or binary changes**; all unit tests still pass.

### Impact & migration
Zero runtime impact – consumers do **not** need to recompile or change any code. The only visible change is richer, cleaner documentation.
