### PR TITLE
Clarify nullability of pool components

### DIFF
--- a/src/main/java/net/openhft/chronicle/core/pool/DynamicEnumClass.java
+++ b/src/main/java/net/openhft/chronicle/core/pool/DynamicEnumClass.java
@@ -18,6 +18,7 @@ package net.openhft.chronicle.core.pool;
 import net.openhft.chronicle.core.Jvm;
 import net.openhft.chronicle.core.OS;
 import net.openhft.chronicle.core.util.CoreDynamicEnum;
+import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.TestOnly;
 
 import java.lang.reflect.Array;
@@ -108,6 +109,7 @@ public class DynamicEnumClass<E extends CoreDynamicEnum<E>> extends EnumCache<E>
      * @return the enum instance with the specified name, or {@code null} if not present.
      */
     @Override
+    @Nullable
     public E get(String name) {
         return eMap.get(name);
     }
@@ -117,7 +119,8 @@ public class DynamicEnumClass<E extends CoreDynamicEnum<E>> extends EnumCache<E>
      * name does not exist, this method dynamically creates a new one.
      *
      * @param name the name of the enum instance to be retrieved or created.
-     * @return the enum instance with the specified name.
+     * @return the enum instance with the specified name. This method never
+     * returns {@code null}; unknown names are created on demand.
      */
     @Override
     public E valueOf(String name) {

--- a/src/main/java/net/openhft/chronicle/core/pool/EnumCache.java
+++ b/src/main/java/net/openhft/chronicle/core/pool/EnumCache.java
@@ -70,7 +70,8 @@ public abstract class EnumCache<E> {
      * Returns the enum instance with the specified name.
      *
      * @param name the name of the enum instance to be returned.
-     * @return the enum instance with the specified name.
+     * @return the enum instance with the specified name, or {@code null}
+     *         if no such instance exists.
      */
     public E get(String name) {
         return valueOf(name);
@@ -80,7 +81,8 @@ public abstract class EnumCache<E> {
      * Returns the enum instance with the specified name.
      *
      * @param name the name of the enum instance to be returned.
-     * @return the enum instance with the specified name.
+     * @return the enum instance with the specified name, or {@code null}
+     *         if no such instance exists.
      */
     public abstract E valueOf(String name);
 

--- a/src/main/java/net/openhft/chronicle/core/pool/ParsingCache.java
+++ b/src/main/java/net/openhft/chronicle/core/pool/ParsingCache.java
@@ -76,7 +76,8 @@ public class ParsingCache<E> {
      * stored in the cache, and then returned.
      *
      * @param cs The CharSequence to be parsed.
-     * @return The object of type E corresponding to the provided CharSequence.
+     * @return The object of type E corresponding to the provided CharSequence,
+     * or {@code null} if {@code cs} is {@code null}.
      */
     @Nullable
     public E intern(@Nullable CharSequence cs) {

--- a/src/main/java/net/openhft/chronicle/core/pool/StaticEnumClass.java
+++ b/src/main/java/net/openhft/chronicle/core/pool/StaticEnumClass.java
@@ -15,6 +15,8 @@
  */
 package net.openhft.chronicle.core.pool;
 
+import org.jetbrains.annotations.Nullable;
+
 import java.util.EnumMap;
 import java.util.EnumSet;
 import java.util.Map;
@@ -60,6 +62,7 @@ public class StaticEnumClass<E extends Enum<E>> extends EnumCache<E> {
      * @return the enum instance with the specified name, or {@code null} if not present.
      */
     @Override
+    @Nullable
     public E valueOf(String name) {
         return name == null || name.isEmpty() ? null : Enum.valueOf(type, name);
     }

--- a/src/main/java/net/openhft/chronicle/core/pool/StringInterner.java
+++ b/src/main/java/net/openhft/chronicle/core/pool/StringInterner.java
@@ -159,9 +159,11 @@ public class StringInterner {
     /**
      * get an intered string based on the index
      *
-     * @param index the index of the  interner string, to acquire an index call  {@link net.openhft.chronicle.core.pool.StringInterner#index}
-     * @return interned String
+     * @param index the index of the interner string; acquire an index via
+     *              {@link net.openhft.chronicle.core.pool.StringInterner#index}
+     * @return the interned string, or {@code null} if no value is stored at that index
      */
+    @Nullable
     public String get(int index) {
         return interner[index];
     }

--- a/src/main/java/net/openhft/chronicle/core/pool/package-info.java
+++ b/src/main/java/net/openhft/chronicle/core/pool/package-info.java
@@ -29,6 +29,14 @@
  *
  * <p>The {@link net.openhft.chronicle.core.pool.StringInterner} class provides string interning functionality, optimizing
  * memory usage by caching strings and referring to them by index rather than storing duplicate strings.
+ * This interner is a <em>best-effort</em> concurrent structure and does not
+ * offer strong thread-safety guarantees.
+ *
+ * <p>Unless otherwise stated, parameters and return values in this package are
+ * non-null by default. Use {@link org.jetbrains.annotations.Nullable} to
+ * indicate when {@code null} is permitted.
+ * The {@link net.openhft.chronicle.core.pool.DynamicEnumClass} implementation
+ * is thread-safe and ensures each name maps to a single instance.
  *
  * @see net.openhft.chronicle.core.pool.ClassAliasPool
  * @see net.openhft.chronicle.core.pool.ClassLookup


### PR DESCRIPTION
## Summary
- revert package-level nullability defaults added outside the pool package
- document null-return cases in pool classes
- clarify thread-safety of the pool package

## Testing
- `mvn -q verify` *(fails: mvn not found)*