### PR TITLE
Improve ScopedResource Javadoc

### DIFF
--- a/src/main/java/net/openhft/chronicle/core/scoped/ScopedResource.java
+++ b/src/main/java/net/openhft/chronicle/core/scoped/ScopedResource.java
@@ -18,12 +18,18 @@ package net.openhft.chronicle.core.scoped;
 import java.io.Closeable;
 
 /**
- * A scoped resource, it is drawn from a "pool" of sorts, and will be returned
- * to that pool when {@link #close()} is called.
+ * A short-lived handle to a shared resource.
  * <p>
- * Do not keep a reference to the contained resource beyond the scope.
+ * Instances are obtained from a {@link ScopedResourcePool} such as
+ * {@link ScopedThreadLocal} and are expected to be used with the
+ * try-with-resources idiom. The underlying resource is returned to the pool
+ * when {@link #close()} completes. Clients must not retain a reference to the
+ * resource after the scope ends.
  *
- * @param <T> The type of the resource contained
+ * @param <T> the type of the resource contained
+ * @see ScopedResourcePool
+ * @see ScopedThreadLocal
+ * @since 2.27ea3
  */
 public interface ScopedResource<T> extends Closeable {
 
@@ -35,7 +41,10 @@ public interface ScopedResource<T> extends Closeable {
     T get();
 
     /**
-     * Signifies the end of the scope, will return the resource to the "pool" for use by other acquirers
+     * Signifies the end of the scope and returns the resource to the pool for
+     * use by other acquirers.
+     * <p>
+     * This method is idempotent; additional invocations have no effect.
      */
     @Override
     void close();


### PR DESCRIPTION
## Summary
- explain how to use `ScopedResource` via try-with-resources
- note that `close()` is idempotent
- add cross-references and `@since` tag

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*