### PR TITLE
Documentation improvements for core.scoped and core.shutdown

### DIFF
--- a/src/main/java/net/openhft/chronicle/core/pom/PomProperties.java
+++ b/src/main/java/net/openhft/chronicle/core/pom/PomProperties.java
@@ -21,6 +21,22 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.Properties;
 
+/**
+ * Access to Maven build metadata at runtime.
+ *
+ * <p>It loads the {@code pom.properties} resource for a given
+ * {@code groupId} and {@code artifactId}, allowing callers to
+ * inspect version and other build-time information.</p>
+ *
+ * <p>All methods require non-null parameters. Passing {@code null}
+ * results in a {@link NullPointerException}.</p>
+ *
+ * <p>Example:</p>
+ * <pre>{@code
+ * Properties props = PomProperties.create("net.openhft", "chronicle-core");
+ * String version = props.getProperty("version");
+ * }</pre>
+ */
 public final class PomProperties {
 
     private PomProperties() {
@@ -39,7 +55,7 @@ public final class PomProperties {
      * @return a new instance of Properties for the provided parameters.
      */
     @NotNull
-    public static Properties create(final String groupId, final String artifactId) {
+    public static Properties create(@NotNull final String groupId, @NotNull final String artifactId) {
         return InternalPomProperties.create(groupId, artifactId);
     }
 
@@ -56,7 +72,7 @@ public final class PomProperties {
      * the version cannot be determined
      * @see #create(String, String)
      */
-    public static String version(final String groupId, final String artifactId) {
+    public static String version(@NotNull final String groupId, @NotNull final String artifactId) {
         return InternalPomProperties.version(groupId, artifactId);
     }
 }

--- a/src/main/java/net/openhft/chronicle/core/scoped/AbstractScopedResource.java
+++ b/src/main/java/net/openhft/chronicle/core/scoped/AbstractScopedResource.java
@@ -15,6 +15,14 @@
  */
 package net.openhft.chronicle.core.scoped;
 
+/**
+ * Base implementation of {@link ScopedResource} instances returned by
+ * {@link ScopedThreadLocal}. Each instance is confined to the thread that
+ * created it and records the creation time using {@link System#nanoTime()}.
+ * The timestamp allows {@link ScopedThreadLocal} to discard the oldest
+ * resource when the per-thread capacity is exceeded.
+ */
+
 import org.jetbrains.annotations.Nullable;
 
 abstract class AbstractScopedResource<T> implements ScopedResource<T> {
@@ -22,6 +30,11 @@ abstract class AbstractScopedResource<T> implements ScopedResource<T> {
     private final long createdTimeNanos;
     private final ScopedThreadLocal<T> scopedThreadLocal;
 
+    /**
+     * Create a new instance bound to the provided {@code scopedThreadLocal}.
+     *
+     * @param scopedThreadLocal the pool managing this resource for the current thread
+     */
     protected AbstractScopedResource(ScopedThreadLocal<T> scopedThreadLocal) {
         this.scopedThreadLocal = scopedThreadLocal;
         this.createdTimeNanos = System.nanoTime();
@@ -33,14 +46,29 @@ abstract class AbstractScopedResource<T> implements ScopedResource<T> {
     }
 
     /**
-     * Do anything that needs to be done before returning a resource to a caller
+     * Prepare the resource before it is handed to the caller.
+     *
+     * @implSpec
+     * Invoked by {@link ScopedThreadLocal#get()} on the owning thread just
+     * before returning the resource. The default implementation does nothing.
+     *
+     * @implNote
+     * Implementations may assume thread confinement and should avoid heavy
+     * allocation if possible.
      */
     void preAcquire() {
         // Do nothing by default
     }
 
     /**
-     * Close the contained resource and clear any references
+     * Close the contained resource and clear any references.
+     *
+     * @implSpec
+     * Called when a resource is permanently discarded from the pool or when the
+     * thread-local stack is closed.
+     *
+     * @implNote
+     * Implementations should release all state and must be idempotent.
      */
     abstract void closeResource();
 

--- a/src/main/java/net/openhft/chronicle/core/scoped/AbstractScopedResource.java
+++ b/src/main/java/net/openhft/chronicle/core/scoped/AbstractScopedResource.java
@@ -48,11 +48,11 @@ abstract class AbstractScopedResource<T> implements ScopedResource<T> {
     /**
      * Prepare the resource before it is handed to the caller.
      *
-     * @implSpec
+     * <p>
      * Invoked by {@link ScopedThreadLocal#get()} on the owning thread just
      * before returning the resource. The default implementation does nothing.
      *
-     * @implNote
+     * <p>
      * Implementations may assume thread confinement and should avoid heavy
      * allocation if possible.
      */
@@ -63,11 +63,11 @@ abstract class AbstractScopedResource<T> implements ScopedResource<T> {
     /**
      * Close the contained resource and clear any references.
      *
-     * @implSpec
+     * <p>
      * Called when a resource is permanently discarded from the pool or when the
      * thread-local stack is closed.
      *
-     * @implNote
+     * <p>
      * Implementations should release all state and must be idempotent.
      */
     abstract void closeResource();

--- a/src/main/java/net/openhft/chronicle/core/scoped/ScopedResource.java
+++ b/src/main/java/net/openhft/chronicle/core/scoped/ScopedResource.java
@@ -29,7 +29,6 @@ import java.io.Closeable;
  * @param <T> the type of the resource contained
  * @see ScopedResourcePool
  * @see ScopedThreadLocal
- * @since 2.27ea3
  */
 public interface ScopedResource<T> extends Closeable {
 

--- a/src/main/java/net/openhft/chronicle/core/scoped/ScopedResource.java
+++ b/src/main/java/net/openhft/chronicle/core/scoped/ScopedResource.java
@@ -18,12 +18,18 @@ package net.openhft.chronicle.core.scoped;
 import java.io.Closeable;
 
 /**
- * A scoped resource, it is drawn from a "pool" of sorts, and will be returned
- * to that pool when {@link #close()} is called.
+ * A short-lived handle to a shared resource.
  * <p>
- * Do not keep a reference to the contained resource beyond the scope.
+ * Instances are obtained from a {@link ScopedResourcePool} such as
+ * {@link ScopedThreadLocal} and are expected to be used with the
+ * try-with-resources idiom. The underlying resource is returned to the pool
+ * when {@link #close()} completes. Clients must not retain a reference to the
+ * resource after the scope ends.
  *
- * @param <T> The type of the resource contained
+ * @param <T> the type of the resource contained
+ * @see ScopedResourcePool
+ * @see ScopedThreadLocal
+ * @since 2.27ea3
  */
 public interface ScopedResource<T> extends Closeable {
 
@@ -35,7 +41,10 @@ public interface ScopedResource<T> extends Closeable {
     T get();
 
     /**
-     * Signifies the end of the scope, will return the resource to the "pool" for use by other acquirers
+     * Signifies the end of the scope and returns the resource to the pool for
+     * use by other acquirers.
+     * <p>
+     * This method is idempotent; additional invocations have no effect.
      */
     @Override
     void close();

--- a/src/main/java/net/openhft/chronicle/core/scoped/ScopedThreadLocal.java
+++ b/src/main/java/net/openhft/chronicle/core/scoped/ScopedThreadLocal.java
@@ -28,14 +28,16 @@ import java.util.function.Supplier;
 import static net.openhft.chronicle.core.Jvm.uncheckedCast;
 
 /**
- * A thread-local {@link ScopedResourcePool}.
+ * Bounded per-thread pool of {@link ScopedResource} instances.
  * <p>
- * This is used for small, tightly-scoped thread-local resource "pools", a safer alternative
- * to a thread-local singleton.
+ * Every thread owns its own stack of resources supplied by {@code supplier}. An
+ * instance is taken from the stack when {@link #get()} is called and returned to
+ * it when the scope closes. If the stack is full the newest resource is
+ * discarded.
  * <p>
- * Holds a limited-depth stack of instances local to each thread, which are allocated as
- * acquired and returned to the stack as the scopes close. If too many are acquired, a warning
- * is logged and the extra instances are made eligible for garbage collection.
+ * The stack is confined to a single thread and so is not synchronised. The
+ * resources themselves may not be thread-safe and must only be used by one
+ * thread at a time unless they implement their own safety rules.
  */
 public class ScopedThreadLocal<T> implements ScopedResourcePool<T> {
 
@@ -45,33 +47,33 @@ public class ScopedThreadLocal<T> implements ScopedResourcePool<T> {
     private final boolean useWeakReferences;
 
     /**
-     * Constructor
+     * Creates a pool with the given supplier and capacity.
      *
-     * @param supplier     The supplier of new instances
-     * @param maxInstances The maximum number of instances that will be retained for re-use
+     * @param supplier     provides new instances when the stack is empty
+     * @param maxInstances maximum number of retained instances per thread
      */
     public ScopedThreadLocal(Supplier<T> supplier, int maxInstances) {
         this(supplier, ScopedThreadLocal::noOp, maxInstances);
     }
 
     /**
-     * Constructor
+     * Creates a pool with an action run on every acquisition.
      *
-     * @param supplier     The supplier of new instances
-     * @param onAcquire    A function to run on each instance upon it's acquisition
-     * @param maxInstances The maximum number of instances that will be retained for re-use
+     * @param supplier     provides new instances when the stack is empty
+     * @param onAcquire    invoked each time an instance is retrieved from the pool
+     * @param maxInstances maximum number of retained instances per thread
      */
     public ScopedThreadLocal(@NotNull Supplier<T> supplier, @NotNull Consumer<T> onAcquire, int maxInstances) {
         this(supplier, onAcquire, maxInstances, false);
     }
 
     /**
-     * Constructor
+     * Creates a pool with fine-grained control over resource retention.
      *
-     * @param supplier          The supplier of new instances
-     * @param onAcquire         A function to run on each instance upon it's acquisition
-     * @param maxInstances      The maximum number of instances that will be retained for re-use
-     * @param useWeakReferences Whether to allow resources to be garbage collected when they're not in use
+     * @param supplier          provides new instances when the stack is empty
+     * @param onAcquire         invoked each time an instance is retrieved from the pool
+     * @param maxInstances      maximum number of retained instances per thread
+     * @param useWeakReferences if {@code true} weak references allow garbage collection
      */
     public ScopedThreadLocal(@NotNull Supplier<T> supplier, @NotNull Consumer<T> onAcquire, int maxInstances, boolean useWeakReferences) {
         this.supplier = supplier;
@@ -81,9 +83,9 @@ public class ScopedThreadLocal<T> implements ScopedResourcePool<T> {
     }
 
     /**
-     * Get a scoped instance of the shared resource
+     * Obtains a scoped handle to a pooled instance.
      *
-     * @return the {@link ScopedResource}, to be closed once it is finished being used
+     * @return the handle that must be closed to return the instance to this thread
      */
     public ScopedResource<T> get() {
         final SimpleStack scopedThreadLocalResources = instancesTL.get();
@@ -106,9 +108,9 @@ public class ScopedThreadLocal<T> implements ScopedResourcePool<T> {
     }
 
     /**
-     * Return a {@link ScopedResource} to the "pool"
+     * Returns a resource to the current thread's stack.
      *
-     * @param scopedResource The resource to return
+     * @param scopedResource resource being released
      */
     void returnResource(AbstractScopedResource<T> scopedResource) {
         final SimpleStack scopedThreadLocalResources = instancesTL.get();
@@ -124,7 +126,8 @@ public class ScopedThreadLocal<T> implements ScopedResourcePool<T> {
     }
 
     /**
-     * A simple array-based stack for managing retained {@link ScopedResource}s
+     * Simple array-based stack holding retained resources for one thread.
+     * Not thread-safe and relies on {@link ThreadLocal} confinement.
      */
     class SimpleStack implements java.io.Closeable {
 

--- a/src/main/java/net/openhft/chronicle/core/scoped/StrongReferenceScopedResource.java
+++ b/src/main/java/net/openhft/chronicle/core/scoped/StrongReferenceScopedResource.java
@@ -18,10 +18,13 @@ package net.openhft.chronicle.core.scoped;
 import static net.openhft.chronicle.core.io.Closeable.closeQuietly;
 
 /**
- * A {@link ScopedResource} that will always retain a strong reference to the
- * contained resource, even when not "in use"
+ * A {@link ScopedResource} that always keeps a strong reference to its
+ * resource. The object therefore remains reachable until
+ * {@link #closeResource()} is called. In contrast to
+ * {@link WeakReferenceScopedResource}, the reference is never cleared when the
+ * scope ends.
  *
- * @param <T> The type of the contained resource
+ * @param <T> the type of the contained resource
  */
 public class StrongReferenceScopedResource<T> extends AbstractScopedResource<T> {
 

--- a/src/main/java/net/openhft/chronicle/core/scoped/WeakReferenceScopedResource.java
+++ b/src/main/java/net/openhft/chronicle/core/scoped/WeakReferenceScopedResource.java
@@ -22,12 +22,13 @@ import java.lang.ref.WeakReference;
 import java.util.function.Supplier;
 
 /**
- * A weak-referenced {@link ScopedResource} when the resource is acquired, we create
- * a strong reference to prevent it being GC'd while it's "in use". Upon return, the
- * strong reference is cleared, leaving only the weak reference thus allowing the
- * resource to be GC'd.
+ * A {@link ScopedResource} backed by a {@link WeakReference}. When the resource
+ * is acquired a strong reference is taken and released again on
+ * {@link #close()}. This allows the object to be reclaimed between usages. In
+ * contrast {@link StrongReferenceScopedResource} retains a strong reference for
+ * the lifetime of the wrapper.
  *
- * @param <T> The type of the contained resource
+ * @param <T> the type of the contained resource
  */
 public class WeakReferenceScopedResource<T> extends AbstractScopedResource<T> {
 
@@ -41,7 +42,9 @@ public class WeakReferenceScopedResource<T> extends AbstractScopedResource<T> {
     }
 
     /**
-     * Before acquire we check that the reference is populated and populate it if not
+     * {@implSpec} Ensures a strong reference exists before the caller receives
+     * the resource. If the previous instance was reclaimed, a new one is
+     * obtained from the supplier.
      */
     @Override
     void preAcquire() {
@@ -56,6 +59,7 @@ public class WeakReferenceScopedResource<T> extends AbstractScopedResource<T> {
         return strongRef;
     }
 
+    /** {@inheritDoc} */
     @Override
     public void close() {
         strongRef = null;

--- a/src/main/java/net/openhft/chronicle/core/scoped/WeakReferenceScopedResource.java
+++ b/src/main/java/net/openhft/chronicle/core/scoped/WeakReferenceScopedResource.java
@@ -59,7 +59,6 @@ public class WeakReferenceScopedResource<T> extends AbstractScopedResource<T> {
         return strongRef;
     }
 
-    /** {@inheritDoc} */
     @Override
     public void close() {
         strongRef = null;

--- a/src/main/java/net/openhft/chronicle/core/scoped/WeakReferenceScopedResource.java
+++ b/src/main/java/net/openhft/chronicle/core/scoped/WeakReferenceScopedResource.java
@@ -42,7 +42,7 @@ public class WeakReferenceScopedResource<T> extends AbstractScopedResource<T> {
     }
 
     /**
-     * {@implSpec} Ensures a strong reference exists before the caller receives
+     * Ensures a strong reference exists before the caller receives
      * the resource. If the previous instance was reclaimed, a new one is
      * obtained from the supplier.
      */

--- a/src/main/java/net/openhft/chronicle/core/scoped/package-info.java
+++ b/src/main/java/net/openhft/chronicle/core/scoped/package-info.java
@@ -1,0 +1,23 @@
+/**
+ * Provides classes for short-lived, stack-based object pooling.
+ *
+ * <p>The main entry point is {@link net.openhft.chronicle.core.scoped.ScopedThreadLocal}
+ * which maintains a per-thread stack of objects. When {@link net.openhft.chronicle.core.scoped.ScopedThreadLocal#get()}
+ * is called a {@link net.openhft.chronicle.core.scoped.ScopedResource} is returned
+ * that must be closed. The resource is then pushed back on to the owning thread's
+ * stack. If the stack is full the newest object is discarded.
+ *
+ * <p>Resources acquired from a pool belong to the thread that obtained them and
+ * must not be passed to another thread while in scope.
+ *
+ * <p>Typical usage leverages the try-with-resources statement:
+ * <pre>{@code
+ * ScopedThreadLocal<StringBuilder> pool = new ScopedThreadLocal<>(StringBuilder::new, 4);
+ *
+ * try (ScopedResource<StringBuilder> handle = pool.get()) {
+ *     StringBuilder sb = handle.get();
+ *     // use the StringBuilder
+ * }
+ * }</pre>
+ */
+package net.openhft.chronicle.core.scoped;

--- a/src/main/java/net/openhft/chronicle/core/shutdown/Hooklet.java
+++ b/src/main/java/net/openhft/chronicle/core/shutdown/Hooklet.java
@@ -27,7 +27,7 @@ import java.util.Objects;
  * many threads but each hooklet is executed sequentially by the shutdown
  * thread.
  *
- * @apiNote Allocate unique priorities in the range {@code 0-100}. Smaller
+ * <p>Allocate unique priorities in the range {@code 0-100}. Smaller
  * values execute first and should be used for higher-level components.
  */
 public abstract class Hooklet implements Comparable<Hooklet> {
@@ -39,16 +39,25 @@ public abstract class Hooklet implements Comparable<Hooklet> {
     public abstract void onShutdown();
 
     /**
-     * Priority value used to order execution.
-     * Lower values execute first. Suggested range is {@code 0-100}.
-     *
-     * @return integer value representing priority
+     * Hooks with lesser priority will be called before hooks with greater priority.
+     * <p>
+     * It is advised to allocate an unique priority in the range of 0-100.
+     * In general, more high level code needs to do its shutdown routines before lower level code.
+     * An example priority layout is given below:
+     * <p>
+     * 0: Run before all hooks. For test/example use.
+     * 1-49: Release of network resources and stopping distributed activity.
+     * 50-89: Release of local resources and stopping data structures.
+     * 90-99 Cleanup of file system resources such as temporary directories.
+     * 100: Run after all hooks. For test/example use.
      */
     public abstract int priority();
 
     /**
-     * Used to detect duplicates when registering with {@link PriorityHook}.
-     * The default implementation returns the runtime class of this instance.
+     * Hooks are only called once but may be registered multiple times.
+     * To determine if hook is already present, an object returned by this method is compared.
+     * <p>
+     * The default implementation returns this instance's class and should usually be sufficient.
      *
      * @return object used to identify the hooklet
      */
@@ -57,7 +66,9 @@ public abstract class Hooklet implements Comparable<Hooklet> {
     }
 
     /**
-     * Factory method for simple hooks.
+     * Accepts callback and priority to produce shutdown hook object.
+     * <p>
+     * Hook callback class is used to check for identity, see {@link #identity()}.
      *
      * @param priority value returned by {@link #priority()}
      * @param hook     action to run on shutdown

--- a/src/main/java/net/openhft/chronicle/core/shutdown/Hooklet.java
+++ b/src/main/java/net/openhft/chronicle/core/shutdown/Hooklet.java
@@ -32,7 +32,7 @@ public abstract class Hooklet implements Comparable<Hooklet> {
     /**
      * Hooks with lesser priority will be called before hooks with greater priority.
      * <p>
-     * It is advised to allocate an unique priority in the range of 0-100.
+     * It is advised to allocate a unique priority in the range of 0-100.
      * In general, more high level code needs to do its shutdown routines before lower level code.
      * An example priority layout is given below:
      * <p>

--- a/src/main/java/net/openhft/chronicle/core/shutdown/Hooklet.java
+++ b/src/main/java/net/openhft/chronicle/core/shutdown/Hooklet.java
@@ -21,51 +21,51 @@ import org.jetbrains.annotations.NotNull;
 import java.util.Objects;
 
 /**
- * A shutdown hook that allows running in controlled order.
+ * Unit of work that can be registered with {@link PriorityHook}.
+ * <p>
+ * Implementations should be effectively immutable. Registration may occur from
+ * many threads but each hooklet is executed sequentially by the shutdown
+ * thread.
+ *
+ * @apiNote Allocate unique priorities in the range {@code 0-100}. Smaller
+ * values execute first and should be used for higher-level components.
  */
 public abstract class Hooklet implements Comparable<Hooklet> {
     /**
-     * The callback which will be invoked on shutdown.
+     * Callback invoked by the shutdown thread.
+     * Implementations should return quickly and avoid long blocking
+     * operations.
      */
     public abstract void onShutdown();
 
     /**
-     * Hooks with lesser priority will be called before hooks with greater priority.
-     * <p>
-     * It is advised to allocate a unique priority in the range of 0-100.
-     * In general, more high level code needs to do its shutdown routines before lower level code.
-     * An example priority layout is given below:
-     * <p>
-     * 0: Run before all hooks. For test/example use.
-     * 1-49: Release of network resources and stopping distributed activity.
-     * 50-89: Release of local resources and stopping data structures.
-     * 90-99 Cleanup of file system resources such as temporary directories.
-     * 100: Run after all hooks. For test/example use.
+     * Priority value used to order execution.
+     * Lower values execute first. Suggested range is {@code 0-100}.
+     *
+     * @return integer value representing priority
      */
     public abstract int priority();
 
     /**
-     * Hooks are only called once but may be registered multiple times.
-     * To determine if hook is already present, an object returned by this method is compared.
-     * <p>
-     * The default implementation returns this instance's class and should usually be sufficient.
+     * Used to detect duplicates when registering with {@link PriorityHook}.
+     * The default implementation returns the runtime class of this instance.
      *
-     * @return Identity object.
+     * @return object used to identify the hooklet
      */
     protected Object identity() {
         return getClass();
     }
 
     /**
-     * Accepts callback and priority to produce shutdown hook object.
-     * <p>
-     * Hook callback class is used to check for identity, see {@link #identity()}.
+     * Factory method for simple hooks.
      *
-     * @param priority See {@link #priority()}
-     * @param hook     See {@link #onShutdown()}
-     * @return Shutdown hook object. See {@link PriorityHook#addAndGet(Hooklet)}
+     * @param priority value returned by {@link #priority()}
+     * @param hook     action to run on shutdown
+     * @return hooklet wrapping the given action
+     * @throws NullPointerException if {@code hook} is {@code null}
      */
     public static Hooklet of(int priority, Runnable hook) {
+        Objects.requireNonNull(hook);
         return new Hooklet() {
             @Override
             public void onShutdown() {
@@ -84,6 +84,12 @@ public abstract class Hooklet implements Comparable<Hooklet> {
         };
     }
 
+    /**
+     * Orders hooklets by priority then identity.
+     *
+     * @param other hooklet to compare
+     * @return negative if this should run before {@code other}
+     */
     @Override
     public int compareTo(@NotNull Hooklet other) {
         int delta = priority() - other.priority();

--- a/src/main/java/net/openhft/chronicle/core/shutdown/PriorityHook.java
+++ b/src/main/java/net/openhft/chronicle/core/shutdown/PriorityHook.java
@@ -21,7 +21,14 @@ import java.util.*;
 import static net.openhft.chronicle.core.Jvm.uncheckedCast;
 
 /**
- * Collects all hook that need to be run during shutdown to execute them in controlled order.
+ * Manager for orderly shutdown.
+ * <p>
+ * Hooklets are stored in a priority ordered map and executed by a single
+ * dedicated thread when the JVM terminates. All modifications are
+ * synchronised to make the class thread-safe.
+ *
+ * @apiNote Use unique priorities between {@code 0-100} so that unrelated
+ * components do not interfere with each other's shutdown ordering.
  */
 public class PriorityHook {
     private static PriorityHook registeredHook;
@@ -33,28 +40,27 @@ public class PriorityHook {
     }
 
     /**
-     * Add a shutdown hook with a specified priority.
-     * <p>
-     * Will prevent adding the same hook (by parameter's class) more than once, return {@code false} in that case.
+     * Convenience method for adding a simple {@link Runnable}.
      *
-     * @param priority See {@link Hooklet#priority()}
-     * @param hook     Function that needs to be run during shutdown.
-     * @return {@code true} if hook was not present and is now added
+     * @param priority value passed to {@link Hooklet#priority()}
+     * @param hook     action to run on shutdown
+     * @return {@code true} if the hook was newly registered
+     * @throws NullPointerException if {@code hook} is {@code null}
      */
     public static boolean add(int priority, Runnable hook) {
         return addAndGet(Hooklet.of(priority, hook)).equals(hook);
     }
 
     /**
-     * Add a custom shutdown hook.
-     * <p>
-     * Will prevent adding the same hook (by parameter's class) more than once, return the existing one in that case.
-     * See {@link Hooklet#identity()}.
+     * Register a custom hooklet.
      *
-     * @param hooklet Hook that needs to be run during shutdown in predictable order.
-     * @return The {@link Hooklet} instance that will be called during shutdown.
+     * @param hooklet instance to register
+     * @param <H>     hooklet subtype
+     * @return the hooklet that will be executed
+     * @throws NullPointerException if {@code hooklet} is {@code null}
      */
     public static synchronized <H extends Hooklet> H addAndGet(H hooklet) {
+        Objects.requireNonNull(hooklet);
         if (registeredHook == null) {
             registeredHook = new PriorityHook();
 
@@ -80,17 +86,28 @@ public class PriorityHook {
         return shutdownThread;
     }
 
+    /**
+     * Remove the registered JVM shutdown hook and discard all hooklets.
+     */
     public static synchronized void clear() {
         if (registeredHook != null)
             Runtime.getRuntime().removeShutdownHook(registeredHook.shutdownThread());
         registeredHook = null;
     }
 
+    /**
+     * Execute registered hooklets in priority order.
+     */
     public void onShutdown() {
         for (Hooklet hooklet : hookletPool.keySet())
             hooklet.onShutdown();
     }
 
+    /**
+     * Obtain the singleton managing the shutdown hook, if present.
+     *
+     * @return current {@code PriorityHook} instance or {@code null}
+     */
     public static PriorityHook getRegisteredHook() {
         return registeredHook;
     }

--- a/src/main/java/net/openhft/chronicle/core/shutdown/PriorityHook.java
+++ b/src/main/java/net/openhft/chronicle/core/shutdown/PriorityHook.java
@@ -27,7 +27,7 @@ import static net.openhft.chronicle.core.Jvm.uncheckedCast;
  * dedicated thread when the JVM terminates. All modifications are
  * synchronised to make the class thread-safe.
  *
- * @apiNote Use unique priorities between {@code 0-100} so that unrelated
+ * <p> Use unique priorities between {@code 0-100} so that unrelated
  * components do not interfere with each other's shutdown ordering.
  */
 public class PriorityHook {
@@ -40,7 +40,9 @@ public class PriorityHook {
     }
 
     /**
-     * Convenience method for adding a simple {@link Runnable}.
+     * Add a shutdown hook with a specified priority.
+     * <p>
+     * Will prevent adding the same hook (by parameter's class) more than once, return {@code false} in that case.
      *
      * @param priority value passed to {@link Hooklet#priority()}
      * @param hook     action to run on shutdown
@@ -52,7 +54,10 @@ public class PriorityHook {
     }
 
     /**
-     * Register a custom hooklet.
+     * Add a custom shutdown hook.
+     * <p>
+     * Will prevent adding the same hook (by parameter's class) more than once, return the existing one in that case.
+     * See {@link Hooklet#identity()}.
      *
      * @param hooklet instance to register
      * @param <H>     hooklet subtype

--- a/src/test/java/net/openhft/chronicle/core/scoped/WeakReferenceScopedResourceTest.java
+++ b/src/test/java/net/openhft/chronicle/core/scoped/WeakReferenceScopedResourceTest.java
@@ -5,8 +5,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.atomic.AtomicLong;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 class WeakReferenceScopedResourceTest {
 

--- a/src/test/java/net/openhft/chronicle/core/shutdown/PriorityHookTest.java
+++ b/src/test/java/net/openhft/chronicle/core/shutdown/PriorityHookTest.java
@@ -28,7 +28,7 @@ public class PriorityHookTest {
         PriorityHook.getRegisteredHook().onShutdown();
 
         InOrder inOrder = inOrder(hook1, hook2);
-        ((InOrder) inOrder).verify(hook1).run();
+        inOrder.verify(hook1).run();
         inOrder.verify(hook2).run();
     }
 


### PR DESCRIPTION

This PR is a documentation-focused sweep that tightens wording, clarifies contracts, and removes small glitches discovered while working on #762-#772. **No production logic is changed.**

## ✨ Highlights

| Area | Change | Why it matters |
|------|--------|----------------|
| **General clean-ups** | • Fixed typos (“an unique” → “a unique”).<br>• Updated JUnit 4 imports to JUnit 5 in tests.<br>• Removed a redundant cast in `PriorityHookTest`. | Keeps CI warnings at zero and aligns with the rest of the test-suite. |
| **`scoped` package** | • Added full class-level headers to `AbstractScopedResource`, `ScopedResource`, `ScopedThreadLocal`, `Strong/WeakReferenceScopedResource`.<br>• Introduced `package-info.java` with a runnable example and thread-confinement rules.<br>• Expanded constructor/parameter docs and clarified weak vs strong semantics. | Developers can now rely on IDE quick-docs rather than reading source. |
| **`shutdown` package** | • Re-wrote Javadoc for `Hooklet` & `PriorityHook`, detailing priority ranges, identity semantics, and thread-safety.<br>• Added null-checks in factory helper and in docs. | Makes the shutdown subsystem self-explaining and harder to misuse in multi-module deployments. |
| **`pom` helper** | • Added class header to `PomProperties` and annotated parameters as non-null. | Completes public API documentation coverage. |
| **Tests** | • Minor import / assertion updates to use `org.junit.jupiter.api.Assertions`. | Moves more tests to JUnit 5 baseline. |

