### PR TITLE
Improve event handler docs

### DIFF
--- a/src/main/java/net/openhft/chronicle/core/threads/EventHandler.java
+++ b/src/main/java/net/openhft/chronicle/core/threads/EventHandler.java
@@ -21,11 +21,20 @@ import org.jetbrains.annotations.NotNull;
 import java.io.Closeable;
 
 /**
- * Represents a handler for events within an event loop.
+ * Represents a handler for events within an {@link EventLoop}.
  * <p>
- * This interface should be implemented by classes that handle specific events within an event loop.
+ * The typical sequence of calls is:
+ * <ol>
+ *   <li>{@link #eventLoop(EventLoop)}</li>
+ *   <li>{@link #loopStarted()}</li>
+ *   <li>zero or more {@link #action()} invocations</li>
+ *   <li>{@link #loopFinished()}</li>
+ *   <li>{@link Closeable#close()}</li>
+ * </ol>
  * <p>
- * An {@code EventHandler} can be registered to an {@link EventLoop} for processing events.
+ * The {@code action()} method must be quick and non-blocking. Long running work
+ * should be delegated to a {@link HandlerPriority#BLOCKING} handler or to
+ * another executor.
  */
 @FunctionalInterface
 public interface EventHandler extends VanillaEventHandler {

--- a/src/main/java/net/openhft/chronicle/core/threads/VanillaEventHandler.java
+++ b/src/main/java/net/openhft/chronicle/core/threads/VanillaEventHandler.java
@@ -32,41 +32,17 @@ import net.openhft.chronicle.core.io.InvalidMarshallableException;
 public interface VanillaEventHandler {
 
     /**
-     * Performs an action corresponding to some amount of work and returns a boolean indicating whether
-     * it is expected that a subsequent call to this method would result in additional work being carried out.
-     * <p>
-     * This method is executed on the event loop's thread. A return value of {@code true} suggests to the event loop
-     * that this handler should be serviced again shortly. However, the exact timing depends on various factors,
-     * including the handler's priority and other activity on the event loop.
-     * <p>
-     * If an event handler returns {@code true } from action(), it biases the event loop to service the same
-     * handler again "soon". How soon depends on a variety of factors and the other work the event loop has
-     * to do across the other handlers.
-     * <p>
-     * Returning {@code true } when there is no actual work to do may waste cycles servicing a handler which has nothing
-     * to do, at the expense of stealing cycles away from other handlers.
-     * Conversely, returning {@code false} when there is work to do will effectively increase latency as the event loop
-     * will take the "false" as a hint that several other handlers can be serviced ahead of this one.
-     * <p>
-     * As a rule of thumb, an action handler should do a certain amount of work then yield/return
-     * If it knows for sure that there is remaining work to be done at the point of yielding then return {@code true}.
-     * Otherwise return {@code false} and the event loop will revisit based on the handler's priority and other work load.
-     * <p>
-     * As with a lot of scheduling approaches there's no single answer and some experimentation under typical loads
-     * would always be recommended. But the above rule of thumb is a good starting point.
-     * <p>
-     * When the event handler is not required anymore and should be removed from the event loop, the
-     * {@link InvalidEventHandlerException#reusable()} method returns a reusable pre-created
-     * InvalidEventHandlerException which can be thrown to remove the EventHandler from the EventLoop.
+     * Performs a unit of work on the event loop thread.
+     * This method should return quickly without blocking.
      *
-     * @return {@code true} if it is expected that there is more work to be done imminently; {@code false} otherwise.
-     * @throws InvalidEventHandlerException when the event handler is not required anymore and should be removed from
-     *                                      the event loop.
-     *                                      It is recommended to throw this exception if the event handler is closed.
-     *                                      The InvalidEventHandlerException.reusable() method returns a reusable, pre-created,
-     *                                      InvalidEventHandlerException that is unmodifiable and contains no stack trace.
-     *                                      See {@link InvalidEventHandlerException#reusable()}.
-     * @throws InvalidMarshallableException if there is a failure in the validation of a DTO being read or written.
+     * @implSpec Returning {@code true} biases the scheduler to call this handler again
+     *           without delay. Throwing {@link InvalidEventHandlerException#reusable()}
+     *           removes the handler from the {@link EventLoop} and must have no side
+     *           effects.
+     *
+     * @return {@code true} if more work is expected imminently; {@code false} otherwise
+     * @throws InvalidEventHandlerException to remove this handler from the event loop
+     * @throws InvalidMarshallableException if a DTO validation fails
      */
     boolean action() throws InvalidEventHandlerException, InvalidMarshallableException;
 }


### PR DESCRIPTION
## Summary
- clarify EventHandler lifecycle sequence
- stress that `action()` must be non-blocking
- document scheduler hints and removal via `InvalidEventHandlerException.reusable()`

## Testing
- `mvn -q verify` *(fails: command not found)*