### PR TITLE
Improve CleaningThread javadoc

### DIFF
--- a/src/main/java/net/openhft/chronicle/core/threads/CleaningThread.java
+++ b/src/main/java/net/openhft/chronicle/core/threads/CleaningThread.java
@@ -30,9 +30,13 @@ import static net.openhft.chronicle.core.Jvm.isResourceTracing;
 import static net.openhft.chronicle.core.Jvm.uncheckedCast;
 
 /**
- * The CleaningThread class extends the Thread class and provides functionality
- * to clean up thread-local variables when the thread completes its execution.
- * It is particularly useful for avoiding memory leaks associated with thread-local variables.
+ * Thread that clears its ThreadLocal values when finished.
+ *
+ * Threads can retain references left in their {@code ThreadLocalMap} even once
+ * the {@link ThreadLocal} instance is no longer reachable. Long-lived threads
+ * may therefore accumulate stale values and leak memory. Reflection is used to
+ * walk the map and remove any entries created by {@link CleaningThreadLocal} so
+ * they are not retained after the task completes.
  */
 public class CleaningThread extends Thread {
     private static final Field THREAD_LOCALS;
@@ -83,12 +87,16 @@ public class CleaningThread extends Thread {
     }
 
     /**
-     * Cleans up any {@link CleaningThreadLocal} associated with the given thread.
-     * This method uses reflection to find the thread locals for a thread and navigates through a
-     * {@link WeakReference} to get to its destination. Note that if a garbage collection has occurred,
-     * this method may not be able to clean up effectively.
+     * Purges all {@link CleaningThreadLocal} entries for the supplied thread.
      *
-     * @param thread The thread whose CleaningThreadLocal instances are to be cleaned up.
+     * Thread-local maps hold strong references to their values until removed. If a
+     * task discards its {@link CleaningThreadLocal} but the thread lives on, those
+     * values leak. This method walks the hidden map via reflection and removes the
+     * entries we created. If garbage collection has cleared a weak key the value
+     * cannot be located and remains until the table is resized.
+     *
+     * @param thread the thread whose {@code CleaningThreadLocal} instances are to be
+     *               cleared
      */
     public static void performCleanup(Thread thread) {
         performCleanup(thread, null);
@@ -172,8 +180,14 @@ public class CleaningThread extends Thread {
     }
 
     /**
-     * Overrides the run method to reset the thread affinity, execute the target runnable
-     * and then perform clean up of thread locals.
+     * Executes the target {@link Runnable} and then clears thread-local values.
+     *
+     * If an event loop pinned this thread to a single CPU, the affinity is
+     * reset to {@link AffinityLock#BASE_AFFINITY} before user code runs so the
+     * binding does not leak once the loop has finished.
+     *
+     * @implSpec Sub-classes overriding this method should call
+     * {@code super.run()} to retain the affinity reset and cleanup behaviour.
      */
     @Override
     public void run() {


### PR DESCRIPTION
## Summary
- clarify memory leak prevention using reflection in `CleaningThread`
- explain affinity reset and document `run()` implementation details

## Testing
- `mvn -q verify` *(fails: `mvn: command not found`)*