### PR TITLE
Clarify ThreadLocalHelper memory management

### DIFF
--- a/src/main/java/net/openhft/chronicle/core/threads/ThreadLocalHelper.java
+++ b/src/main/java/net/openhft/chronicle/core/threads/ThreadLocalHelper.java
@@ -26,10 +26,11 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 /**
- * A utility class for managing values in a {@link ThreadLocal}.
+ * Utility methods for caching values in a {@link ThreadLocal} without locking.
  * <p>
- * This class provides helper methods for fetching values from {@link ThreadLocal},
- * taking care of initializing the value if not present.
+ * Each thread keeps its own instance so no synchronisation is required. Where
+ * {@link WeakReference}s are used the value can be reclaimed once nothing else
+ * refers to it, preventing user-level leaks if the thread outlives the value.
  */
 public final class ThreadLocalHelper {
 
@@ -38,12 +39,16 @@ public final class ThreadLocalHelper {
     }
 
     /**
-     * Retrieves a thread-local weakly-referenced value, or creates a new one using a supplier if none exists.
+     * Gets a thread-local value backed by a {@link WeakReference} without locks.
+     * <p>
+     * The value is created via the supplier when absent. Storing the weak
+     * reference means it can be cleared when the caller drops the strong
+     * reference, avoiding memory leaks if the thread persists.
      *
-     * @param threadLocal The ThreadLocal object to retrieve or create a value for.
-     * @param supplier    The supplier to generate a new value if necessary.
-     * @param <T>         The type of the value.
-     * @return The retrieved or newly created value.
+     * @param threadLocal ThreadLocal storing the weak reference
+     * @param supplier    Supplier used to create the value on first access
+     * @param <T>         Type of value held
+     * @return Existing or newly created value
      */
     @NotNull
     public static <T> T getTL(@NotNull ThreadLocal<WeakReference<T>> threadLocal, @NotNull Supplier<T> supplier) {
@@ -59,12 +64,16 @@ public final class ThreadLocalHelper {
     }
 
     /**
-     * Retrieves a thread-local value, or creates a new one using a supplier if none exists.
+     * Gets a strong thread-local value without needing locks.
+     * <p>
+     * The supplier is called once per thread to create the value. The returned
+     * object remains strongly referenced by the thread until removed, so use
+     * {@link #getTL(ThreadLocal, Supplier)} if the value should be reclaimable.
      *
-     * @param threadLocal The ThreadLocal object to retrieve or create a value for.
-     * @param supplier    The supplier to generate a new value if necessary.
-     * @param <T>         The type of the value.
-     * @return The retrieved or newly created value.
+     * @param threadLocal ThreadLocal holding the value
+     * @param supplier    Supplier used to create the value when absent
+     * @param <T>         Type of value held
+     * @return Existing or newly created value
      */
     @NotNull
     public static <T> T getSTL(@NotNull ThreadLocal<T> threadLocal, @NotNull Supplier<T> supplier) {
@@ -77,14 +86,17 @@ public final class ThreadLocalHelper {
     }
 
     /**
-     * Retrieves a thread-local weakly-referenced value, or creates a new one using a function if none exists.
+     * Gets a thread-local value via a function using a {@link WeakReference}.
+     * <p>
+     * Each thread holds its own instance so no locking is needed. The supplier
+     * is invoked only when the reference is absent or has been cleared.
      *
-     * @param threadLocal The ThreadLocal object to retrieve or create a value for.
-     * @param a           The input for the function to generate a new value if necessary.
-     * @param function    The function to generate a new value if necessary.
-     * @param <T>         The type of the value.
-     * @param <A>         The type of the input to the function.
-     * @return The retrieved or newly created value.
+     * @param threadLocal ThreadLocal storing the weak reference
+     * @param a           Input passed to the constructor function
+     * @param function    Function used to create the value when required
+     * @param <T>         Type of value held
+     * @param <A>         Type of the supplied argument
+     * @return Existing or newly created value
      */
     @NotNull
     public static <T, A> T getTL(@NotNull ThreadLocal<WeakReference<T>> threadLocal, A a, @NotNull Function<A, T> function) {
@@ -92,17 +104,21 @@ public final class ThreadLocalHelper {
     }
 
     /**
-     * Retrieves a thread-local weakly-referenced value, or creates a new one using a function if none exists.
-     * Allows for the registration of the newly created weak reference in a reference queue via a registrar consumer.
+     * Gets a thread-local value via a function and records the weak reference.
+     * <p>
+     * When a new value is created the reference may be registered in the given
+     * {@code referenceQueue} using the supplied {@code registrar}. This lets a
+     * background cleaner notice when the value has been cleared and remove any
+     * associated state outside the event loop.
      *
-     * @param threadLocal     The ThreadLocal object to retrieve or create a value for.
-     * @param supplyingEntity The input for the function to generate a new value if necessary.
-     * @param constructor     The function to generate a new value if necessary.
-     * @param referenceQueue  The reference queue to register the weak reference in.
-     * @param registrar       The consumer to use for registration of the weak reference.
-     * @param <T>             The type of the value.
-     * @param <A>             The type of the input to the function.
-     * @return The retrieved or newly created value.
+     * @param threadLocal     ThreadLocal holding the weak reference
+     * @param supplyingEntity Argument passed to the constructor
+     * @param constructor     Function to create the value if required
+     * @param referenceQueue  Optional queue in which to enqueue the weak reference
+     * @param registrar       Optional consumer used to register the reference
+     * @param <T>             Type of value held
+     * @param <A>             Type of the supplied argument
+     * @return Existing or newly created value
      */
     @NotNull
     public static <T, A> T getTL(@NotNull final ThreadLocal<WeakReference<T>> threadLocal,


### PR DESCRIPTION
## Summary
- document that thread-local helpers avoid locking and can use weak references
- explain clean up via `referenceQueue` and `registrar`

## Testing
- `mvn -q verify` *(fails: mvn not found)*