### PR TITLE
Clarify autoIncrement use in tests

### DIFF
--- a/src/main/java/net/openhft/chronicle/core/time/SetTimeProvider.java
+++ b/src/main/java/net/openhft/chronicle/core/time/SetTimeProvider.java
@@ -92,7 +92,16 @@ public class SetTimeProvider extends AtomicLong implements TimeProvider {
     }
 
     /**
-     * Configures this time provider to auto-increment the time after each invocation.
+     * Enables time auto-increment after each call to {@link #currentTimeNanos()}.
+     *
+     * <p>Example usage in a JUnit test:</p>
+     * <pre>{@code
+     * SetTimeProvider tp = new SetTimeProvider("2023-01-01T00:00:00")
+     *         .autoIncrement(1, TimeUnit.MILLISECONDS);
+     * }
+     * </pre>
+     * <p>Every read of the current time now advances by one millisecond. When
+     * running tests concurrently, coordinate access to avoid unexpected jumps.</p>
      *
      * @param autoIncrement The amount of time to auto-increment after each time retrieval.
      * @param timeUnit      The time unit of the autoIncrement value.


### PR DESCRIPTION
## Summary
- document use of `autoIncrement` in `SetTimeProvider`

## Testing
- `mvn -q verify` *(fails: `mvn: command not found`)*