### PR TITLE
Document TimeProvider methods

### DIFF
--- a/src/main/java/net/openhft/chronicle/core/time/LongTime.java
+++ b/src/main/java/net/openhft/chronicle/core/time/LongTime.java
@@ -29,22 +29,58 @@ public final class LongTime {
     public static final long EPOCH_MICROS = EPOCH_MILLIS * 1000; // 1970-04-17T18:02:52.037
     public static final long EPOCH_NANOS = EPOCH_MICROS * 1000; // 1970-04-17T18:02:52.037
 
+    /**
+     * Tests whether the supplied value appears to be a second based timestamp.
+     *
+     * @param time candidate timestamp, expected to be no earlier than {@link #EPOCH_SECS}
+     * @return {@code true} if {@code time} falls between {@link #EPOCH_SECS} and {@link #MAX_SECS}
+     * @implSpec This method is thread-safe as it holds no state.
+     */
     public static boolean isSecs(long time) {
         return EPOCH_SECS <= time && time <= MAX_SECS;
     }
 
+    /**
+     * Tests whether the supplied value appears to be a millisecond based timestamp.
+     *
+     * @param time candidate timestamp, expected to be within the millisecond range
+     * @return {@code true} if {@code time} lies between {@link #EPOCH_MILLIS} and {@link #MAX_MILLIS}
+     * @implSpec This method is thread-safe as it holds no state.
+     */
     public static boolean isMillis(long time) {
         return EPOCH_MILLIS <= time && time <= MAX_MILLIS;
     }
 
+    /**
+     * Tests whether the supplied value appears to be a microsecond based timestamp.
+     *
+     * @param time candidate timestamp, expected to be within the microsecond range
+     * @return {@code true} if {@code time} lies between {@link #EPOCH_MICROS} and {@link #MAX_MICROS}
+     * @implSpec This method is thread-safe as it holds no state.
+     */
     public static boolean isMicros(long time) {
         return EPOCH_MICROS <= time && time <= MAX_MICROS;
     }
 
+    /**
+     * Tests whether the supplied value appears to be a nanosecond based timestamp.
+     *
+     * @param time candidate timestamp, expected to be at least {@link #EPOCH_NANOS}
+     * @return {@code true} if {@code time} is not less than {@link #EPOCH_NANOS}
+     * @implSpec This method is thread-safe as it holds no state.
+     */
     public static boolean isNanos(long time) {
         return EPOCH_NANOS <= time /*&& time <= MAX_NANOS*/;
     }
 
+    /**
+     * Converts the supplied time to seconds.
+     *
+     * @param time timestamp in seconds, milliseconds, microseconds or nanoseconds
+     * @return the equivalent value in seconds
+     * @implSpec This method is thread-safe as it holds no state.
+     * @implNote Values greater than {@link #MAX_NANOS} may overflow and wrap.
+     */
     public static long toSecs(long time) {
         if (time < EPOCH_MILLIS) // || time < EPOCH_SECS
             return time;
@@ -55,6 +91,14 @@ public final class LongTime {
         return time / 1000_000_000;
     }
 
+    /**
+     * Converts the supplied time to milliseconds.
+     *
+     * @param time timestamp in seconds, milliseconds, microseconds or nanoseconds
+     * @return the equivalent value in milliseconds
+     * @implSpec This method is thread-safe as it holds no state.
+     * @implNote Multiplication may overflow if {@code time} is very large.
+     */
     public static long toMillis(long time) {
         if (time < EPOCH_SECS)
             return time;
@@ -67,6 +111,14 @@ public final class LongTime {
         return time / 1000_000;
     }
 
+    /**
+     * Converts the supplied time to microseconds.
+     *
+     * @param time timestamp in seconds, milliseconds, microseconds or nanoseconds
+     * @return the equivalent value in microseconds
+     * @implSpec This method is thread-safe as it holds no state.
+     * @implNote Multiplication may overflow if {@code time} is very large.
+     */
     public static long toMicros(long time) {
         if (time < EPOCH_SECS)
             return time;
@@ -79,6 +131,14 @@ public final class LongTime {
         return time / 1_000;
     }
 
+    /**
+     * Converts the supplied time to nanoseconds.
+     *
+     * @param time timestamp in seconds, milliseconds, microseconds or nanoseconds
+     * @return the equivalent value in nanoseconds
+     * @implSpec This method is thread-safe as it holds no state.
+     * @implNote Multiplication may overflow for values approaching {@link Long#MAX_VALUE}.
+     */
     public static long toNanos(long time) {
         if (time >= EPOCH_NANOS)
             return time;

--- a/src/main/java/net/openhft/chronicle/core/time/PosixTimeProvider.java
+++ b/src/main/java/net/openhft/chronicle/core/time/PosixTimeProvider.java
@@ -36,6 +36,8 @@ public enum PosixTimeProvider implements TimeProvider {
      * Returns the current time in milliseconds using the standard Java system clock.
      *
      * @return the current time in milliseconds since the Unix epoch
+     * @implSpec Thread-safe; the method holds no state.
+     * @implNote Values may overflow after year 2262.
      */
     @Override
     public long currentTimeMillis() {
@@ -49,6 +51,8 @@ public enum PosixTimeProvider implements TimeProvider {
      *
      * @return the current time in microseconds since the Unix epoch
      * @throws IllegalStateException if the time cannot be determined or converted
+     * @implSpec Thread-safe; the method holds no state.
+     * @implNote Values may overflow after year 2262.
      */
     @Override
     public long currentTimeMicros() throws IllegalStateException {
@@ -64,6 +68,8 @@ public enum PosixTimeProvider implements TimeProvider {
      *
      * @return the current time in nanoseconds since the Unix epoch
      * @throws IllegalStateException if the native call fails
+     * @implSpec Thread-safe; the method holds no state.
+     * @implNote Values may overflow after year 2262.
      */
     @Override
     public long currentTimeNanos() {

--- a/src/main/java/net/openhft/chronicle/core/time/SetTimeProvider.java
+++ b/src/main/java/net/openhft/chronicle/core/time/SetTimeProvider.java
@@ -35,7 +35,9 @@ public class SetTimeProvider extends AtomicLong implements TimeProvider {
     private long autoIncrement = 0;
 
     /**
-     * Constructs a time provider initialized to 0 nanoseconds.
+     * Constructs a time provider initialised to zero nanoseconds.
+     *
+     * @implSpec Thread-safe via {@link AtomicLong}.
      */
     public SetTimeProvider() {
         this(0L);
@@ -44,7 +46,9 @@ public class SetTimeProvider extends AtomicLong implements TimeProvider {
     /**
      * Constructs a time provider starting at a specific time in nanoseconds.
      *
-     * @param initialNanos Initial time in nanoseconds since the epoch.
+     * @param initialNanos starting time in nanoseconds, non-negative
+     * @implSpec Thread-safe via {@link AtomicLong}.
+     * @implNote Values beyond {@code Long.MAX_VALUE} wrap due to overflow.
      */
     public SetTimeProvider(long initialNanos) {
         super(initialNanos);
@@ -53,7 +57,8 @@ public class SetTimeProvider extends AtomicLong implements TimeProvider {
     /**
      * Constructs a time provider starting at a time specified in ISO8601 format.
      *
-     * @param timestamp The initial timestamp in ISO8601 format.
+     * @param timestamp ISO8601 timestamp, not {@code null}
+     * @implSpec Thread-safe via {@link AtomicLong}.
      */
     public SetTimeProvider(String timestamp) {
         super(initialNanos(timestamp));
@@ -62,16 +67,18 @@ public class SetTimeProvider extends AtomicLong implements TimeProvider {
     /**
      * Constructs a time provider starting at a given {@link Instant}.
      *
-     * @param instant The initial time instant.
+     * @param instant initial time instant, not {@code null}
+     * @implSpec Thread-safe via {@link AtomicLong}.
      */
     public SetTimeProvider(Instant instant) {
         super(initialNanos(instant));
     }
 
     /**
-     * Constructs a time provider that starts now, using the current nanosecond time.
+     * Constructs a time provider that starts now.
      *
-     * @return A new {@code SetTimeProvider} initialized to the current time.
+     * @return a new provider initialised to the current time
+     * @implSpec Thread-safe. Each instance is independent.
      */
     public SetTimeProvider now() {
         return new SetTimeProvider(SystemTimeProvider.CLOCK.currentTimeNanos());
@@ -92,11 +99,13 @@ public class SetTimeProvider extends AtomicLong implements TimeProvider {
     }
 
     /**
-     * Configures this time provider to auto-increment the time after each invocation.
+     * Configures this provider to auto-increment after each invocation.
      *
-     * @param autoIncrement The amount of time to auto-increment after each time retrieval.
-     * @param timeUnit      The time unit of the autoIncrement value.
-     * @return The current {@code SetTimeProvider} instance for fluent method chaining.
+     * @param autoIncrement increment amount, non-negative
+     * @param timeUnit unit of {@code autoIncrement}
+     * @return this instance for chaining
+     * @implSpec Thread-safe for the time value but not for concurrent changes to {@code autoIncrement}.
+     * @implNote Overflow is unchecked and wraps.
      */
     public SetTimeProvider autoIncrement(long autoIncrement, TimeUnit timeUnit) {
         this.autoIncrement = timeUnit.toNanos(autoIncrement);
@@ -106,8 +115,10 @@ public class SetTimeProvider extends AtomicLong implements TimeProvider {
     /**
      * Explicitly sets the current time in milliseconds.
      *
-     * @param millis New time value in milliseconds since the epoch. It must not be less than the previous value.
-     * @throws IllegalArgumentException if the time is set to a value earlier than the current time.
+     * @param millis new time in milliseconds, not less than the current value
+     * @throws IllegalArgumentException if the time would go backwards
+     * @implSpec Thread-safe via {@link AtomicLong}.
+     * @implNote Overflow is unchecked.
      */
     public void currentTimeMillis(long millis) throws IllegalArgumentException {
         currentTimeNanos(TimeUnit.MILLISECONDS.toNanos(millis));
@@ -116,7 +127,9 @@ public class SetTimeProvider extends AtomicLong implements TimeProvider {
     /**
      * Retrieves the current time in milliseconds.
      *
-     * @return Current time in milliseconds since the epoch.
+     * @return the current time in milliseconds since the epoch
+     * @implSpec Thread-safe via {@link AtomicLong}.
+     * @implNote Overflow is unchecked.
      */
     @Override
     public long currentTimeMillis() {
@@ -126,8 +139,10 @@ public class SetTimeProvider extends AtomicLong implements TimeProvider {
     /**
      * Explicitly sets the current time in microseconds.
      *
-     * @param micros New time value in microseconds since the epoch. It must not be less than the previous value.
-     * @throws IllegalArgumentException if the time is set to a value earlier than the current time.
+     * @param micros new time in microseconds, not less than the current value
+     * @throws IllegalArgumentException if the time would go backwards
+     * @implSpec Thread-safe via {@link AtomicLong}.
+     * @implNote Overflow is unchecked.
      */
     public void currentTimeMicros(long micros) throws IllegalArgumentException {
         currentTimeNanos(TimeUnit.MICROSECONDS.toNanos(micros));
@@ -136,7 +151,9 @@ public class SetTimeProvider extends AtomicLong implements TimeProvider {
     /**
      * Retrieves the current time in microseconds.
      *
-     * @return Current time in microseconds since the epoch.
+     * @return the current time in microseconds since the epoch
+     * @implSpec Thread-safe via {@link AtomicLong}.
+     * @implNote Overflow is unchecked.
      */
     @Override
     public long currentTimeMicros() {
@@ -146,8 +163,10 @@ public class SetTimeProvider extends AtomicLong implements TimeProvider {
     /**
      * Explicitly sets the current time in nanoseconds.
      *
-     * @param nanos New time value in nanoseconds since the epoch. It must not be less than the previous value.
-     * @throws IllegalArgumentException if the time is set to a value earlier than the current time.
+     * @param nanos new time in nanoseconds, not less than the current value
+     * @throws IllegalArgumentException if the time would go backwards
+     * @implSpec Thread-safe via {@link AtomicLong}.
+     * @implNote Overflow is unchecked.
      */
     public void currentTimeNanos(long nanos) throws IllegalArgumentException {
         if (nanos < get())
@@ -158,7 +177,9 @@ public class SetTimeProvider extends AtomicLong implements TimeProvider {
     /**
      * Retrieves the current time in nanoseconds.
      *
-     * @return Current time in nanoseconds since the epoch.
+     * @return the current time in nanoseconds since the epoch
+     * @implSpec Thread-safe via {@link AtomicLong}.
+     * @implNote Overflow is unchecked.
      */
     @Override
     public long currentTimeNanos() {
@@ -166,10 +187,12 @@ public class SetTimeProvider extends AtomicLong implements TimeProvider {
     }
 
     /**
-     * Converts and retrieves the current time in the specified time unit.
+     * Converts and retrieves the current time in the specified unit.
      *
-     * @param unit The time unit to return the current time in.
-     * @return The current time in the specified time unit.
+     * @param unit target unit, not {@code null}
+     * @return the current time in that unit
+     * @implSpec Thread-safe via {@link AtomicLong}.
+     * @implNote Overflow is unchecked.
      */
     public long currentTime(TimeUnit unit) {
         return unit.convert(currentTimeNanos(), TimeUnit.NANOSECONDS);
@@ -178,8 +201,10 @@ public class SetTimeProvider extends AtomicLong implements TimeProvider {
     /**
      * Advances the current time by the specified duration in milliseconds.
      *
-     * @param millis The duration in milliseconds to advance the time.
-     * @return The current {@code SetTimeProvider} instance for fluent method chaining.
+     * @param millis duration to add, may be negative
+     * @return this instance for chaining
+     * @implSpec Thread-safe via {@link AtomicLong}.
+     * @implNote Overflow is unchecked.
      */
     public SetTimeProvider advanceMillis(long millis) {
         advanceNanos(TimeUnit.MILLISECONDS.toNanos(millis));
@@ -189,8 +214,10 @@ public class SetTimeProvider extends AtomicLong implements TimeProvider {
     /**
      * Advances the current time by the specified duration in microseconds.
      *
-     * @param micros The duration in microseconds to advance the time.
-     * @return The current {@code SetTimeProvider} instance for fluent method chaining.
+     * @param micros duration to add, may be negative
+     * @return this instance for chaining
+     * @implSpec Thread-safe via {@link AtomicLong}.
+     * @implNote Overflow is unchecked.
      */
     public SetTimeProvider advanceMicros(long micros) {
         advanceNanos(TimeUnit.MICROSECONDS.toNanos(micros));
@@ -200,8 +227,10 @@ public class SetTimeProvider extends AtomicLong implements TimeProvider {
     /**
      * Advances the current time by the specified duration in nanoseconds.
      *
-     * @param nanos The duration in nanoseconds to advance the time.
-     * @return The current {@code SetTimeProvider} instance for fluent method chaining.
+     * @param nanos duration to add, may be negative
+     * @return this instance for chaining
+     * @implSpec Thread-safe via {@link AtomicLong}.
+     * @implNote Overflow is unchecked.
      */
     public SetTimeProvider advanceNanos(long nanos) {
         addAndGet(nanos);
@@ -209,9 +238,10 @@ public class SetTimeProvider extends AtomicLong implements TimeProvider {
     }
 
     /**
-     * Provides a string representation of the {@code SetTimeProvider} state.
+     * Provides a string representation of the provider state.
      *
-     * @return A string representation, including the auto-increment value and current nanosecond time.
+     * @return summary of auto-increment value and current time
+     * @implSpec Thread-safe via {@link AtomicLong}.
      */
     @Override
     public String toString() {

--- a/src/main/java/net/openhft/chronicle/core/time/SystemTimeProvider.java
+++ b/src/main/java/net/openhft/chronicle/core/time/SystemTimeProvider.java
@@ -39,18 +39,36 @@ public enum SystemTimeProvider implements TimeProvider {
 
     private long delta = 0;
 
+    /**
+     * Returns the current wall-clock time in milliseconds.
+     *
+     * @return milliseconds since the Unix epoch
+     * @implSpec Thread-safe; the method holds no state.
+     * @implNote Values may overflow after year 2262.
+     */
     @Override
     public long currentTimeMillis() {
         return System.currentTimeMillis();
     }
 
+    /**
+     * Returns the current wall-clock time in microseconds.
+     *
+     * @return microseconds since the Unix epoch
+     * @implSpec Thread-safe; the method holds no state.
+     * @implNote Values may overflow after year 2262.
+     */
     @Override
     public long currentTimeMicros() {
         return currentTimeNanos() / 1000;
     }
 
     /**
-     * @return a nanosecond time stamp which is generally monotonically increasing
+     * Returns a nanosecond timestamp which is generally monotonically increasing.
+     *
+     * @return nanoseconds since the Unix epoch
+     * @implSpec Thread-safe; the method holds no state.
+     * @implNote Values may overflow after year 2262.
      */
     @Override
     public long currentTimeNanos() {

--- a/src/main/java/net/openhft/chronicle/core/time/TimeProvider.java
+++ b/src/main/java/net/openhft/chronicle/core/time/TimeProvider.java
@@ -39,10 +39,10 @@ public interface TimeProvider {
      * Retrieves the current time in milliseconds.
      * <p>
      * This method returns the current time with millisecond precision, measured from the Unix epoch
-     * (00:00:00 UTC on 1 January 1970). It is expected to be implemented by all subclasses, providing
-     * the baseline precision for time measurements.
+     * (00:00:00 UTC on 1 January 1970). Implementations must guarantee thread-safe access.
      *
      * @return the current time in milliseconds since the Unix epoch
+     * @implSpec Implementations must be thread-safe. Values may overflow after year 2262.
      */
     long currentTimeMillis();
 
@@ -53,8 +53,9 @@ public interface TimeProvider {
      * {@link #currentTimeMillis()} by a factor of 1000. Implementations may override this for higher
      * accuracy if available.
      *
-     * @return The current time in microseconds since the Unix epoch.
-     * @throws IllegalStateException if the time value cannot be accurately determined or converted.
+     * @return the current time in microseconds since the Unix epoch
+     * @throws IllegalStateException if the time value cannot be accurately determined or converted
+     * @implSpec Thread-safe if {@link #currentTimeMillis()} is thread-safe. Values may overflow after year 2262.
      */
     default long currentTimeMicros() throws IllegalStateException {
         return currentTimeMillis() * 1000;
@@ -67,8 +68,9 @@ public interface TimeProvider {
      * from {@link #currentTimeMicros()} by 1000. Implementations may provide more precise or direct
      * measurements if their underlying system supports it.
      *
-     * @return The current time in nanoseconds since the Unix epoch.
-     * @throws IllegalStateException if the time value cannot be accurately determined or converted.
+     * @return the current time in nanoseconds since the Unix epoch
+     * @throws IllegalStateException if the time value cannot be accurately determined or converted
+     * @implSpec Thread-safe if {@link #currentTimeMicros()} is thread-safe. Values may overflow after year 2262.
      */
     default long currentTimeNanos() throws IllegalStateException {
         return currentTimeMicros() * 1000;

--- a/src/main/java/net/openhft/chronicle/core/time/UniqueMicroTimeProvider.java
+++ b/src/main/java/net/openhft/chronicle/core/time/UniqueMicroTimeProvider.java
@@ -36,18 +36,22 @@ public class UniqueMicroTimeProvider implements TimeProvider {
     /**
      * Constructs a new UniqueMicroTimeProvider.
      * <p>
-     * This constructor initializes the time provider with zero. New instances are typically created for
-     * testing purposes, as this class is stateful and maintains the last time value issued.
-         */
+     * This constructor initialises the provider with zero. Instances are typically used for testing as
+     * the class maintains the last issued time.
+     *
+     * @implSpec Thread-safe via {@link AtomicLong}.
+     */
     public UniqueMicroTimeProvider() {
         // Do nothing
     }
 
     /**
-     * Sets the underlying time provider for this instance and initializes the last time value.
+     * Sets the underlying time provider for this instance and initialises the last time value.
      *
-     * @param provider The {@link TimeProvider} to use for time calculations.
-     * @return The current {@code UniqueMicroTimeProvider} instance for fluent method chaining.
+     * @param provider delegate provider, not {@code null}
+     * @return this instance for chaining
+     * @implSpec Thread-safe via {@link AtomicLong}. Changing the provider while other threads read the time
+     *           may produce non-monotonic values.
      */
     public UniqueMicroTimeProvider provider(TimeProvider provider) {
         this.provider = provider;
@@ -58,7 +62,9 @@ public class UniqueMicroTimeProvider implements TimeProvider {
     /**
      * Retrieves the current time in milliseconds, ensuring uniqueness across threads.
      *
-     * @return The current unique time in milliseconds since the epoch.
+     * @return the current unique time in milliseconds since the epoch
+     * @implSpec Thread-safe via {@link AtomicLong}. The method may spin until a unique value is obtained.
+     * @implNote Values may overflow after year 2262.
      */
     @Override
     public long currentTimeMillis() {
@@ -80,7 +86,9 @@ public class UniqueMicroTimeProvider implements TimeProvider {
      * Retrieves the current time in microseconds, ensuring uniqueness across threads.
      * It increments the time value by one microsecond if necessary to guarantee uniqueness.
      *
-     * @return The current unique time in microseconds since the epoch.
+     * @return the current unique time in microseconds since the epoch
+     * @implSpec Thread-safe via {@link AtomicLong}. The method may spin until a unique value is obtained.
+     * @implNote Values may overflow after year 2262.
      */
     @Override
     public long currentTimeMicros() {
@@ -101,7 +109,9 @@ public class UniqueMicroTimeProvider implements TimeProvider {
      * Retrieves the current time in nanoseconds, ensuring uniqueness across threads.
      * It adapts the nanosecond time based on the microsecond value to maintain unique timestamps.
      *
-     * @return The current unique time in nanoseconds since the epoch.
+     * @return the current unique time in nanoseconds since the epoch
+     * @implSpec Thread-safe via {@link AtomicLong}. The method may spin until a unique value is obtained.
+     * @implNote Values may overflow after year 2262.
      */
     @Override
     public long currentTimeNanos() {


### PR DESCRIPTION
## Summary
- clarify LongTime utility conversions
- expand PosixTimeProvider javadoc
- detail SetTimeProvider thread-safety and overflow
- describe SystemTimeProvider behaviour
- specify TimeProvider requirements
- cover UniqueMicroTimeProvider behaviour

## Testing
- `mvn -q javadoc:javadoc` *(fails: command not found)*
- `mvn -q verify` *(fails: command not found)*