### PR TITLE
Remove @since from core package overview

### DIFF
--- a/src/main/java/net/openhft/chronicle/core/package-info.java
+++ b/src/main/java/net/openhft/chronicle/core/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * Supplies low level utilities and system helpers used across the Chronicle libraries.
+ * The memory model relies on off heap allocations that are managed explicitly and
+ * sit outside the JVM garbage collector. See decision log entry CORE-OPS-002 for
+ * background on this design.
+ */
+package net.openhft.chronicle.core;


### PR DESCRIPTION
## Summary
- remove the `@since` tag from the Chronicle Core package overview

## Testing
- `mvn -q verify` *(fails: command not found)*