### PR TITLE
Update Javadocs and tidy getters

### DIFF
--- a/src/main/java/net/openhft/chronicle/core/Jvm.java
+++ b/src/main/java/net/openhft/chronicle/core/Jvm.java
@@ -399,10 +399,10 @@ public final class Jvm {
     }
 
     /**
-     * Append the provided {@code StackTraceElements} to the provided {@code stringBuilder} trimming some internal methods.
+     * Appends stack trace elements to the builder while skipping Chronicle internal frames.
      *
-     * @param stringBuilder      to append to
-     * @param stackTraceElements stack trace elements
+     * @param stringBuilder      destination for the stack trace
+     * @param stackTraceElements elements to append
      */
     public static void trimStackTrace(@NotNull final StringBuilder stringBuilder, @NotNull final StackTraceElement... stackTraceElements) {
         final int first = trimFirst(stackTraceElements);

--- a/src/main/java/net/openhft/chronicle/core/Maths.java
+++ b/src/main/java/net/openhft/chronicle/core/Maths.java
@@ -49,12 +49,12 @@ public final class Maths {
     }
 
     /**
-     * Performs a round which is accurate to within 1 ulp. i.e. for values very close to 0.5 it
-     * might be rounded up or down. This is a pragmatic choice for performance reasons as it is
-     * assumed you are not working on the edge of the precision of double.
+     * Rounds the value to a fixed number of decimal places.
+     * The result is within one ulp of the mathematical rounding and
+     * may round values very close to 0.5 either way for speed.
      *
      * @param d      value to round
-     * @param digits 0 to 18 digits of precision
+     * @param digits precision from 0 to 18 digits
      * @return rounded value
      */
     public static double roundN(double d, int digits) {
@@ -147,6 +147,14 @@ public final class Maths {
                 ? Math.floor((d + ulp) * factor) / factor : d;
     }
 
+    /**
+     * Rounds the value using a fractional number of decimal places.
+     * Behaviour matches {@link #roundN(double, int)} when {@code digits} is an integer.
+     *
+     * @param d      value to round
+     * @param digits fractional digits of precision
+     * @return rounded value
+     */
     public static double roundN(double d, double digits) {
         final long factor = roundingFactor(digits);
         return Math.abs(d) < (double) Long.MAX_VALUE / factor
@@ -182,9 +190,8 @@ public final class Maths {
     }
 
     /**
-     * Performs a round which is accurate to within 1 ulp. i.e. for values very close to 0.5 it
-     * might be rounded up or down. This is a pragmatic choice for performance reasons as it is
-     * assumed you are not working on the edge of the precision of double.
+     * Rounds to one decimal place.
+     * Accuracy is within one ulp so values close to 0.5 may round either way.
      *
      * @param d value to round
      * @return rounded value
@@ -212,9 +219,8 @@ public final class Maths {
     }
 
     /**
-     * Performs a round which is accurate to within 1 ulp. i.e. for values very close to 0.5 it
-     * might be rounded up or down. This is a pragmatic choice for performance reasons as it is
-     * assumed you are not working on the edge of the precision of double.
+     * Rounds to two decimal places.
+     * Accuracy is within one ulp so values close to 0.5 may round either way.
      *
      * @param d value to round
      * @return rounded value

--- a/src/main/java/net/openhft/chronicle/core/Memory.java
+++ b/src/main/java/net/openhft/chronicle/core/Memory.java
@@ -30,14 +30,13 @@ import java.nio.ByteBuffer;
 public interface Memory {
 
     /**
-     * Ensures that all previous writes to memory are completed before any
-     * subsequent memory access instruction.
+     * Ensures writes before the call become visible to other threads before
+     * writes that follow.
      */
     void storeFence();
 
     /**
-     * Ensures that all previous reads from memory are completed before any
-     * subsequent memory access instruction.
+     * Ensures reads after the call see updates published before the fence.
      */
     void loadFence();
 
@@ -331,52 +330,52 @@ public interface Memory {
     double readDouble(Object object, long offset);
 
     /**
-     * Copies a range of bytes from the given byte array to the specified memory address.
+     * Copies bytes from an array to a native address.
      *
-     * @param bytes   the source byte array
-     * @param offset  the starting index in the byte array
-     * @param address the destination memory address
-     * @param length  the number of bytes to copy
+     * @param bytes   source array
+     * @param offset  first byte to copy, non-negative and within {@code bytes}
+     * @param address destination address
+     * @param length  number of bytes to copy
      */
     void copyMemory(byte[] bytes, int offset, long address, int length);
 
     /**
-     * Copies a range of memory from one address to another.
+     * Copies memory from one address to another.
      *
-     * @param fromAddress the source memory address
-     * @param address     the destination memory address
-     * @param length      the number of bytes to copy
+     * @param fromAddress source address
+     * @param address     destination address
+     * @param length      number of bytes to copy
      */
     void copyMemory(long fromAddress, long address, long length);
 
     /**
-     * Copies a range of memory from the given object to the specified memory address.
+     * Copies memory from an object to a native address.
      *
-     * @param o         the source object
-     * @param offset    the starting offset in the source object
-     * @param toAddress the destination memory address
-     * @param length    the number of bytes to copy
+     * @param o         source object
+     * @param offset    start offset within {@code o}
+     * @param toAddress destination address
+     * @param length    number of bytes to copy
      */
     void copyMemory(Object o, long offset, long toAddress, int length);
 
     /**
-     * Copies a range of memory from one object to another at the specified offsets.
+     * Copies memory between two objects at the given offsets.
      *
-     * @param o       the source object
-     * @param offset  the starting offset in the source object
-     * @param o2      the destination object
-     * @param offset2 the starting offset in the destination object
-     * @param length  the number of bytes to copy
+     * @param o       source object
+     * @param offset  offset within {@code o}
+     * @param o2      destination object
+     * @param offset2 offset within {@code o2}
+     * @param length  number of bytes to copy
      */
     void copyMemory(Object o, long offset, Object o2, long offset2, int length);
 
     /**
-     * Copies a range of memory from the given memory address to the specified object at the given offset.
+     * Copies memory from a native address into an object.
      *
-     * @param fromAddress the source memory address
-     * @param obj2        the destination object
-     * @param offset2     the starting offset in the destination object
-     * @param length      the number of bytes to copy
+     * @param fromAddress source address
+     * @param obj2        destination object
+     * @param offset2     offset within {@code obj2}
+     * @param length      number of bytes to copy
      */
     void copyMemory(long fromAddress, Object obj2, long offset2, int length);
 

--- a/src/main/java/net/openhft/chronicle/core/OS.java
+++ b/src/main/java/net/openhft/chronicle/core/OS.java
@@ -502,15 +502,15 @@ public final class OS {
     }
 
     /**
-     * Map a region of a file into memory.
+     * Maps part of a file into memory.
      *
-     * @param fileChannel to map
-     * @param mode        of access
-     * @param start       offset within a file
-     * @param size        of region to map.
-     * @return the address of the memory mapping.
+     * @param fileChannel file to map
+     * @param mode        access mode
+     * @param start       start offset, page aligned
+     * @param size        length of region. On Windows this must be \<= 4096 MiB
+     * @return address of the mapping
      * @throws IOException              if the mapping fails
-     * @throws IllegalArgumentException if the arguments are not valid
+     * @throws IllegalArgumentException if the arguments are invalid
      */
     public static long map(@NotNull FileChannel fileChannel, FileChannel.MapMode mode, long start, long size, int pageSize)
             throws IOException, IllegalArgumentException {
@@ -573,11 +573,11 @@ public final class OS {
     }
 
     /**
-     * Unmap a region of memory.
+     * Releases a previously mapped memory region.
      *
-     * @param address of the start of the mapping.
-     * @param size    of the region mapped.
-     * @throws IOException if the unmap fails.
+     * @param address start of the mapping, page aligned
+     * @param size    length of the region
+     * @throws IOException if the unmap fails
      */
     public static void unmap(long address, long size, int pageSize) throws IOException {
         try {
@@ -595,9 +595,9 @@ public final class OS {
     }
 
     /**
-     * Returns the number of bytes that is memory mapped.
+     * Reports how many bytes are currently mapped using {@link #map}.
      *
-     * @return bytes memory mapped
+     * @return number of bytes mapped
      */
     public static long memoryMapped() {
         return memoryMapped.get();

--- a/src/main/java/net/openhft/chronicle/core/util/Histogram.java
+++ b/src/main/java/net/openhft/chronicle/core/util/Histogram.java
@@ -171,36 +171,28 @@ public class Histogram implements NanoSampler {
     }
 
     /**
-     * Gets the number of fraction bits used by the histogram.
-     *
-     * @return the number of fraction bits
+     * Returns the fractional precision used to subdivide each power-of-two bucket.
      */
     public int fractionBits() {
         return fractionBits;
     }
 
     /**
-     * Gets the number of powers of 2 used by the histogram.
-     *
-     * @return the number of powers of 2
+     * Returns the exponent controlling the number of power-of-two buckets.
      */
     public int powersOf2() {
         return powersOf2;
     }
 
     /**
-     * Gets the number of values that are over the range of the histogram's buckets.
-     *
-     * @return the over range count
+     * Returns how many samples exceeded the top bucket.
      */
     public long overRange() {
         return overRange;
     }
 
     /**
-     * Gets the array of sample counts per bucket.
-     *
-     * @return the array of sample counts
+     * Provides direct access to the bucket counters.
      */
     public int[] sampleCount() {
         return sampleCount;


### PR DESCRIPTION
## Summary
- improve summary wording for memory fences
- document copyMemory overloads more clearly
- clarify rounding helpers in `Maths`
- tidy up mapping helpers in `OS`
- document stack trace trimming
- update Histogram getter comments

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*