### PR TITLE
Improve Javadoc

### DIFF
--- a/src/main/java/net/openhft/chronicle/core/Jvm.java
+++ b/src/main/java/net/openhft/chronicle/core/Jvm.java
@@ -928,7 +928,7 @@ public final class Jvm {
     }
 
     /**
-     * Inserts a low-cost Java safe-point in the code path if -Djvm.safepoint.enabled
+     * Inserts a low-cost Java safepoint when the {@code jvm.safepoint.enabled} property is set.
      */
     public static void safepoint() {
         if (SAFEPOINT_ENABLED) {

--- a/src/main/java/net/openhft/chronicle/core/StackTrace.java
+++ b/src/main/java/net/openhft/chronicle/core/StackTrace.java
@@ -74,16 +74,14 @@ public class StackTrace extends Throwable {
     private static final int NANOS_PER_MILLI = 1_000_000;
 
     /**
-     * Constructs a new {@code StackTrace} for the current thread with the
-     * default message "stack trace".
+     * Creates a stack trace for the current thread using the message "stack trace".
      */
     public StackTrace() {
         this("stack trace", false);
     }
 
     /**
-     * Constructs a new {@code StackTrace} for the current thread with the
-     * default message "stack trace", optionally including a timestamp in the stack trace message.
+     * Creates a stack trace for the current thread using the message "stack trace" and optionally adds a timestamp.
      *
      * @param addTimestamp whether to add a timestamp to the stack trace message
      */
@@ -92,38 +90,38 @@ public class StackTrace extends Throwable {
     }
 
     /**
-     * Constructs a new {@code StackTrace} for the current thread with the specified message.
+     * Creates a stack trace for the current thread with the specified message.
      *
-     * @param message the detail message for this stack trace.
+     * @param message the detail message for this stack trace
      */
     public StackTrace(String message) {
         this(message, null);
     }
 
     /**
-     * Constructs a new {@code StackTrace} for the current thread with the specified message, optionally including a timestamp in the stack trace message.
+     * Creates a stack trace for the current thread with the specified message and an optional timestamp.
      *
-     * @param message the detail message for this stack trace.
-     * @param addTimestamp whether to add a timestamp to the stack trace message*
+     * @param message      the detail message for this stack trace
+     * @param addTimestamp whether to add a timestamp to the stack trace message
      */
     public StackTrace(String message, boolean addTimestamp) { this(message, null, addTimestamp); }
 
 
     /**
-     * Constructs a new {@code StackTrace} with the specified message and cause.
+     * Creates a stack trace with the specified message and cause.
      *
-     * @param message the detail message for this stack trace.
-     * @param cause   the cause of this stack trace, or {@code null} if the cause is unknown or nonexistent.
+     * @param message the detail message for this stack trace
+     * @param cause   the underlying cause, or {@code null} if unknown
      */
     public StackTrace(String message, Throwable cause) {
         this(message, cause, false);
     }
 
     /**
-     * Constructs a new {@code StackTrace} with the specified message and cause, optionally including a timestamp in the stack trace message.
+     * Creates a stack trace with the specified message and cause and can add a timestamp.
      *
-     * @param message the detail message for this stack trace.
-     * @param cause   the cause of this stack trace, or {@code null} if the cause is unknown or nonexistent.
+     * @param message      the detail message for this stack trace
+     * @param cause        the underlying cause, or {@code null} if unknown
      * @param addTimestamp whether to add a timestamp to the stack trace message
      */
     public StackTrace(String message, Throwable cause, boolean addTimestamp) {

--- a/src/main/java/net/openhft/chronicle/core/util/Histogram.java
+++ b/src/main/java/net/openhft/chronicle/core/util/Histogram.java
@@ -170,16 +170,10 @@ public class Histogram implements NanoSampler {
             sampleCount = new int[minSampleCountLength];
     }
 
-    /**
-     * Returns the fractional precision used to subdivide each power-of-two bucket.
-     */
     public int fractionBits() {
         return fractionBits;
     }
 
-    /**
-     * Returns the exponent controlling the number of power-of-two buckets.
-     */
     public int powersOf2() {
         return powersOf2;
     }
@@ -191,9 +185,6 @@ public class Histogram implements NanoSampler {
         return overRange;
     }
 
-    /**
-     * Provides direct access to the bucket counters.
-     */
     public int[] sampleCount() {
         return sampleCount;
     }


### PR DESCRIPTION
## Summary
- adjust StackTrace constructors' JavaDoc
- clean up safepoint JavaDoc
- remove trivial JavaDoc from Histogram getters

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*