### PR TITLE
Implement mmap directory whitelist

### DIFF
--- a/src/main/adoc/memory-management-guide.adoc
+++ b/src/main/adoc/memory-management-guide.adoc
@@ -105,6 +105,7 @@ Useful for diagnosing leaks of mapped regions.
 
 * The system property `chronicle.core.mmap.allowedDirs` can be set to a comma-separated list of directory paths.
 * If this property is set, `OS.map()` will only allow mapping files located within these whitelisted directories, throwing a `SecurityException` otherwise.
+* When the property is absent or empty, mapping is unrestricted (current behaviour).
 This helps mitigate potential path traversal vulnerabilities.
 
 == 3. Page Alignment

--- a/src/main/java/net/openhft/chronicle/core/OS.java
+++ b/src/main/java/net/openhft/chronicle/core/OS.java
@@ -35,6 +35,8 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.nio.channels.FileChannel;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.security.SecureRandom;
 import java.util.Scanner;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -71,6 +73,9 @@ public final class OS {
     private static final String USER_DIR = Jvm.getProperty("user.dir");
     public static final String TMP = findTmp();
     private static final Field FD_FIELD = Jvm.getField(FileChannelImpl.class, "fd");
+    private static final Field PATH_FIELD = Jvm.getFieldOrNull(FileChannelImpl.class, "path");
+    private static final String MMAP_ALLOWED_DIRS_PROP = "chronicle.core.mmap.allowedDirs";
+    private static final Path[] MMAP_ALLOWED_DIRS;
     private static final String TARGET = findTarget();
     private static final String USER_NAME = Jvm.getProperty("user.name");
     private static final int MAP_RO = 0;
@@ -108,6 +113,16 @@ public final class OS {
             final WriteZero wz = new WriteZero(fdi);
             WRITE0_MH = wz.write0Mh;
             WRITE0_MH2 = wz.write0Mh2;
+
+            String allowed = Jvm.getProperty(MMAP_ALLOWED_DIRS_PROP);
+            if (allowed == null || allowed.trim().isEmpty()) {
+                MMAP_ALLOWED_DIRS = null;
+            } else {
+                String[] parts = allowed.split(",");
+                MMAP_ALLOWED_DIRS = new Path[parts.length];
+                for (int i = 0; i < parts.length; i++)
+                    MMAP_ALLOWED_DIRS[i] = Paths.get(parts[i].trim()).toAbsolutePath().normalize();
+            }
 
             TIME_LIMIT.setStackTrace(new StackTraceElement[0]);
 
@@ -514,6 +529,7 @@ public final class OS {
      */
     public static long map(@NotNull FileChannel fileChannel, FileChannel.MapMode mode, long start, long size, int pageSize)
             throws IOException, IllegalArgumentException {
+        enforceMMapWhitelist(fileChannel);
         if (isWindows() && size > 4L << 30)
             throw new IllegalArgumentException("Mapping more than 4096 MiB is unusable on Windows, size = " + (size >> 20) + " MiB");
         final long address = map0(fileChannel, imodeFor(mode), mapAlign(start, pageSize), pageAlign(size, pageSize));
@@ -610,6 +626,25 @@ public final class OS {
         if (e instanceof IOException)
             return (IOException) e;
         return new IOException(e);
+    }
+
+    private static void enforceMMapWhitelist(FileChannel fileChannel) {
+        if (MMAP_ALLOWED_DIRS == null)
+            return;
+        if (PATH_FIELD == null)
+            throw new SecurityException("Cannot verify mapping directory");
+        try {
+            String pathStr = (String) PATH_FIELD.get(fileChannel);
+            if (pathStr == null)
+                throw new SecurityException("Unknown mapping path");
+            Path filePath = Paths.get(pathStr).toAbsolutePath().normalize();
+            for (Path dir : MMAP_ALLOWED_DIRS)
+                if (filePath.startsWith(dir))
+                    return;
+        } catch (IllegalAccessException e) {
+            throw new SecurityException("Cannot access mapping path", e);
+        }
+        throw new SecurityException("Mapping outside whitelisted directories: " + fileChannel);
     }
 
     static int imodeFor(FileChannel.MapMode mode) {

--- a/systemProperties.adoc
+++ b/systemProperties.adoc
@@ -45,7 +45,7 @@ Any other value is treated as `false`.
 | `reference.warn.count` | `Integer.MAX_VALUE` | Emit a warning once the reference count reaches this level. | integer | `WARN_COUNT`
 | `reference.warn.secs` | `0.003` | Threshold before warning about slow release. | decimal seconds | `WARN_NS`
 | `warnAndCloseIfNotClosed` | `true` | Automatically close leaked resources at shutdown. | boolean | -
-| `chronicle.core.mmap.allowedDirs` | | Whitelist of directories for memory mapping. | comma-separated paths | -
+| `chronicle.core.mmap.allowedDirs` | | Whitelist of directories for memory mapping. | comma-separated paths (empty = unrestricted) | -
 | `system.properties` | `system.properties` | External file to load system properties. | file path | `SYSTEM_PROPERTIES`
 | `chronicle.stringBuilderPool.instancesPerThread` | `4` | Size of the per-thread `StringBuilder` pool. | integer | `DEFAULT_STRING_BUILDER_POOL_SIZE_PER_THREAD`
 |===


### PR DESCRIPTION
## Summary
- add optional whitelist for mmap directories
- document that absence of property leaves behaviour unchanged

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f032de5c48329a77718ba253911f1