### PR TITLE
 minimizes the need for explicit `--add-opens` flags when running on Java 9+

### DIFF
--- a/src/main/java/net/openhft/chronicle/core/Jvm.java
+++ b/src/main/java/net/openhft/chronicle/core/Jvm.java
@@ -60,6 +60,7 @@ import java.util.function.Supplier;
 import static java.lang.Runtime.getRuntime;
 import static java.lang.management.ManagementFactory.getRuntimeMXBean;
 import static java.util.stream.Collectors.toList;
+import static net.openhft.chronicle.core.Jvm.MaxMemoryHolder.MAX_DIRECT_MEMORY;
 import static net.openhft.chronicle.core.OS.*;
 import static net.openhft.chronicle.core.UnsafeMemory.UNSAFE;
 import static net.openhft.chronicle.core.internal.Bootstrap.*;
@@ -87,7 +88,6 @@ public final class Jvm {
     private static final boolean IS_COVERAGE = INPUT_ARGUMENTS2.contains("coverage");
     private static final int COMPILE_THRESHOLD = getCompileThreshold0();
     private static final boolean REPORT_UNOPTIMISED;
-    private static final Supplier<Long> reservedMemory;
     private static final boolean DISABLE_DEBUG = Jvm.getBoolean("disable.debug.info");
     @NotNull
     private static final ThreadLocalisedExceptionHandler ERROR = new ThreadLocalisedExceptionHandler(DEFAULT_ERROR_EXCEPTION_HANDLER);
@@ -97,7 +97,6 @@ public final class Jvm {
     private static final ThreadLocalisedExceptionHandler PERF = new ThreadLocalisedExceptionHandler(DEFAULT_PERF_EXCEPTION_HANDLER);
     @NotNull
     private static final ExceptionHandler DEBUG;
-    private static final long MAX_DIRECT_MEMORY;
     private static final boolean SAFEPOINT_ENABLED;
     private static final Map<Class<?>, ClassMetrics> CLASS_METRICS_MAP = new ConcurrentHashMap<>();
     private static final Map<Class<?>, Integer> PRIMITIVE_SIZE = ofUnmodifiable(
@@ -142,25 +141,6 @@ public final class Jvm {
 
         findAndLoadSystemProperties();
 
-        MAX_DIRECT_MEMORY = maxDirectMemory0();
-
-        Supplier<Long> reservedMemoryGetter;
-        try {
-            final Class<?> bitsClass = Class.forName("java.nio.Bits");
-            final Field firstTry = getFieldOrNull(bitsClass, "reservedMemory");
-            final Field f = firstTry != null ? firstTry : getField(bitsClass, "RESERVED_MEMORY");
-            if (f.getType() == AtomicLong.class) {
-                AtomicLong reservedMemory = (AtomicLong) f.get(null);
-                reservedMemoryGetter = reservedMemory::get;
-            } else {
-                reservedMemoryGetter = ThrowingSupplier.asSupplier(() -> f.getLong(null));
-            }
-        } catch (Exception e) {
-            if (MAX_DIRECT_MEMORY > 0)
-                System.err.println(Jvm.class.getName() + ": Unable to determine the reservedMemory value, will always report 0");
-            reservedMemoryGetter = () -> 0L;
-        }
-        reservedMemory = reservedMemoryGetter;
         signalHandlerGlobal = new ChainedSignalHandler();
 
         onSpinWaitMH = getOnSpinWait();
@@ -539,7 +519,7 @@ public final class Jvm {
     // Todo: Should not throw an AssertionError but rather a RuntimeException
     @NotNull
     public static Field getField(@NotNull final Class<?> clazz, @NotNull final String fieldName) {
-        return ClassUtil.getField0(clazz, fieldName, true);
+        return ClassUtil.getField0(clazz, fieldName, true, true);
     }
 
     /**
@@ -553,7 +533,7 @@ public final class Jvm {
      */
     @Nullable
     public static Field getFieldOrNull(@NotNull final Class<?> clazz, @NotNull final String fieldName) {
-        return ClassUtil.getField0(clazz, fieldName, false);
+        return ClassUtil.getField0(clazz, fieldName, false, true);
     }
 
     /**
@@ -662,7 +642,7 @@ public final class Jvm {
      * or 0 if the value cannot be determined
      */
     public static long usedDirectMemory() {
-        return reservedMemory.get();
+        return ReserveMemoryHolder.reservedMemory.get();
     }
 
     /**
@@ -1710,5 +1690,31 @@ public final class Jvm {
             }
         }
         return false;
+    }
+
+    static class ReserveMemoryHolder {
+        static final Supplier<Long> reservedMemory;
+        static {
+            Supplier<Long> reservedMemoryGetter;
+            try {
+                final Class<?> bitsClass = Class.forName("java.nio.Bits");
+                final Field firstTry = getFieldOrNull(bitsClass, "reservedMemory");
+                final Field f = firstTry != null ? firstTry : getField(bitsClass, "RESERVED_MEMORY");
+                if (f.getType() == AtomicLong.class) {
+                    AtomicLong reservedMemory = (AtomicLong) f.get(null);
+                    reservedMemoryGetter = reservedMemory::get;
+                } else {
+                    reservedMemoryGetter = ThrowingSupplier.asSupplier(() -> f.getLong(null));
+                }
+            } catch (Exception e) {
+                if (MAX_DIRECT_MEMORY > 0)
+                    System.err.println(Jvm.class.getName() + ": Unable to determine the reservedMemory value, will always report 0");
+                reservedMemoryGetter = () -> 0L;
+            }
+            reservedMemory = reservedMemoryGetter;
+        }
+    }
+    static class MaxMemoryHolder {
+        static final long MAX_DIRECT_MEMORY = maxDirectMemory();
     }
 }

--- a/src/main/java/net/openhft/chronicle/core/Jvm.java
+++ b/src/main/java/net/openhft/chronicle/core/Jvm.java
@@ -624,6 +624,7 @@ public final class Jvm {
      * @param fieldName the name of the field
      * @return the offset
      */
+    @SuppressWarnings("deprecation")
     public static long fieldOffset(final Class<?> clazz, final String fieldName) {
         try {
             return UNSAFE.objectFieldOffset(clazz.getDeclaredField(fieldName));
@@ -1384,6 +1385,7 @@ public final class Jvm {
         throw new UnsupportedOperationException("Not supported on this OS");
     }
 
+    @SuppressWarnings("deprecation")
     private static boolean isProcessAlive0(final long pid, final String command) {
 
         try {
@@ -1570,7 +1572,7 @@ public final class Jvm {
      * @param clazz the class whose package name is to be determined
      * @return the package name of the specified class
      */
-    public static String getPackageName(Class clazz) {
+    public static String getPackageName(Class<?> clazz) {
         return PackageNameUtil.getPackageName(clazz);
     }
 
@@ -1715,6 +1717,6 @@ public final class Jvm {
         }
     }
     static class MaxMemoryHolder {
-        static final long MAX_DIRECT_MEMORY = maxDirectMemory();
+        static final long MAX_DIRECT_MEMORY = maxDirectMemory0();
     }
 }

--- a/src/main/java/net/openhft/chronicle/core/Jvm.java
+++ b/src/main/java/net/openhft/chronicle/core/Jvm.java
@@ -156,7 +156,8 @@ public final class Jvm {
                 reservedMemoryGetter = ThrowingSupplier.asSupplier(() -> f.getLong(null));
             }
         } catch (Exception e) {
-            System.err.println(Jvm.class.getName() + ": Unable to determine the reservedMemory value, will always report 0");
+            if (MAX_DIRECT_MEMORY > 0)
+                System.err.println(Jvm.class.getName() + ": Unable to determine the reservedMemory value, will always report 0");
             reservedMemoryGetter = () -> 0L;
         }
         reservedMemory = reservedMemoryGetter;
@@ -908,7 +909,7 @@ public final class Jvm {
         } catch (Exception e) {
             // ignore
         }
-        System.err.println(Jvm.class.getName() + ": Unable to determine max direct memory");
+        System.err.println(Jvm.class.getName() + ": Unable to determine max direct memory, will always report 0");
         return 0L;
     }
 

--- a/src/main/java/net/openhft/chronicle/core/OS.java
+++ b/src/main/java/net/openhft/chronicle/core/OS.java
@@ -759,6 +759,7 @@ public final class OS {
             }
         }
 
+        @SuppressWarnings("deprecation")
         static String execHostname() throws IOException {
             try (BufferedReader br = new BufferedReader(
                     new InputStreamReader(

--- a/src/main/java/net/openhft/chronicle/core/OS.java
+++ b/src/main/java/net/openhft/chronicle/core/OS.java
@@ -19,10 +19,12 @@
 package net.openhft.chronicle.core;
 
 import net.openhft.chronicle.core.internal.Bootstrap;
+import net.openhft.chronicle.core.io.IORuntimeException;
 import net.openhft.chronicle.core.util.ClassLocal;
 import net.openhft.chronicle.core.util.ThrowingFunction;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.slf4j.LoggerFactory;
 import sun.nio.ch.FileChannelImpl;
 
 import javax.naming.TimeLimitExceededException;
@@ -43,7 +45,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static java.lang.management.ManagementFactory.getRuntimeMXBean;
-import static net.openhft.chronicle.core.util.Longs.*;
+import static net.openhft.chronicle.core.util.Longs.requireNonNegative;
+import static net.openhft.chronicle.core.util.Longs.requirePositive;
 
 /**
  * Low level access to OS class. The OS class provides utility methods related to the operating system.
@@ -72,7 +75,6 @@ public final class OS {
     });
     private static final String USER_DIR = Jvm.getProperty("user.dir");
     public static final String TMP = findTmp();
-    private static final Field FD_FIELD = Jvm.getField(FileChannelImpl.class, "fd");
     private static final String TARGET = findTarget();
     private static final String USER_NAME = Jvm.getProperty("user.name");
     private static final int MAP_RO = 0;
@@ -81,10 +83,6 @@ public final class OS {
     private static final boolean IS64BIT = is64Bit0();
     private static final AtomicInteger PROCESS_ID = new AtomicInteger();
     private static final AtomicLong memoryMapped = new AtomicLong();
-    private static final MethodHandle UNMAPP0_MH;
-    private static final MethodHandle READ0_MH;
-    private static final MethodHandle WRITE0_MH;
-    private static final MethodHandle WRITE0_MH2;
     private static final String PROC_SELF = "/proc/self";
     private static final String PROC_SYS_KERNEL_PID_MAX = "/proc/sys/kernel/pid_max";
     private static int pageSize; // avoid circular initialisation
@@ -93,29 +91,7 @@ public final class OS {
     static {
         // make sure it is initialised first.
         Jvm.debug();
-        try {
-            Method unmap0;
-            if (Jvm.isJava20Plus()) {
-                Class<?> dispatcherClass = OS.isWindows() ? findClass("sun.nio.ch.FileDispatcherImpl") : findClass("sun.nio.ch.UnixFileDispatcherImpl");
-                unmap0 = Jvm.getMethod(dispatcherClass, "unmap0", long.class, long.class);
-            } else {
-                unmap0 = Jvm.getMethod(FileChannelImpl.class, "unmap0", long.class, long.class);
-            }
-            UNMAPP0_MH = MethodHandles.lookup().unreflect(unmap0);
-
-            Class<?> fdi = Class.forName("sun.nio.ch.FileDispatcherImpl");
-            Method read0 = Jvm.getMethod(fdi, "read0", FileDescriptor.class, long.class, int.class);
-            READ0_MH = MethodHandles.lookup().unreflect(read0);
-
-            final WriteZero wz = new WriteZero(fdi);
-            WRITE0_MH = wz.write0Mh;
-            WRITE0_MH2 = wz.write0Mh2;
-
-            TIME_LIMIT.setStackTrace(new StackTraceElement[0]);
-
-        } catch (IllegalAccessException | ClassNotFoundException e) {
-            throw new AssertionError(e);
-        }
+        TIME_LIMIT.setStackTrace(new StackTraceElement[0]);
     }
 
     // Suppresses default constructor, ensuring non-instantiability.
@@ -286,6 +262,7 @@ public final class OS {
     public static String getUserDir() {
         return USER_DIR;
     }
+
     /**
      * @return native memory accessor class
      */
@@ -337,6 +314,7 @@ public final class OS {
         // c.f. https://docs.microsoft.com/en-us/windows/win32/memory/creating-a-view-within-a-file
         return isWindows() ? SAFE_PAGE_SIZE : pageSize();
     }
+
     /**
      * Aligns the specified offset for a memory-mapped file based on the operating system's page size.
      * Memory mapping typically requires that the offset be aligned to the operating system's page size.
@@ -411,7 +389,6 @@ public final class OS {
      *
      * <p>
      * Note: Getting the process ID may be slow if the reserve DNS is not set up correctly.
-     * 
      *
      * @return the process ID
      */
@@ -540,10 +517,10 @@ public final class OS {
             // For now, access is assumed to be non-synchronous
             // TODO - Support passing/deducing synchronous flag externally
             if (Jvm.isJava20Plus()) {
-                final FileDescriptor fd = (FileDescriptor) FD_FIELD.get(fileChannel);
+                final FileDescriptor fd = (FileDescriptor) getFdField().get(fileChannel);
                 return (long) map0.invokeExact(fd, imode, start, size, false);
             } else if (Jvm.isJava19Plus()) {
-                final FileDescriptor fd = (FileDescriptor) FD_FIELD.get(fileChannel);
+                final FileDescriptor fd = (FileDescriptor) getFdField().get(fileChannel);
                 return (long) map0.invokeExact((FileChannelImpl) fileChannel, fd, imode, start, size, false);
             } else if (Jvm.isJava14Plus())
                 return (long) map0.invokeExact((FileChannelImpl) fileChannel, imode, start, size, false);
@@ -558,6 +535,10 @@ public final class OS {
         } catch (Throwable e) {
             throw new IOException(e);
         }
+    }
+
+    private static Field getFdField() {
+        return FDFieldHolder.FD_FIELD;
     }
 
     static long map0(@NotNull FileChannel fileChannel, int imode, long start, long size) throws IOException {
@@ -585,11 +566,15 @@ public final class OS {
         try {
             final long size2 = pageAlign(size, pageSize);
             // n must be used here
-            final int n = (int) UNMAPP0_MH.invokeExact(address, size2);
+            final int n = (int) getUnmapp0Mh().invokeExact(address, size2);
             memoryMapped.addAndGet(-size2);
         } catch (Throwable e) {
             throw asAnIOException(e);
         }
+    }
+
+    private static MethodHandle getUnmapp0Mh() {
+        return Unmapp0Holder.UNMAPP0_MH;
     }
 
     public static void unmap(long address, long size) throws IOException {
@@ -673,7 +658,7 @@ public final class OS {
 
     public static int read0(FileDescriptor fd, long address, int len) throws IOException {
         try {
-            return (int) READ0_MH.invokeExact(fd, address, len);
+            return (int) getRead0Mh().invokeExact(fd, address, len);
         } catch (IOException ioe) {
             throw ioe;
         } catch (Throwable e) {
@@ -681,12 +666,16 @@ public final class OS {
         }
     }
 
+    private static MethodHandle getRead0Mh() {
+        return Read0Holder.READ0_MH;
+    }
+
     public static int write0(FileDescriptor fd, long address, int len) throws IOException {
         try {
-            if (WRITE0_MH2 == null)
-                return (int) WRITE0_MH.invokeExact(fd, address, len);
+            if (Write0Holder.WRITE0_MH2 == null)
+                return (int) Write0Holder.WRITE0_MH.invokeExact(fd, address, len);
             else
-                return (int) WRITE0_MH2.invokeExact(fd, address, len, false);
+                return (int) Write0Holder.WRITE0_MH2.invokeExact(fd, address, len, false);
         } catch (IOException ioe) {
             throw ioe;
         } catch (Throwable e) {
@@ -696,21 +685,6 @@ public final class OS {
 
     private static boolean isSet(String s) {
         return !(s == null || s.isEmpty());
-    }
-
-    private static final class WriteZero {
-        private MethodHandle write0Mh = null;
-        private MethodHandle write0Mh2 = null;
-
-        public WriteZero(final Class<?> fdi) throws IllegalAccessException {
-            try {
-                Method write0 = Jvm.getMethod(fdi, "write0", FileDescriptor.class, long.class, int.class);
-                write0Mh = MethodHandles.lookup().unreflect(write0);
-            } catch (AssertionError ae) {
-                Method write0 = Jvm.getMethod(fdi, "write0", FileDescriptor.class, long.class, int.class, boolean.class);
-                write0Mh2 = MethodHandles.lookup().unreflect(write0);
-            }
-        }
     }
 
     static class IPAddressHolder {
@@ -792,6 +766,64 @@ public final class OS {
                                     .getInputStream()))) {
                 return br.readLine();
             }
+        }
+    }
+
+    static class FDFieldHolder {
+        static final Field FD_FIELD = Jvm.getField(FileChannelImpl.class, "fd");
+    }
+
+    static class Unmapp0Holder {
+        static final MethodHandle UNMAPP0_MH;
+
+        static {
+            Method unmap0;
+            if (Jvm.isJava20Plus()) {
+                Class<?> dispatcherClass = OS.isWindows() ? findClass("sun.nio.ch.FileDispatcherImpl") : findClass("sun.nio.ch.UnixFileDispatcherImpl");
+                unmap0 = Jvm.getMethod(dispatcherClass, "unmap0", long.class, long.class);
+            } else {
+                unmap0 = Jvm.getMethod(FileChannelImpl.class, "unmap0", long.class, long.class);
+            }
+            try {
+                UNMAPP0_MH = MethodHandles.lookup().unreflect(unmap0);
+            } catch (IllegalAccessException e) {
+                throw new IORuntimeException(e);
+            }
+        }
+    }
+
+    static class Read0Holder {
+        static final MethodHandle READ0_MH;
+        static {
+            try {
+                Class<?> fdi = Class.forName("sun.nio.ch.FileDispatcherImpl");
+                Method read0 = Jvm.getMethod(fdi, "read0", FileDescriptor.class, long.class, int.class);
+                READ0_MH = MethodHandles.lookup().unreflect(read0);
+            } catch (Throwable t) {
+                throw new IORuntimeException(t);
+            }
+        }
+    }
+
+    static class Write0Holder {
+        static final MethodHandle WRITE0_MH;
+        static final MethodHandle WRITE0_MH2;
+        static {
+            MethodHandle write0Mh = null, write0Mh2 = null;
+            try {
+                Class<?> fdi = Class.forName("sun.nio.ch.FileDispatcherImpl");
+                try {
+                    Method write0 = Jvm.getMethod(fdi, "write0", FileDescriptor.class, long.class, int.class);
+                    write0Mh = MethodHandles.lookup().unreflect(write0);
+                } catch (AssertionError ae) {
+                    Method write0 = Jvm.getMethod(fdi, "write0", FileDescriptor.class, long.class, int.class, boolean.class);
+                    write0Mh2 = MethodHandles.lookup().unreflect(write0);
+                }
+            } catch (Throwable t) {
+                throw new IORuntimeException(t);
+            }
+            WRITE0_MH = write0Mh;
+            WRITE0_MH2 = write0Mh2;
         }
     }
 }

--- a/src/main/java/net/openhft/chronicle/core/StackTrace.java
+++ b/src/main/java/net/openhft/chronicle/core/StackTrace.java
@@ -189,6 +189,7 @@ public class StackTrace extends Throwable {
          * @param message the detail message for this stack trace.
          * @param stackTrace the stack trace elements for this stack trace.
          */
+        @SuppressWarnings("this-escape")
         public Less(String message, StackTraceElement[] stackTrace) {
             this(message);
             setStackTrace(stackTrace);

--- a/src/main/java/net/openhft/chronicle/core/UnsafeMemory.java
+++ b/src/main/java/net/openhft/chronicle/core/UnsafeMemory.java
@@ -524,6 +524,7 @@ public class UnsafeMemory implements Memory {
      * @param field the field whose offset should be fetched.
      * @return the offset of the field.
      */
+    @SuppressWarnings("deprecation")
     public static long unsafeObjectFieldOffset(Field field) {
         assert SKIP_ASSERTIONS || field != null;
         return UNSAFE.objectFieldOffset(field);
@@ -552,6 +553,7 @@ public class UnsafeMemory implements Memory {
      * @param field the field whose offset should be fetched.
      * @return the offset of the field.
      */
+    @SuppressWarnings("deprecation")
     @Override
     public long getFieldOffset(Field field) {
         assert SKIP_ASSERTIONS || field != null;
@@ -2279,6 +2281,7 @@ public class UnsafeMemory implements Memory {
      * @param field the field object.
      * @return the offset of the field.
      */
+    @SuppressWarnings("deprecation")
     @Override
     public long objectFieldOffset(Field field) {
         return UNSAFE.objectFieldOffset(field);

--- a/src/main/java/net/openhft/chronicle/core/internal/ClassUtil.java
+++ b/src/main/java/net/openhft/chronicle/core/internal/ClassUtil.java
@@ -1,5 +1,6 @@
 package net.openhft.chronicle.core.internal;
 
+import net.openhft.chronicle.core.Jvm;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -10,27 +11,28 @@ import java.lang.invoke.MethodType;
 import java.lang.reflect.*;
 
 public final class ClassUtil {
-    public static final MethodHandle setAccessible0_Method = getSetAccessible0Method();
+    static class SetAccessibleHolder {
+        static final MethodHandle setAccessible0_Method = getSetAccessible0Method();
 
-    private ClassUtil() {
+        private static MethodHandle getSetAccessible0Method() {
+            if (!Bootstrap.isJava9Plus()) {
+                return null;
+            }
+            final MethodType signature = MethodType.methodType(boolean.class, boolean.class);
+            try {
+                // Access privateLookupIn() reflectively to support compilation with JDK 8
+                Method privateLookupIn = MethodHandles.class.getDeclaredMethod("privateLookupIn", Class.class, MethodHandles.Lookup.class);
+                MethodHandles.Lookup lookup = (MethodHandles.Lookup) privateLookupIn.invoke(null, AccessibleObject.class, MethodHandles.lookup());
+                return lookup.findVirtual(AccessibleObject.class, "setAccessible0", signature);
+            } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException |
+                     IllegalArgumentException e) {
+                Logger logger = LoggerFactory.getLogger(ClassUtil.class);
+                logger.error("Chronicle products may require command line arguments to be provided for Java 11 and above. See https://chronicle.software/chronicle-support-java-17");
+                return null;
+            }
+        }
     }
-
-    private static MethodHandle getSetAccessible0Method() {
-        if (!Bootstrap.isJava9Plus()) {
-            return null;
-        }
-        final MethodType signature = MethodType.methodType(boolean.class, boolean.class);
-        try {
-            // Access privateLookupIn() reflectively to support compilation with JDK 8
-            Method privateLookupIn = MethodHandles.class.getDeclaredMethod("privateLookupIn", Class.class, MethodHandles.Lookup.class);
-            MethodHandles.Lookup lookup = (MethodHandles.Lookup) privateLookupIn.invoke(null, AccessibleObject.class, MethodHandles.lookup());
-            return lookup.findVirtual(AccessibleObject.class, "setAccessible0", signature);
-        } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException |
-                 IllegalArgumentException e) {
-            Logger logger = LoggerFactory.getLogger(ClassUtil.class);
-            logger.error("Chronicle products require command line arguments to be provided for Java 11 and above. See https://chronicle.software/chronicle-support-java-17");
-            throw new ExceptionInInitializerError(e);
-        }
+    private ClassUtil() {
     }
 
     public static Field getField0(@NotNull final Class<?> clazz,
@@ -41,6 +43,10 @@ public final class ClassUtil {
             setAccessible(field);
             return field;
 
+        } catch (IllegalAccessError e) {
+            if (error)
+                Jvm.warn().on(clazz, "Unable to access " + name + " " + e.getMessage());
+            return null;
         } catch (NoSuchFieldException e) {
             final Class<?> superclass = clazz.getSuperclass();
             if (superclass != null) {
@@ -68,7 +74,9 @@ public final class ClassUtil {
     public static void setAccessible(@NotNull final AccessibleObject accessibleObject) {
         if (Bootstrap.isJava9Plus())
             try {
-                boolean newFlag = (boolean) setAccessible0_Method.invokeExact(accessibleObject, true);
+                if (SetAccessibleHolder.setAccessible0_Method == null)
+                    return;
+                boolean newFlag = (boolean) SetAccessibleHolder.setAccessible0_Method.invokeExact(accessibleObject, true);
                 assert newFlag;
             } catch (Throwable throwable) {
                 throw new AssertionError(throwable);

--- a/src/main/java/net/openhft/chronicle/core/internal/ClassUtil.java
+++ b/src/main/java/net/openhft/chronicle/core/internal/ClassUtil.java
@@ -37,10 +37,12 @@ public final class ClassUtil {
 
     public static Field getField0(@NotNull final Class<?> clazz,
                                   @NotNull final String name,
-                                  final boolean error) {
+                                  final boolean error,
+                                  final boolean setAccessible) {
         try {
             final Field field = clazz.getDeclaredField(name);
-            setAccessible(field);
+            if (setAccessible)
+                setAccessible(field);
             return field;
 
         } catch (IllegalAccessError e) {
@@ -50,7 +52,7 @@ public final class ClassUtil {
         } catch (NoSuchFieldException e) {
             final Class<?> superclass = clazz.getSuperclass();
             if (superclass != null) {
-                final Field field = getField0(superclass, name, false);
+                final Field field = getField0(superclass, name, false, setAccessible);
                 if (field != null)
                     return field;
             }

--- a/src/main/java/net/openhft/chronicle/core/internal/cleaner/ReflectionBasedByteBufferCleanerService.java
+++ b/src/main/java/net/openhft/chronicle/core/internal/cleaner/ReflectionBasedByteBufferCleanerService.java
@@ -48,7 +48,7 @@ public final class ReflectionBasedByteBufferCleanerService implements ByteBuffer
             final Class<?> cleanerClass = Class.forName(cleanerClassname);
             cleaner = lookup.findVirtual(DirectBufferUtil.directBufferClass(), "cleaner", MethodType.methodType(cleanerClass));
             clean = lookup.findVirtual(cleanerClass, "clean", MethodType.methodType(void.class));
-        } catch (NoSuchMethodException | ClassNotFoundException | IllegalAccessException e) {
+        } catch (IllegalAccessError | NoSuchMethodException | ClassNotFoundException | IllegalAccessException e) {
             // Don't want to record this in tests so just send to slf4j
             final Logger logger = Logger.getLogger(ReflectionBasedByteBufferCleanerService.class.getName());
             if (logger.isLoggable(Level.WARNING)) {

--- a/src/main/java/net/openhft/chronicle/core/internal/util/DirectBufferUtil.java
+++ b/src/main/java/net/openhft/chronicle/core/internal/util/DirectBufferUtil.java
@@ -67,7 +67,11 @@ public final class DirectBufferUtil {
      * @throws ClassCastException   if the provided {@code buffer } is not an instance of sun.nio.ch.DirectBuffer
      */
     public static long addressOrThrow(final ByteBuffer buffer) {
-        requireNonNull(buffer);
-        return ((DirectBuffer) buffer).address();
+        try {
+            requireNonNull(buffer);
+            return ((DirectBuffer) buffer).address();
+        } catch (IllegalAccessError e) {
+            throw new ClassCastException(e.toString());
+        }
     }
 }

--- a/src/main/java/net/openhft/chronicle/core/io/AbstractCloseable.java
+++ b/src/main/java/net/openhft/chronicle/core/io/AbstractCloseable.java
@@ -21,6 +21,7 @@ import net.openhft.chronicle.core.Jvm;
 import net.openhft.chronicle.core.StackTrace;
 import net.openhft.chronicle.core.UnsafeMemory;
 import net.openhft.chronicle.core.annotation.UsedViaReflection;
+import net.openhft.chronicle.core.internal.ClassUtil;
 import net.openhft.chronicle.core.internal.CloseableUtils;
 import net.openhft.chronicle.core.onoes.ExceptionHandler;
 import net.openhft.chronicle.core.onoes.Slf4jExceptionHandler;
@@ -74,7 +75,7 @@ public abstract class AbstractCloseable implements ReferenceOwner, ManagedClosea
     static {
         if (Jvm.isResourceTracing())
             enableCloseableTracing();
-        CLOSED_OFFSET = UnsafeMemory.unsafeObjectFieldOffset(Jvm.getField(AbstractCloseable.class, "closed"));
+        CLOSED_OFFSET = UnsafeMemory.unsafeObjectFieldOffset(ClassUtil.getField0(AbstractCloseable.class, "closed", true, false));
     }
 
     private final transient StackTrace createdHere;

--- a/src/main/java/net/openhft/chronicle/core/io/AbstractCloseableReferenceCounted.java
+++ b/src/main/java/net/openhft/chronicle/core/io/AbstractCloseableReferenceCounted.java
@@ -53,7 +53,7 @@ public abstract class AbstractCloseableReferenceCounted
      * Constructs a new AbstractCloseableReferenceCounted instance and adds the instance
      * to the CloseableUtils set for tracking.
      */
-    @SuppressWarnings("this-escaope")
+    @SuppressWarnings("this-escape")
     protected AbstractCloseableReferenceCounted() {
         CloseableUtils.add(this);
     }

--- a/src/main/java/net/openhft/chronicle/core/io/IOTools.java
+++ b/src/main/java/net/openhft/chronicle/core/io/IOTools.java
@@ -42,6 +42,8 @@ import java.util.stream.Stream;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
+import static net.openhft.chronicle.core.io.Closeable.closeQuietly;
+
 /**
  * IOTools is a utility class containing a variety of methods and constants
  * designed for handling input/output (IO) operations, especially regarding
@@ -348,7 +350,7 @@ public final class IOTools {
                 out.write(bytes, 0, len);
             return out.toByteArray();
         } finally {
-            Closeable.closeQuietly(is);
+            closeQuietly(is);
         }
     }
 
@@ -496,9 +498,9 @@ public final class IOTools {
         return () -> {
             Jvm.pause(50);
             System.out.println("Close " + sc);
-            Closeable.closeQuietly(sc);
+            closeQuietly(sc);
             Jvm.pause(10);
-            Closeable.closeQuietly(s2);
+            closeQuietly(s2);
         };
     }
 
@@ -509,8 +511,8 @@ public final class IOTools {
             Jvm.pause(50);
             main.interrupt();
             Jvm.pause(10);
-            Closeable.closeQuietly(sc);
-            Closeable.closeQuietly(s2);
+            closeQuietly(sc);
+            closeQuietly(s2);
         };
     }
 
@@ -535,7 +537,7 @@ public final class IOTools {
                 try (Socket s = new Socket("localhost", port);
                      SocketChannel s2 = ssc.accept()) {
                     final OutputStream os = s.getOutputStream();
-                    s2.close();
+                    closeQuietly(s2);
                     final byte[] bytes = new byte[512];
                     try {
                         for (int i = 0; i < 100; i++) {
@@ -544,7 +546,7 @@ public final class IOTools {
                     } catch (IOException ioe) {
                         CLOSED_MESSAGES.add(ioe.getMessage());
                     } finally {
-                        s.close();
+                        closeQuietly(s);
                     }
                     try {
                         s.getOutputStream().write(bytes);
@@ -554,6 +556,7 @@ public final class IOTools {
                 }
                 try (Socket s = new Socket("localhost", port);
                      SocketChannel s2 = ssc.accept()) {
+                    assert s2 != null;
                     OutputStream os = s.getOutputStream();
                     os.close();
                     os.write(1);
@@ -563,6 +566,7 @@ public final class IOTools {
                 ByteBuffer bytes = ByteBuffer.allocateDirect(1024);
                 try (SocketChannel sc = SocketChannel.open(address);
                      SocketChannel s2 = ssc.accept()) {
+                    assert s2 != null;
                     try {
                         for (int i = 0; i < 100; i++) {
                             bytes.clear();

--- a/src/main/java/net/openhft/chronicle/core/io/Wget.java
+++ b/src/main/java/net/openhft/chronicle/core/io/Wget.java
@@ -41,6 +41,7 @@ public final class Wget {
      * @param sb  The StringBuilder to which the response will be written to
      * @throws IOException if an error occurs while establishing the connection
      */
+    @SuppressWarnings("deprecation")
     public static void url(String url, StringBuilder sb) throws IOException {
         InputStream is = null;
         try {

--- a/src/main/java/net/openhft/chronicle/core/util/StringUtils.java
+++ b/src/main/java/net/openhft/chronicle/core/util/StringUtils.java
@@ -18,6 +18,7 @@
 
 package net.openhft.chronicle.core.util;
 
+import net.openhft.chronicle.core.Jvm;
 import net.openhft.chronicle.core.Maths;
 import net.openhft.chronicle.core.UnsafeMemory;
 import net.openhft.chronicle.core.annotation.Java9;
@@ -73,9 +74,9 @@ public final class StringUtils {
             S_VALUE = String.class.getDeclaredField(VALUE_FIELD_NAME);
             ClassUtil.setAccessible(S_VALUE);
             S_VALUE_OFFSET = getMemory().getFieldOffset(S_VALUE);
-            if (Bootstrap.isJava9Plus()) {
-                SB_CODER = ClassUtil.getField0(StringBuilder.class.getSuperclass(), CODER_FIELD_NAME, true);
-                S_CODER = ClassUtil.getField0(String.class, CODER_FIELD_NAME, true);
+            if (Bootstrap.isJava9Plus() && Jvm.maxDirectMemory() > 0) {
+                SB_CODER = ClassUtil.getField0(StringBuilder.class.getSuperclass(), CODER_FIELD_NAME, true, true);
+                S_CODER = ClassUtil.getField0(String.class, CODER_FIELD_NAME, true, true);
                 Object a = S_VALUE.get("A");
                 HAS_ONE_BYTE_PER_CHAR = Array.getLength(a) == 1;
             } else {
@@ -141,6 +142,10 @@ public final class StringUtils {
      * @throws AssertionError if there is an IllegalAccessException or IllegalArgumentException.
      */
     public static void setLength(@NotNull StringBuilder sb, int length) {
+        if (Jvm.maxDirectMemory() == 0) {
+            sb.setLength(length);
+            return;
+        }
         try {
             SB_COUNT.set(sb, length);
         } catch (IllegalAccessException | IllegalArgumentException e) {
@@ -293,7 +298,7 @@ public final class StringUtils {
             else if (charSequence instanceof StringBuilder)
                 coder = SB_CODER;
             else
-                coder = ClassUtil.getField0(charSequence.getClass(), CODER_FIELD_NAME, true);
+                coder = ClassUtil.getField0(charSequence.getClass(), CODER_FIELD_NAME, true, true);
             assert coder != null;
             return coder.getByte(charSequence);
         } catch (IllegalArgumentException | IllegalAccessException e) {

--- a/src/test/java/net/openhft/chronicle/core/JvmTest.java
+++ b/src/test/java/net/openhft/chronicle/core/JvmTest.java
@@ -137,6 +137,7 @@ public class JvmTest extends CoreTestCommon {
     @Test
     public void testUsedDirectMemory() {
         long used = Jvm.usedDirectMemory();
+        assumeFalse(used == 0);
         ByteBuffer.allocateDirect(4 << 10);
         assertEquals(used + (4 << 10), Jvm.usedDirectMemory());
     }

--- a/src/test/java/net/openhft/chronicle/core/MathsTest.java
+++ b/src/test/java/net/openhft/chronicle/core/MathsTest.java
@@ -320,6 +320,7 @@ public class MathsTest extends CoreTestCommon {
         }
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testRounding() {
         @NotNull Random rand = new Random(1);

--- a/src/test/java/net/openhft/chronicle/core/UnsafeMemory2Test.java
+++ b/src/test/java/net/openhft/chronicle/core/UnsafeMemory2Test.java
@@ -407,13 +407,13 @@ public class UnsafeMemory2Test extends CoreTestCommon {
         long offset = memory.objectFieldOffset(num);
         final long addr = memory.allocate(Integer.BYTES);
         int expected = 97;
-        memory.unsafePutInt(addr, expected);
+        UnsafeMemory.unsafePutInt(addr, expected);
         MyDTO to = new MyDTO();
         memory.copyMemory(addr, to, offset, Integer.BYTES);
         assertEquals(expected, to.num);
         to.num = 75;
         memory.copyMemory(to, offset, addr, Integer.BYTES);
-        assertEquals(to.num, memory.unsafeGetInt(addr));
+        assertEquals(to.num, UnsafeMemory.unsafeGetInt(addr));
     }
 
     @Test

--- a/src/test/java/net/openhft/chronicle/core/UnsafeMemoryTest.java
+++ b/src/test/java/net/openhft/chronicle/core/UnsafeMemoryTest.java
@@ -32,6 +32,7 @@ import java.util.*;
 import static net.openhft.chronicle.core.UnsafeMemory.UNSAFE;
 import static org.junit.Assert.*;
 
+@SuppressWarnings("deprecation")
 @RunWith(Parameterized.class)
 public class UnsafeMemoryTest extends CoreTestCommon {
 

--- a/src/test/java/net/openhft/chronicle/core/internal/CloseableUtilsTest.java
+++ b/src/test/java/net/openhft/chronicle/core/internal/CloseableUtilsTest.java
@@ -65,6 +65,7 @@ public class CloseableUtilsTest {
     }
 
     // Private helper to access the private CLOSEABLES field in CloseableUtils
+    @SuppressWarnings("unchecked")
     private AtomicReference<Set<Closeable>> getCloseablesRef() {
         try {
             java.lang.reflect.Field field = CloseableUtils.class.getDeclaredField("CLOSEABLES");

--- a/src/test/java/net/openhft/chronicle/core/internal/util/DirectBufferUtilTest.java
+++ b/src/test/java/net/openhft/chronicle/core/internal/util/DirectBufferUtilTest.java
@@ -1,14 +1,21 @@
 package net.openhft.chronicle.core.internal.util;
 
 import net.openhft.chronicle.core.Jvm;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 
+import static org.junit.Assume.assumeTrue;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 public class DirectBufferUtilTest {
+
+    @BeforeEach
+    public void addOpens() {
+        assumeTrue(Jvm.maxDirectMemory() > 0);
+    }
 
     @Test
     public void directBufferClassShouldReturnCorrectClass() {

--- a/src/test/java/net/openhft/chronicle/core/io/CleaningRandomAccessFileTest.java
+++ b/src/test/java/net/openhft/chronicle/core/io/CleaningRandomAccessFileTest.java
@@ -24,6 +24,7 @@ public class CleaningRandomAccessFileTest {
         assertTrue(tempFile.delete());
     }
 
+    @SuppressWarnings("removal")
     @Test
     public void testFinalizeAndCleanup() throws IOException {
         File tempFile = File.createTempFile("test", "raf");

--- a/src/test/java/net/openhft/chronicle/core/onoes/ExceptionHandlerFallbackTest.java
+++ b/src/test/java/net/openhft/chronicle/core/onoes/ExceptionHandlerFallbackTest.java
@@ -1,6 +1,7 @@
 package net.openhft.chronicle.core.onoes;
 
 import net.openhft.chronicle.core.Jvm;
+import org.junit.AssumptionViolatedException;
 import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
 
@@ -18,8 +19,13 @@ class ExceptionHandlerFallbackTest {
     @Test
     void classShouldFallBackWhenDelegateThrows() throws IllegalAccessException {
         Field initializationState = Jvm.getField(LoggerFactory.class, "INITIALIZATION_STATE");
-        int state = initializationState.getInt(null);
-        initializationState.setInt(null, FAILED_INITIALIZATION);
+        int state;
+        try {
+            state = initializationState.getInt(null);
+            initializationState.setInt(null, FAILED_INITIALIZATION);
+        } catch (IllegalAccessException e) {
+            throw new AssumptionViolatedException(e.toString());
+        }
         try {
             Slf4jExceptionHandler.WARN.on(
                     ExceptionHandlerFallbackTest.class,

--- a/src/test/java/net/openhft/chronicle/core/pool/EcnDynamic.java
+++ b/src/test/java/net/openhft/chronicle/core/pool/EcnDynamic.java
@@ -20,7 +20,7 @@ package net.openhft.chronicle.core.pool;
 
 import net.openhft.chronicle.core.util.CoreDynamicEnum;
 
-public enum EcnDynamic implements CoreDynamicEnum {
+public enum EcnDynamic implements CoreDynamicEnum<EcnDynamic> {
 
     EBS_LIVE_NYK,
     RFX,

--- a/src/test/java/net/openhft/chronicle/core/scoped/ScopedThreadLocalTest.java
+++ b/src/test/java/net/openhft/chronicle/core/scoped/ScopedThreadLocalTest.java
@@ -12,8 +12,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static net.openhft.chronicle.core.io.Closeable.closeQuietly;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public class ScopedThreadLocalTest extends CoreTestCommon {
 
@@ -98,6 +97,8 @@ public class ScopedThreadLocalTest extends CoreTestCommon {
             try (final ScopedResource<CloseableResource> cr1 = stl.get();
                  final ScopedResource<CloseableResource> cr2 = stl.get()) {
                 // Create two resources, do nothing
+                assertNotNull(cr1);
+                assertNotNull(cr2);
             }
             // None should be closed
             assertTrue(allResources.stream().noneMatch(cr -> cr.closed));

--- a/src/test/java/net/openhft/chronicle/core/shutdown/PriorityHookTest.java
+++ b/src/test/java/net/openhft/chronicle/core/shutdown/PriorityHookTest.java
@@ -28,7 +28,7 @@ public class PriorityHookTest {
         PriorityHook.getRegisteredHook().onShutdown();
 
         InOrder inOrder = inOrder(hook1, hook2);
-        ((InOrder) inOrder).verify(hook1).run();
+        inOrder.verify(hook1).run();
         inOrder.verify(hook2).run();
     }
 

--- a/src/test/java/net/openhft/chronicle/core/util/ObjectUtilsTest.java
+++ b/src/test/java/net/openhft/chronicle/core/util/ObjectUtilsTest.java
@@ -32,6 +32,7 @@ import java.util.function.Supplier;
 import static org.junit.Assert.*;
 
 public class ObjectUtilsTest extends CoreTestCommon {
+    @SuppressWarnings("rawtypes")
     @Test
     public void testImmutable() {
         for (@NotNull Class<?> c: new Class[]{

--- a/src/test/java/net/openhft/chronicle/core/util/ReadResolvableTest.java
+++ b/src/test/java/net/openhft/chronicle/core/util/ReadResolvableTest.java
@@ -49,6 +49,7 @@ class ReadResolvableTest {
         }
     }
 
+    @SuppressWarnings("serial")
     // Serializable object not implementing ReadResolvable
     static class SerializableObject implements Serializable {
     }


### PR DESCRIPTION
This pull request minimises the need for explicit `--add-opens` flags when running on Java 9+ by only opening JDK internals when required. Rather than unconditionally logging errors or eagerly reflecting into internal APIs, the changes defer and guard reflective access behind runtime checks and holder classes—so if a particular internal member or method isn’t used, no warning or failure occurs, and no `--add-opens` is needed. This reduces startup noise and improves compatibility with stricter module encapsulation in Java 9 and later.

## Motivation

Java 9+ introduced strong encapsulation of internal JDK APIs, blocking calls like `setAccessible(true)` on non-public members unless the module’s package is opened via `--add-opens` at runtime [[docs.oracle.com](https://docs.oracle.com/en/java/javase/21/migrate/migrating-jdk-8-later-jdk-releases.html?utm_source=chatgpt.com)]. Overly aggressive reflection or unguarded initializers often force every Chronicle module user to supply extensive `--add-opens` options, complicating deployment and container configurations. By guarding reflective lookups and only emitting warnings or errors when a reflective accessor is invoked, we avoid unnecessary module openings and let vanilla code run unmodified in most environments [[openjdk.org](https://openjdk.org/jeps/403?utm_source=chatgpt.com)].

## Key Changes

1. **Conditional Logging in `Jvm.java`**

   * Only logs “unable to determine reservedMemory” if `MAX_DIRECT_MEMORY > 0`, avoiding spurious error lines on platforms where direct memory isn’t used.
   * Clarified log messages for `maxDirectMemory0()` to state “will always report 0” when reflection fails, highlighting the fallback behaviour.

2. **Holder Classes for Reflection in `OS.java` and Related Utilities**

   * Extracted `Field` and `MethodHandle` lookups into nested holder classes (`FDFieldHolder`, `Unmapp0Holder`, `Read0Holder`, `Write0Holder`) initialised lazily on first access. This delays reflective access until actually needed, preventing unnecessary illegal-access issues at startup.
   * Swapped direct static fields (`FD_FIELD`, `UNMAPP0_MH`, etc.) for holder-based accessors (`getFdField()`, `getUnmapp0Mh()`, etc.), encapsulating `ClassNotFoundException` and `IllegalAccessError` into `IORuntimeException` or safe fallbacks.

3. **Graceful Fallbacks in Access Utilities**

   * In `DirectBufferUtil.addressOrThrow()`, catch `IllegalAccessError` and rethrow a standard `ClassCastException`, making it more transparent when direct buffer access is impossible without module flags.
   * In `ClassUtil`, moved `setAccessible0_Method` into a `SetAccessibleHolder` and return `null` if unavailable, logging a warning instead of failing initialization ([[stackoverflow.com](https://stackoverflow.com/questions/44056405/whats-the-difference-between-add-exports-and-add-opens-in-java-9?utm_source=chatgpt.com)][3]).

4. **Test Adjustments**

   * Added JUnit assumptions (`assumeFalse`, `assumeTrue`) in `JvmTest` and `DirectBufferUtilTest` to skip tests when direct-memory or reflective paths are unavailable on the current JVM configuration, avoiding spurious failures on strictly encapsulated runtimes.

## Backwards Compatibility

* **No API changes**: Public methods and classes remain unchanged.
* **Logging behaviour**: Some error messages now only appear under conditional circumstances, reducing noise but retaining complete diagnostic information when reflection truly fails.
* **Tests**: Tests will be skipped rather than fail when module encapsulation denies reflective access, maintaining pass/fail consistency across Java 8–21 environments.


