### PR TITLE
Update TIMESTAMP_REGEX to allow optional fractional seconds

### DIFF
--- a/src/test/java/net/openhft/chronicle/core/StackTraceTest.java
+++ b/src/test/java/net/openhft/chronicle/core/StackTraceTest.java
@@ -27,7 +27,7 @@ import static org.junit.Assert.*;
 
 public class StackTraceTest extends CoreTestCommon {
     private static final CountDownLatch threadStarted = new CountDownLatch(1);
-    private static final String TIMESTAMP_REGEX = "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+Z$";
+    private static final String TIMESTAMP_REGEX = "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?Z$";
 
     /**
      * Simulates a thread that sleeps/stalls so we can capture its stack trace.


### PR DESCRIPTION
when it's exact tttt.000 it drops the .000