### PR TITLE
Enhance GenericReflection to handle TypeVariable bounds and add test for parameter types

### DIFF
--- a/src/main/java/net/openhft/chronicle/core/util/GenericReflection.java
+++ b/src/main/java/net/openhft/chronicle/core/util/GenericReflection.java
@@ -99,7 +99,18 @@ public enum GenericReflection {
     public static Type[] getParameterTypes(Method method, Type type) {
         final Type[] parameterTypes = method.getGenericParameterTypes();
         for (int i = 0; i < parameterTypes.length; i++) {
-            parameterTypes[i] = findType(method, type, parameterTypes[i]);
+            Type typeI = findType(method, type, parameterTypes[i]);
+            if (typeI instanceof TypeVariable) {
+                TypeVariable<?> typeVariable = (TypeVariable<?>) typeI;
+                Type[] bounds = typeVariable.getBounds();
+                if (bounds.length > 0) {
+                    typeI = bounds[0];
+                } else {
+                    // If no bounds, use Object as a fallback
+                    typeI = Object.class;
+                }
+            }
+            parameterTypes[i] = typeI;
         }
         return parameterTypes;
     }
@@ -120,10 +131,11 @@ public enum GenericReflection {
         if (!(forClass instanceof Class))
             throw new UnsupportedOperationException();
 
-        for (Type genericInterface : ((Class) forClass).getGenericInterfaces())
+        Class<?> forClass2 = (Class<?>) forClass;
+        for (Type genericInterface : forClass2.getGenericInterfaces())
             getGenericClassesSuperclassesAndInterfaces(genericInterface, collectedTypes);
 
-        Type superclass = ((Class) forClass).getGenericSuperclass();
+        Type superclass = forClass2.getGenericSuperclass();
         if (superclass != null)
             getGenericClassesSuperclassesAndInterfaces(superclass, collectedTypes);
     }

--- a/src/test/java/net/openhft/chronicle/core/util/GenericReflectionTest.java
+++ b/src/test/java/net/openhft/chronicle/core/util/GenericReflectionTest.java
@@ -26,8 +26,7 @@ import java.lang.reflect.Type;
 import java.util.Arrays;
 import java.util.Set;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 class GenericReflectionTest extends CoreTestCommon {
 
@@ -88,6 +87,21 @@ class GenericReflectionTest extends CoreTestCommon {
                 Arrays.toString(GenericReflection.getParameterTypes(method0, MassivelyNestedExtendsGenericMethod.class)));
     }
 
+    @Test
+    public void getParameterTypesExtends() {
+        Method method = null;
+        for (Method m : GenericMethodExtends.class.getMethods()) {
+            if (m.getName().equals("method")) {
+                method = m;
+                break;
+            }
+        }
+        assertNotNull(method);
+        final String expected = "[" + Number.class + ", " + CharSequence.class + "]";
+        assertEquals(expected,
+                Arrays.toString(GenericReflection.getParameterTypes(method, GenericMethodExtends.class)));
+    }
+
     interface Returns<A> {
         A ret();
     }
@@ -97,6 +111,10 @@ class GenericReflectionTest extends CoreTestCommon {
     }
 
     interface ReturnsString extends Returns<String> {
+    }
+
+    interface GenericMethodExtends<A extends Number, B extends CharSequence> {
+        void method(A a, B b);
     }
 
     interface GenericMethod<A, B> {


### PR DESCRIPTION
This pull request improves the way `GenericReflection.getParameterTypes(...)` handles generic parameters declared with bounds (e.g. `A extends Number`). Instead of returning the raw `TypeVariable` instance, it now resolves the parameter to its first bound (or `Object.class` if no explicit bounds are present). Additionally, the recursive collection of superclasses and interfaces in `getGenericClassesSuperclassesAndInterfaces(...)` is made cleaner by casting the input `Type` to `Class<?>` once up front (removing repeated casts). These changes ensure more accurate runtime type resolution and cleaner code. 

## Background

Reflective APIs such as `Method.getGenericParameterTypes()` often return `TypeVariable` objects for parameters declared with generics, which can obscure the actual concrete types at runtime.
The `TypeVariable.getBounds()` method returns the array of upper bounds declared for a type variable, defaulting to `Object.class` if none are specified.
Many frameworks normalize generic bounds by using the first bound or falling back to `Object` to simplify downstream processing and avoid dealing with raw type variables.

## Changes

1. **Resolve bounded type variables to their first bound**

   * In `getParameterTypes(...)`, after calling `findType(...)`, check if the resolved `Type` is a `TypeVariable<?>`. If so, extract `typeVariable.getBounds()[0]` or `Object.class` when no bounds exist 
   * This replaces raw `TypeVariable` occurrences with concrete classes like `Number` or `CharSequence` for `A extends Number` or `B extends CharSequence`, respectively.

2. **Consolidate class casting in recursive type collection**

   * In `getGenericClassesSuperclassesAndInterfaces(Type forClass, ...)`, cast `forClass` to `Class<?>` once (`Class<?> forClass2`) instead of repeating `(Class)` each time 
   * This reduces redundant casts and clarifies that only non-generic `Class` types are traversed here.

3. **Add dedicated unit test for bounded generics**

   * Introduce `getParameterTypesExtends()` in `GenericReflectionTest` to verify that parameters declared as `<A extends Number, B extends CharSequence>` are resolved to `[Number.class, CharSequence.class]` 

## Impact

* **Improved type accuracy** when reflecting on methods that use generics with bounds—users no longer need to manually unwrap `TypeVariable` instances to their bounds.
* **Better compatibility** with frameworks and libraries that expect concrete `Class<?>` types rather than `TypeVariable` objects during reflective operations.
* **Minimal behavioral change** for methods without generic bounds, since the first bound defaults to `Object.class`, matching previous expectations when no bounds were declared
