### PR TITLE
Update copyright headers to 2016–2025 and remove legacy URL lines

### DIFF
--- a/assertions-disabled/pom.xml
+++ b/assertions-disabled/pom.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2016-2022 chronicle.software
-  ~
-  ~ https://chronicle.software
+  ~ Copyright 2016-2025 chronicle.software
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/assertions-enabled/pom.xml
+++ b/assertions-enabled/pom.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2016-2022 chronicle.software
-  ~
-  ~ https://chronicle.software
+  ~ Copyright 2016-2025 chronicle.software
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright 2016 chronicle.software
+  ~ Copyright 2016-2025 chronicle.software
   ~
   ~ Licensed under the *Apache License, Version 2.0* (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/checked-exceptions/pom.xml
+++ b/checked-exceptions/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2016 chronicle.software
+  ~ Copyright 2016-2025 chronicle.software
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2016 chronicle.software
+  ~ Copyright 2016-2025 chronicle.software
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/Bootstrap.java
+++ b/src/main/java/net/openhft/chronicle/core/Bootstrap.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/ChronicleInit.java
+++ b/src/main/java/net/openhft/chronicle/core/ChronicleInit.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/ChronicleInitRunnable.java
+++ b/src/main/java/net/openhft/chronicle/core/ChronicleInitRunnable.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/Jvm.java
+++ b/src/main/java/net/openhft/chronicle/core/Jvm.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/LicenceCheck.java
+++ b/src/main/java/net/openhft/chronicle/core/LicenceCheck.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/Maths.java
+++ b/src/main/java/net/openhft/chronicle/core/Maths.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/Memory.java
+++ b/src/main/java/net/openhft/chronicle/core/Memory.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/Mocker.java
+++ b/src/main/java/net/openhft/chronicle/core/Mocker.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/OS.java
+++ b/src/main/java/net/openhft/chronicle/core/OS.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/StackTrace.java
+++ b/src/main/java/net/openhft/chronicle/core/StackTrace.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2024 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/UnsafeMemory.java
+++ b/src/main/java/net/openhft/chronicle/core/UnsafeMemory.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/analytics/AnalyticsFacade.java
+++ b/src/main/java/net/openhft/chronicle/core/analytics/AnalyticsFacade.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/annotation/DontChain.java
+++ b/src/main/java/net/openhft/chronicle/core/annotation/DontChain.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/annotation/ForceInline.java
+++ b/src/main/java/net/openhft/chronicle/core/annotation/ForceInline.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/annotation/HotMethod.java
+++ b/src/main/java/net/openhft/chronicle/core/annotation/HotMethod.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/annotation/Java9.java
+++ b/src/main/java/net/openhft/chronicle/core/annotation/Java9.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/annotation/Negative.java
+++ b/src/main/java/net/openhft/chronicle/core/annotation/Negative.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/annotation/NonNegative.java
+++ b/src/main/java/net/openhft/chronicle/core/annotation/NonNegative.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/annotation/NonPositive.java
+++ b/src/main/java/net/openhft/chronicle/core/annotation/NonPositive.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/annotation/PackageLocal.java
+++ b/src/main/java/net/openhft/chronicle/core/annotation/PackageLocal.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/annotation/Positive.java
+++ b/src/main/java/net/openhft/chronicle/core/annotation/Positive.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/annotation/Range.java
+++ b/src/main/java/net/openhft/chronicle/core/annotation/Range.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/annotation/RequiredForClient.java
+++ b/src/main/java/net/openhft/chronicle/core/annotation/RequiredForClient.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/annotation/ScopeConfined.java
+++ b/src/main/java/net/openhft/chronicle/core/annotation/ScopeConfined.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/annotation/SingleThreaded.java
+++ b/src/main/java/net/openhft/chronicle/core/annotation/SingleThreaded.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/annotation/TargetMajorVersion.java
+++ b/src/main/java/net/openhft/chronicle/core/annotation/TargetMajorVersion.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/annotation/UsedViaReflection.java
+++ b/src/main/java/net/openhft/chronicle/core/annotation/UsedViaReflection.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/announcer/Announcer.java
+++ b/src/main/java/net/openhft/chronicle/core/announcer/Announcer.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/cleaner/CleanerServiceLocator.java
+++ b/src/main/java/net/openhft/chronicle/core/cleaner/CleanerServiceLocator.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/cleaner/spi/ByteBufferCleanerService.java
+++ b/src/main/java/net/openhft/chronicle/core/cleaner/spi/ByteBufferCleanerService.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/cooler/CoolerTester.java
+++ b/src/main/java/net/openhft/chronicle/core/cooler/CoolerTester.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/cooler/CpuCooler.java
+++ b/src/main/java/net/openhft/chronicle/core/cooler/CpuCooler.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/cooler/CpuCoolers.java
+++ b/src/main/java/net/openhft/chronicle/core/cooler/CpuCoolers.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/domestic/package-info.java
+++ b/src/main/java/net/openhft/chronicle/core/domestic/package-info.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/internal/Bootstrap.java
+++ b/src/main/java/net/openhft/chronicle/core/internal/Bootstrap.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/internal/ReferenceCountedUtils.java
+++ b/src/main/java/net/openhft/chronicle/core/internal/ReferenceCountedUtils.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/internal/analytics/MuteAnalytics.java
+++ b/src/main/java/net/openhft/chronicle/core/internal/analytics/MuteAnalytics.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/internal/analytics/MuteBuilder.java
+++ b/src/main/java/net/openhft/chronicle/core/internal/analytics/MuteBuilder.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/internal/analytics/ReflectionUtil.java
+++ b/src/main/java/net/openhft/chronicle/core/internal/analytics/ReflectionUtil.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/internal/analytics/ReflectiveAnalytics.java
+++ b/src/main/java/net/openhft/chronicle/core/internal/analytics/ReflectiveAnalytics.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/internal/analytics/ReflectiveBuilder.java
+++ b/src/main/java/net/openhft/chronicle/core/internal/analytics/ReflectiveBuilder.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/internal/analytics/StandardMaps.java
+++ b/src/main/java/net/openhft/chronicle/core/internal/analytics/StandardMaps.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/internal/announcer/InternalAnnouncer.java
+++ b/src/main/java/net/openhft/chronicle/core/internal/announcer/InternalAnnouncer.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/internal/cleaner/Jdk9ByteBufferCleanerService.java
+++ b/src/main/java/net/openhft/chronicle/core/internal/cleaner/Jdk9ByteBufferCleanerService.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/internal/cleaner/ReflectionBasedByteBufferCleanerService.java
+++ b/src/main/java/net/openhft/chronicle/core/internal/cleaner/ReflectionBasedByteBufferCleanerService.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/internal/invariant/ints/IntCondition.java
+++ b/src/main/java/net/openhft/chronicle/core/internal/invariant/ints/IntCondition.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/internal/invariant/longs/LongCondition.java
+++ b/src/main/java/net/openhft/chronicle/core/internal/invariant/longs/LongCondition.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/internal/package-info.java
+++ b/src/main/java/net/openhft/chronicle/core/internal/package-info.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/internal/pom/InternalPomProperties.java
+++ b/src/main/java/net/openhft/chronicle/core/internal/pom/InternalPomProperties.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/internal/util/DirectBufferUtil.java
+++ b/src/main/java/net/openhft/chronicle/core/internal/util/DirectBufferUtil.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/internal/util/MapUtil.java
+++ b/src/main/java/net/openhft/chronicle/core/internal/util/MapUtil.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/internal/util/NopThreadConfinementAsserter.java
+++ b/src/main/java/net/openhft/chronicle/core/internal/util/NopThreadConfinementAsserter.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/internal/util/RangeUtil.java
+++ b/src/main/java/net/openhft/chronicle/core/internal/util/RangeUtil.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/internal/util/ThreadConfinementLifecycle.java
+++ b/src/main/java/net/openhft/chronicle/core/internal/util/ThreadConfinementLifecycle.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/internal/util/VanillaThreadConfinementAsserter.java
+++ b/src/main/java/net/openhft/chronicle/core/internal/util/VanillaThreadConfinementAsserter.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/io/AbstractCloseable.java
+++ b/src/main/java/net/openhft/chronicle/core/io/AbstractCloseable.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/io/AbstractCloseableReferenceCounted.java
+++ b/src/main/java/net/openhft/chronicle/core/io/AbstractCloseableReferenceCounted.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/io/AbstractReferenceCounted.java
+++ b/src/main/java/net/openhft/chronicle/core/io/AbstractReferenceCounted.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/io/BackgroundResourceReleaser.java
+++ b/src/main/java/net/openhft/chronicle/core/io/BackgroundResourceReleaser.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/io/CleaningRandomAccessFile.java
+++ b/src/main/java/net/openhft/chronicle/core/io/CleaningRandomAccessFile.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/io/Closeable.java
+++ b/src/main/java/net/openhft/chronicle/core/io/Closeable.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/io/ClosedIORuntimeException.java
+++ b/src/main/java/net/openhft/chronicle/core/io/ClosedIORuntimeException.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/io/ClosedIllegalStateException.java
+++ b/src/main/java/net/openhft/chronicle/core/io/ClosedIllegalStateException.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/io/ClosedState.java
+++ b/src/main/java/net/openhft/chronicle/core/io/ClosedState.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/io/IORuntimeException.java
+++ b/src/main/java/net/openhft/chronicle/core/io/IORuntimeException.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/io/IOTools.java
+++ b/src/main/java/net/openhft/chronicle/core/io/IOTools.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/io/InvalidMarshallableException.java
+++ b/src/main/java/net/openhft/chronicle/core/io/InvalidMarshallableException.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/io/ManagedCloseable.java
+++ b/src/main/java/net/openhft/chronicle/core/io/ManagedCloseable.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/io/MonitorReferenceCounted.java
+++ b/src/main/java/net/openhft/chronicle/core/io/MonitorReferenceCounted.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/io/Monitorable.java
+++ b/src/main/java/net/openhft/chronicle/core/io/Monitorable.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/io/QueryCloseable.java
+++ b/src/main/java/net/openhft/chronicle/core/io/QueryCloseable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  */
 
 package net.openhft.chronicle.core.io;

--- a/src/main/java/net/openhft/chronicle/core/io/ReferenceCounted.java
+++ b/src/main/java/net/openhft/chronicle/core/io/ReferenceCounted.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/io/ReferenceCountedTracer.java
+++ b/src/main/java/net/openhft/chronicle/core/io/ReferenceCountedTracer.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/io/ReferenceOwner.java
+++ b/src/main/java/net/openhft/chronicle/core/io/ReferenceOwner.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/io/Resettable.java
+++ b/src/main/java/net/openhft/chronicle/core/io/Resettable.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/io/SimpleCloseable.java
+++ b/src/main/java/net/openhft/chronicle/core/io/SimpleCloseable.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/io/SingleThreadedChecked.java
+++ b/src/main/java/net/openhft/chronicle/core/io/SingleThreadedChecked.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/io/Syncable.java
+++ b/src/main/java/net/openhft/chronicle/core/io/Syncable.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/io/ThreadingIllegalStateException.java
+++ b/src/main/java/net/openhft/chronicle/core/io/ThreadingIllegalStateException.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/io/TracingReferenceCounted.java
+++ b/src/main/java/net/openhft/chronicle/core/io/TracingReferenceCounted.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  */
 
 package net.openhft.chronicle.core.io;

--- a/src/main/java/net/openhft/chronicle/core/io/UnsafeCloseable.java
+++ b/src/main/java/net/openhft/chronicle/core/io/UnsafeCloseable.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/io/Validatable.java
+++ b/src/main/java/net/openhft/chronicle/core/io/Validatable.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/io/ValidatableUtil.java
+++ b/src/main/java/net/openhft/chronicle/core/io/ValidatableUtil.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/io/VanillaReferenceCounted.java
+++ b/src/main/java/net/openhft/chronicle/core/io/VanillaReferenceCounted.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/io/VanillaReferenceOwner.java
+++ b/src/main/java/net/openhft/chronicle/core/io/VanillaReferenceOwner.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/onoes/ChainedExceptionHandler.java
+++ b/src/main/java/net/openhft/chronicle/core/onoes/ChainedExceptionHandler.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/onoes/ExceptionHandler.java
+++ b/src/main/java/net/openhft/chronicle/core/onoes/ExceptionHandler.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/onoes/ExceptionKey.java
+++ b/src/main/java/net/openhft/chronicle/core/onoes/ExceptionKey.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/onoes/LogLevel.java
+++ b/src/main/java/net/openhft/chronicle/core/onoes/LogLevel.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/onoes/NullExceptionHandler.java
+++ b/src/main/java/net/openhft/chronicle/core/onoes/NullExceptionHandler.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/onoes/RecordingExceptionHandler.java
+++ b/src/main/java/net/openhft/chronicle/core/onoes/RecordingExceptionHandler.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/onoes/Slf4jExceptionHandler.java
+++ b/src/main/java/net/openhft/chronicle/core/onoes/Slf4jExceptionHandler.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/onoes/ThreadLocalisedExceptionHandler.java
+++ b/src/main/java/net/openhft/chronicle/core/onoes/ThreadLocalisedExceptionHandler.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/pom/PomProperties.java
+++ b/src/main/java/net/openhft/chronicle/core/pom/PomProperties.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/pool/ClassAliasPool.java
+++ b/src/main/java/net/openhft/chronicle/core/pool/ClassAliasPool.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/pool/ClassLookup.java
+++ b/src/main/java/net/openhft/chronicle/core/pool/ClassLookup.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/pool/DynamicEnumClass.java
+++ b/src/main/java/net/openhft/chronicle/core/pool/DynamicEnumClass.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/pool/EnumCache.java
+++ b/src/main/java/net/openhft/chronicle/core/pool/EnumCache.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/pool/EnumInterner.java
+++ b/src/main/java/net/openhft/chronicle/core/pool/EnumInterner.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/pool/ParsingCache.java
+++ b/src/main/java/net/openhft/chronicle/core/pool/ParsingCache.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/pool/StaticEnumClass.java
+++ b/src/main/java/net/openhft/chronicle/core/pool/StaticEnumClass.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/pool/StringBuilderPool.java
+++ b/src/main/java/net/openhft/chronicle/core/pool/StringBuilderPool.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/pool/StringInterner.java
+++ b/src/main/java/net/openhft/chronicle/core/pool/StringInterner.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/shutdown/Hooklet.java
+++ b/src/main/java/net/openhft/chronicle/core/shutdown/Hooklet.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/shutdown/PriorityHook.java
+++ b/src/main/java/net/openhft/chronicle/core/shutdown/PriorityHook.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/threads/CancellableTimer.java
+++ b/src/main/java/net/openhft/chronicle/core/threads/CancellableTimer.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/threads/CleaningThread.java
+++ b/src/main/java/net/openhft/chronicle/core/threads/CleaningThread.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/threads/CleaningThreadLocal.java
+++ b/src/main/java/net/openhft/chronicle/core/threads/CleaningThreadLocal.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/threads/DelegatingEventLoop.java
+++ b/src/main/java/net/openhft/chronicle/core/threads/DelegatingEventLoop.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/threads/EventHandler.java
+++ b/src/main/java/net/openhft/chronicle/core/threads/EventHandler.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/threads/EventLoop.java
+++ b/src/main/java/net/openhft/chronicle/core/threads/EventLoop.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/threads/HandlerPriority.java
+++ b/src/main/java/net/openhft/chronicle/core/threads/HandlerPriority.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/threads/InterruptedRuntimeException.java
+++ b/src/main/java/net/openhft/chronicle/core/threads/InterruptedRuntimeException.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/threads/InvalidEventHandlerException.java
+++ b/src/main/java/net/openhft/chronicle/core/threads/InvalidEventHandlerException.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/threads/OnDemandEventLoop.java
+++ b/src/main/java/net/openhft/chronicle/core/threads/OnDemandEventLoop.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/threads/ThreadDump.java
+++ b/src/main/java/net/openhft/chronicle/core/threads/ThreadDump.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/threads/ThreadLocalHelper.java
+++ b/src/main/java/net/openhft/chronicle/core/threads/ThreadLocalHelper.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/threads/Timer.java
+++ b/src/main/java/net/openhft/chronicle/core/threads/Timer.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/threads/VanillaEventHandler.java
+++ b/src/main/java/net/openhft/chronicle/core/threads/VanillaEventHandler.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/time/LongTime.java
+++ b/src/main/java/net/openhft/chronicle/core/time/LongTime.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/time/PosixTimeProvider.java
+++ b/src/main/java/net/openhft/chronicle/core/time/PosixTimeProvider.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/time/SetTimeProvider.java
+++ b/src/main/java/net/openhft/chronicle/core/time/SetTimeProvider.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/time/SystemTimeProvider.java
+++ b/src/main/java/net/openhft/chronicle/core/time/SystemTimeProvider.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/time/TimeProvider.java
+++ b/src/main/java/net/openhft/chronicle/core/time/TimeProvider.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/time/UniqueMicroTimeProvider.java
+++ b/src/main/java/net/openhft/chronicle/core/time/UniqueMicroTimeProvider.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/util/AbstractInvocationHandler.java
+++ b/src/main/java/net/openhft/chronicle/core/util/AbstractInvocationHandler.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/util/BooleanConsumer.java
+++ b/src/main/java/net/openhft/chronicle/core/util/BooleanConsumer.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/util/Builder.java
+++ b/src/main/java/net/openhft/chronicle/core/util/Builder.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/util/ByteConsumer.java
+++ b/src/main/java/net/openhft/chronicle/core/util/ByteConsumer.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/util/CharConsumer.java
+++ b/src/main/java/net/openhft/chronicle/core/util/CharConsumer.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/util/CharSequenceComparator.java
+++ b/src/main/java/net/openhft/chronicle/core/util/CharSequenceComparator.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/util/CharToBooleanFunction.java
+++ b/src/main/java/net/openhft/chronicle/core/util/CharToBooleanFunction.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/util/ClassLocal.java
+++ b/src/main/java/net/openhft/chronicle/core/util/ClassLocal.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/util/ClassMetrics.java
+++ b/src/main/java/net/openhft/chronicle/core/util/ClassMetrics.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/util/ClassNotFoundRuntimeException.java
+++ b/src/main/java/net/openhft/chronicle/core/util/ClassNotFoundRuntimeException.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/util/CompilerUtils.java
+++ b/src/main/java/net/openhft/chronicle/core/util/CompilerUtils.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2021 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/util/CoreDynamicEnum.java
+++ b/src/main/java/net/openhft/chronicle/core/util/CoreDynamicEnum.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/util/FloatConsumer.java
+++ b/src/main/java/net/openhft/chronicle/core/util/FloatConsumer.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/util/GenericReflection.java
+++ b/src/main/java/net/openhft/chronicle/core/util/GenericReflection.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/util/Histogram.java
+++ b/src/main/java/net/openhft/chronicle/core/util/Histogram.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/util/IgnoresEverything.java
+++ b/src/main/java/net/openhft/chronicle/core/util/IgnoresEverything.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/util/Ints.java
+++ b/src/main/java/net/openhft/chronicle/core/util/Ints.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/util/InvocationTargetRuntimeException.java
+++ b/src/main/java/net/openhft/chronicle/core/util/InvocationTargetRuntimeException.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/util/Longs.java
+++ b/src/main/java/net/openhft/chronicle/core/util/Longs.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/util/MisAlignedAssertionError.java
+++ b/src/main/java/net/openhft/chronicle/core/util/MisAlignedAssertionError.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/util/Mocker.java
+++ b/src/main/java/net/openhft/chronicle/core/util/Mocker.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/util/NanoSampler.java
+++ b/src/main/java/net/openhft/chronicle/core/util/NanoSampler.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/util/ObjBooleanConsumer.java
+++ b/src/main/java/net/openhft/chronicle/core/util/ObjBooleanConsumer.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/util/ObjByteConsumer.java
+++ b/src/main/java/net/openhft/chronicle/core/util/ObjByteConsumer.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/util/ObjCharConsumer.java
+++ b/src/main/java/net/openhft/chronicle/core/util/ObjCharConsumer.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/util/ObjFloatConsumer.java
+++ b/src/main/java/net/openhft/chronicle/core/util/ObjFloatConsumer.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/util/ObjShortConsumer.java
+++ b/src/main/java/net/openhft/chronicle/core/util/ObjShortConsumer.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/util/ObjectUtils.java
+++ b/src/main/java/net/openhft/chronicle/core/util/ObjectUtils.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/util/ReadResolvable.java
+++ b/src/main/java/net/openhft/chronicle/core/util/ReadResolvable.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/util/RecordingHistogram.java
+++ b/src/main/java/net/openhft/chronicle/core/util/RecordingHistogram.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/util/SerializableBiFunction.java
+++ b/src/main/java/net/openhft/chronicle/core/util/SerializableBiFunction.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/util/SerializableConsumer.java
+++ b/src/main/java/net/openhft/chronicle/core/util/SerializableConsumer.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/util/SerializableFunction.java
+++ b/src/main/java/net/openhft/chronicle/core/util/SerializableFunction.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/util/SerializablePredicate.java
+++ b/src/main/java/net/openhft/chronicle/core/util/SerializablePredicate.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/util/SerializableUpdater.java
+++ b/src/main/java/net/openhft/chronicle/core/util/SerializableUpdater.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/util/SerializableUpdaterWithArg.java
+++ b/src/main/java/net/openhft/chronicle/core/util/SerializableUpdaterWithArg.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/util/ShortConsumer.java
+++ b/src/main/java/net/openhft/chronicle/core/util/ShortConsumer.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/util/SimpleCleaner.java
+++ b/src/main/java/net/openhft/chronicle/core/util/SimpleCleaner.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/util/StringUtils.java
+++ b/src/main/java/net/openhft/chronicle/core/util/StringUtils.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/util/ThreadConfinementAsserter.java
+++ b/src/main/java/net/openhft/chronicle/core/util/ThreadConfinementAsserter.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/util/ThrowingBiConsumer.java
+++ b/src/main/java/net/openhft/chronicle/core/util/ThrowingBiConsumer.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/util/ThrowingBiFunction.java
+++ b/src/main/java/net/openhft/chronicle/core/util/ThrowingBiFunction.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/util/ThrowingCallable.java
+++ b/src/main/java/net/openhft/chronicle/core/util/ThrowingCallable.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/util/ThrowingConsumer.java
+++ b/src/main/java/net/openhft/chronicle/core/util/ThrowingConsumer.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/util/ThrowingConsumerNonCapturing.java
+++ b/src/main/java/net/openhft/chronicle/core/util/ThrowingConsumerNonCapturing.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/util/ThrowingFunction.java
+++ b/src/main/java/net/openhft/chronicle/core/util/ThrowingFunction.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/util/ThrowingIntSupplier.java
+++ b/src/main/java/net/openhft/chronicle/core/util/ThrowingIntSupplier.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/util/ThrowingLongSupplier.java
+++ b/src/main/java/net/openhft/chronicle/core/util/ThrowingLongSupplier.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/util/ThrowingRunnable.java
+++ b/src/main/java/net/openhft/chronicle/core/util/ThrowingRunnable.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/util/ThrowingSupplier.java
+++ b/src/main/java/net/openhft/chronicle/core/util/ThrowingSupplier.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/util/ThrowingTriFunction.java
+++ b/src/main/java/net/openhft/chronicle/core/util/ThrowingTriFunction.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/util/Time.java
+++ b/src/main/java/net/openhft/chronicle/core/util/Time.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/util/TypeOf.java
+++ b/src/main/java/net/openhft/chronicle/core/util/TypeOf.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/util/UnresolvedType.java
+++ b/src/main/java/net/openhft/chronicle/core/util/UnresolvedType.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/util/Updater.java
+++ b/src/main/java/net/openhft/chronicle/core/util/Updater.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/util/WeakIdentityHashMap.java
+++ b/src/main/java/net/openhft/chronicle/core/util/WeakIdentityHashMap.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/values/BooleanValue.java
+++ b/src/main/java/net/openhft/chronicle/core/values/BooleanValue.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/values/ByteValue.java
+++ b/src/main/java/net/openhft/chronicle/core/values/ByteValue.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/values/CharValue.java
+++ b/src/main/java/net/openhft/chronicle/core/values/CharValue.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/values/DoubleValue.java
+++ b/src/main/java/net/openhft/chronicle/core/values/DoubleValue.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/values/FloatValue.java
+++ b/src/main/java/net/openhft/chronicle/core/values/FloatValue.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/values/IntArrayValues.java
+++ b/src/main/java/net/openhft/chronicle/core/values/IntArrayValues.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/values/IntValue.java
+++ b/src/main/java/net/openhft/chronicle/core/values/IntValue.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/values/LongArrayValues.java
+++ b/src/main/java/net/openhft/chronicle/core/values/LongArrayValues.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/values/LongValue.java
+++ b/src/main/java/net/openhft/chronicle/core/values/LongValue.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/values/MaxBytes.java
+++ b/src/main/java/net/openhft/chronicle/core/values/MaxBytes.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/values/ShortValue.java
+++ b/src/main/java/net/openhft/chronicle/core/values/ShortValue.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/values/StringValue.java
+++ b/src/main/java/net/openhft/chronicle/core/values/StringValue.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/core/values/TwoLongValue.java
+++ b/src/main/java/net/openhft/chronicle/core/values/TwoLongValue.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/resources/META-INF/services/net.openhft.chronicle.core.cleaner.spi.ByteBufferCleanerService
+++ b/src/main/resources/META-INF/services/net.openhft.chronicle.core.cleaner.spi.ByteBufferCleanerService
@@ -1,7 +1,5 @@
 #
-# Copyright 2016-2022 chronicle.software
-#
-#       https://chronicle.software
+# Copyright 2016-2025 chronicle.software
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/resources/net/openhft/chronicle/core/onoes/Google.properties
+++ b/src/main/resources/net/openhft/chronicle/core/onoes/Google.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2016 higherfrequencytrading.com
+# Copyright 2016-2025 chronicle.software
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/src/main/resources/net/openhft/chronicle/core/onoes/Stackoverflow.properties
+++ b/src/main/resources/net/openhft/chronicle/core/onoes/Stackoverflow.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2016 higherfrequencytrading.com
+# Copyright 2016-2025 chronicle.software
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/core/ChronicleInitTest.java
+++ b/src/test/java/net/openhft/chronicle/core/ChronicleInitTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/core/ClassLocalTest.java
+++ b/src/test/java/net/openhft/chronicle/core/ClassLocalTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/core/CleaningRandomAccessFileTest.java
+++ b/src/test/java/net/openhft/chronicle/core/CleaningRandomAccessFileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  */
 
 package net.openhft.chronicle.core;

--- a/src/test/java/net/openhft/chronicle/core/CoreTestCommon.java
+++ b/src/test/java/net/openhft/chronicle/core/CoreTestCommon.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/core/JvmMain.java
+++ b/src/test/java/net/openhft/chronicle/core/JvmMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  */
 
 package net.openhft.chronicle.core;

--- a/src/test/java/net/openhft/chronicle/core/JvmParseSizeTest.java
+++ b/src/test/java/net/openhft/chronicle/core/JvmParseSizeTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/core/JvmSafepointTest.java
+++ b/src/test/java/net/openhft/chronicle/core/JvmSafepointTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/core/JvmTest.java
+++ b/src/test/java/net/openhft/chronicle/core/JvmTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/core/LicenceCheckTest.java
+++ b/src/test/java/net/openhft/chronicle/core/LicenceCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  */
 
 package net.openhft.chronicle.core;

--- a/src/test/java/net/openhft/chronicle/core/MathsTest.java
+++ b/src/test/java/net/openhft/chronicle/core/MathsTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/core/MemoryTest.java
+++ b/src/test/java/net/openhft/chronicle/core/MemoryTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/core/MockerTest.java
+++ b/src/test/java/net/openhft/chronicle/core/MockerTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/core/NotNullIntrumentationTargetTest.java
+++ b/src/test/java/net/openhft/chronicle/core/NotNullIntrumentationTargetTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/core/OSTest.java
+++ b/src/test/java/net/openhft/chronicle/core/OSTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/core/RandomAccessFileCleanupMain.java
+++ b/src/test/java/net/openhft/chronicle/core/RandomAccessFileCleanupMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  */
 
 package net.openhft.chronicle.core;

--- a/src/test/java/net/openhft/chronicle/core/SleepTesterMain.java
+++ b/src/test/java/net/openhft/chronicle/core/SleepTesterMain.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/core/StackTraceTest.java
+++ b/src/test/java/net/openhft/chronicle/core/StackTraceTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/core/UnsafeMemory2Test.java
+++ b/src/test/java/net/openhft/chronicle/core/UnsafeMemory2Test.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/core/UnsafeMemoryByteTest.java
+++ b/src/test/java/net/openhft/chronicle/core/UnsafeMemoryByteTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/core/UnsafeMemoryIntTest.java
+++ b/src/test/java/net/openhft/chronicle/core/UnsafeMemoryIntTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/core/UnsafeMemoryLongTest.java
+++ b/src/test/java/net/openhft/chronicle/core/UnsafeMemoryLongTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/core/UnsafeMemoryShortTest.java
+++ b/src/test/java/net/openhft/chronicle/core/UnsafeMemoryShortTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/core/UnsafeMemoryTest.java
+++ b/src/test/java/net/openhft/chronicle/core/UnsafeMemoryTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/core/UnsafeMemoryTestMixin.java
+++ b/src/test/java/net/openhft/chronicle/core/UnsafeMemoryTestMixin.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/core/UnsafePingPointMain.java
+++ b/src/test/java/net/openhft/chronicle/core/UnsafePingPointMain.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/core/ZeroCostAssertionStatusTest.java
+++ b/src/test/java/net/openhft/chronicle/core/ZeroCostAssertionStatusTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/core/annotation/ScopeConfinedTest.java
+++ b/src/test/java/net/openhft/chronicle/core/annotation/ScopeConfinedTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/core/benchmarks/Randomness.java
+++ b/src/test/java/net/openhft/chronicle/core/benchmarks/Randomness.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/core/cleaner/impl/CleanerTestUtil.java
+++ b/src/test/java/net/openhft/chronicle/core/cleaner/impl/CleanerTestUtil.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/core/cleaner/impl/jdk9/Jdk9ByteBufferCleanerServiceTest.java
+++ b/src/test/java/net/openhft/chronicle/core/cleaner/impl/jdk9/Jdk9ByteBufferCleanerServiceTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/core/cleaner/impl/reflect/ReflectionBasedByteBufferCleanerServiceTest.java
+++ b/src/test/java/net/openhft/chronicle/core/cleaner/impl/reflect/ReflectionBasedByteBufferCleanerServiceTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/core/internal/JvmExceptionTracker.java
+++ b/src/test/java/net/openhft/chronicle/core/internal/JvmExceptionTracker.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/core/internal/analytics/AnalyticsFacadeTest.java
+++ b/src/test/java/net/openhft/chronicle/core/internal/analytics/AnalyticsFacadeTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/core/internal/analytics/StandardMapsTest.java
+++ b/src/test/java/net/openhft/chronicle/core/internal/analytics/StandardMapsTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/core/internal/util/VanillaThreadConfinementAsserterTest.java
+++ b/src/test/java/net/openhft/chronicle/core/internal/util/VanillaThreadConfinementAsserterTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/core/io/AbstractCloseableReferenceCountedTest.java
+++ b/src/test/java/net/openhft/chronicle/core/io/AbstractCloseableReferenceCountedTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/core/io/AbstractCloseableTest.java
+++ b/src/test/java/net/openhft/chronicle/core/io/AbstractCloseableTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/core/io/AbstractReferenceCountedTest.java
+++ b/src/test/java/net/openhft/chronicle/core/io/AbstractReferenceCountedTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/core/io/BackgroundResourceReleaserMain.java
+++ b/src/test/java/net/openhft/chronicle/core/io/BackgroundResourceReleaserMain.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/core/io/BackgroundResourceReleaserTest.java
+++ b/src/test/java/net/openhft/chronicle/core/io/BackgroundResourceReleaserTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/core/io/CloseableTest.java
+++ b/src/test/java/net/openhft/chronicle/core/io/CloseableTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/core/io/IOBenchmarkMain.java
+++ b/src/test/java/net/openhft/chronicle/core/io/IOBenchmarkMain.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/core/io/IOToolsTest.java
+++ b/src/test/java/net/openhft/chronicle/core/io/IOToolsTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/core/io/ReferenceOwnerTest.java
+++ b/src/test/java/net/openhft/chronicle/core/io/ReferenceOwnerTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/core/io/UnsafeCloseableTest.java
+++ b/src/test/java/net/openhft/chronicle/core/io/UnsafeCloseableTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/core/io/ValidatableTest.java
+++ b/src/test/java/net/openhft/chronicle/core/io/ValidatableTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/core/jitter/LongPingPongMain.java
+++ b/src/test/java/net/openhft/chronicle/core/jitter/LongPingPongMain.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/core/onoes/ExceptionHandlerTest.java
+++ b/src/test/java/net/openhft/chronicle/core/onoes/ExceptionHandlerTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/core/onoes/ExceptionKeyTest.java
+++ b/src/test/java/net/openhft/chronicle/core/onoes/ExceptionKeyTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/core/pool/ClassAliasPoolTest.java
+++ b/src/test/java/net/openhft/chronicle/core/pool/ClassAliasPoolTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/core/pool/DynamicEnumPooledClassTest.java
+++ b/src/test/java/net/openhft/chronicle/core/pool/DynamicEnumPooledClassTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/core/pool/Ecn.java
+++ b/src/test/java/net/openhft/chronicle/core/pool/Ecn.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/core/pool/EcnDynamic.java
+++ b/src/test/java/net/openhft/chronicle/core/pool/EcnDynamic.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/core/pool/EnumInternerTest.java
+++ b/src/test/java/net/openhft/chronicle/core/pool/EnumInternerTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/core/pool/ParsingCacheTest.java
+++ b/src/test/java/net/openhft/chronicle/core/pool/ParsingCacheTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/core/pool/StaticEnumClassTest.java
+++ b/src/test/java/net/openhft/chronicle/core/pool/StaticEnumClassTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/core/pool/StringInternerTest.java
+++ b/src/test/java/net/openhft/chronicle/core/pool/StringInternerTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/core/pool/YesNo.java
+++ b/src/test/java/net/openhft/chronicle/core/pool/YesNo.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/core/threads/CleaningThreadTest.java
+++ b/src/test/java/net/openhft/chronicle/core/threads/CleaningThreadTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/core/threads/InvalidEventHandlerExceptionTest.java
+++ b/src/test/java/net/openhft/chronicle/core/threads/InvalidEventHandlerExceptionTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/core/threads/OnDemandEventLoopTest.java
+++ b/src/test/java/net/openhft/chronicle/core/threads/OnDemandEventLoopTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/core/time/LongTimeTest.java
+++ b/src/test/java/net/openhft/chronicle/core/time/LongTimeTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/core/time/PosixTimeProviderTest.java
+++ b/src/test/java/net/openhft/chronicle/core/time/PosixTimeProviderTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/core/time/SetTimeProviderTest.java
+++ b/src/test/java/net/openhft/chronicle/core/time/SetTimeProviderTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/core/time/SystemTimeProviderTest.java
+++ b/src/test/java/net/openhft/chronicle/core/time/SystemTimeProviderTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/core/time/UniqueMicroTimeProviderTest.java
+++ b/src/test/java/net/openhft/chronicle/core/time/UniqueMicroTimeProviderTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/core/util/AbstractInvocationHandlerTest.java
+++ b/src/test/java/net/openhft/chronicle/core/util/AbstractInvocationHandlerTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/core/util/GenericReflectionTest.java
+++ b/src/test/java/net/openhft/chronicle/core/util/GenericReflectionTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/core/util/HistogramTest.java
+++ b/src/test/java/net/openhft/chronicle/core/util/HistogramTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/core/util/IgnoresEverythingTest.java
+++ b/src/test/java/net/openhft/chronicle/core/util/IgnoresEverythingTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/core/util/IntConditionTest.java
+++ b/src/test/java/net/openhft/chronicle/core/util/IntConditionTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/core/util/ObjectUtilsConvertToTest.java
+++ b/src/test/java/net/openhft/chronicle/core/util/ObjectUtilsConvertToTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/core/util/ObjectUtilsTest.java
+++ b/src/test/java/net/openhft/chronicle/core/util/ObjectUtilsTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/core/util/RecordingHistogramTest.java
+++ b/src/test/java/net/openhft/chronicle/core/util/RecordingHistogramTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/core/util/StringUtilsTest.java
+++ b/src/test/java/net/openhft/chronicle/core/util/StringUtilsTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/core/util/ThrowingFunctionTest.java
+++ b/src/test/java/net/openhft/chronicle/core/util/ThrowingFunctionTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/core/util/TypeOfTest.java
+++ b/src/test/java/net/openhft/chronicle/core/util/TypeOfTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/core/util/WeakIdentityHashMapTest.java
+++ b/src/test/java/net/openhft/chronicle/core/util/WeakIdentityHashMapTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/resources/META-INF/services/net.openhft.chronicle.core.ChronicleInitRunnable
+++ b/src/test/resources/META-INF/services/net.openhft.chronicle.core.ChronicleInitRunnable
@@ -1,7 +1,5 @@
 #
-# Copyright 2016-2022 chronicle.software
-#
-#       https://chronicle.software
+# Copyright 2016-2025 chronicle.software
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/resources/META-INF/services/net.openhft.chronicle.core.cleaner.spi.ByteBufferCleanerService
+++ b/src/test/resources/META-INF/services/net.openhft.chronicle.core.cleaner.spi.ByteBufferCleanerService
@@ -1,7 +1,5 @@
 #
-# Copyright 2016-2022 chronicle.software
-#
-#       https://chronicle.software
+# Copyright 2016-2025 chronicle.software
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/system.properties
+++ b/system.properties
@@ -1,7 +1,5 @@
 #
-# Copyright 2016-2022 chronicle.software
-#
-#       https://chronicle.software
+# Copyright 2016-2025 chronicle.software
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
This PR refreshes copyright notices across the project to **2016–2025** and removes the now-redundant `https://chronicle.software` line from header blocks. The update spans Maven POMs, Java sources, tests, resources, and properties files to keep legal attributions current and consistent.

## Scope of changes

* **Bumped years** to `2016–2025` in:

  * Module POMs: `assertions-*/pom.xml`, `benchmarks/pom.xml`, root `pom.xml`.
  * Java sources under `src/main/java/**` (core, annotations, io, threads, time, util, values, internal, cleaner, analytics, etc.).
  * Tests under `src/test/java/**` and service descriptors under `src/test/resources/**`.
  * Resource/service files and properties under `src/main/resources/**`.
  * `system.properties`.
* **Removed URL line** (`https://chronicle.software`) from header comments where present to simplify and standardize headers.
* **Normalized attributions** in a couple of resource files:

  * `Google.properties` and `Stackoverflow.properties` now attribute `2016–2025 chronicle.software` instead of the old `higherfrequencytrading.com`.

## Functional impact

**None.** All edits are in comment blocks or resource metadata only. No code logic, configuration behavior, or build settings were changed.

## Why this is useful

* Keeps legal notices accurate for the new year.
* Ensures consistent header formatting across all modules and artifacts.
* Removes stale domain lines from headers to avoid duplication and drift.