### PR TITLE
SLF4J logging now is not linked to debug being enabled

### DIFF
--- a/src/main/java/net/openhft/chronicle/core/onoes/Slf4jExceptionHandler.java
+++ b/src/main/java/net/openhft/chronicle/core/onoes/Slf4jExceptionHandler.java
@@ -21,7 +21,12 @@ public enum Slf4jExceptionHandler implements ExceptionHandler {
     ERROR(Logger::error),
     WARN(Logger::warn),
     PERF(Logger::info),
-    DEBUG(Logger::debug);
+    DEBUG(Logger::debug) {
+        @Override
+        public boolean isEnabled(@NotNull Class<?> aClass) {
+            return getLogger(aClass).isDebugEnabled();
+        }
+    };
 
     private final LogMethod logMethod;
 
@@ -55,11 +60,6 @@ public enum Slf4jExceptionHandler implements ExceptionHandler {
             }
             t.printStackTrace();
         }
-    }
-
-    @Override
-    public boolean isEnabled(@NotNull Class<?> aClass) {
-        return getLogger(aClass).isDebugEnabled();
     }
 
     static Logger getLogger(Class<?> clazz) {


### PR DESCRIPTION
all `isEnabled(class)` calls were linked to whether the debug logger was enabled, revert to correct this issue