### PR TITLE
Cache thread liveness once per orphan-cleanup sweep

### DIFF
--- a/src/main/java/net/openhft/chronicle/core/threads/CleaningThreadLocal.java
+++ b/src/main/java/net/openhft/chronicle/core/threads/CleaningThreadLocal.java
@@ -11,6 +11,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
 
@@ -216,8 +217,16 @@ public class CleaningThreadLocal<T> extends ThreadLocal<T> {
      *
      * <p>Call at whatever cadence suits your application (e.g.&nbsp;every few
      * seconds, once a minute, or only at JVM shutdown).</p>
+     *
+     * <p>Liveness is sampled once per distinct thread during each sweep. If a
+     * thread terminates after being observed alive, its remaining values are
+     * retained until the next sweep.</p>
      */
     public static void cleanupNonCleaningThreads() {
+        cleanupNonCleaningThreads(Thread::isAlive);
+    }
+
+    static void cleanupNonCleaningThreads(Predicate<Thread> isThreadAlive) {
         // Drain stale entries under the lock, then run user cleanup
         // callbacks outside it so slow cleanup code never blocks
         // set()/remove()/initialValue() across the JVM.
@@ -226,7 +235,11 @@ public class CleaningThreadLocal<T> extends ThreadLocal<T> {
             if (cleaningThreadLocals.isEmpty())
                 return;
             pendingCleanups = new ArrayList<>();
-            cleaningThreadLocals.removeIf(ctl -> ctl.drainStaleInto(pendingCleanups));
+            //! Cache across all locals because thread keys are unique within each local map.
+            //! Keep the cache per sweep so a later sweep always refreshes liveness.
+            Map<Thread, Boolean> livenessByThread = new IdentityHashMap<>();
+            cleaningThreadLocals.removeIf(ctl ->
+                    ctl.drainStaleInto(pendingCleanups, livenessByThread, isThreadAlive));
         }
 
         for (Runnable r : pendingCleanups)
@@ -234,7 +247,9 @@ public class CleaningThreadLocal<T> extends ThreadLocal<T> {
     }
 
     // holds lock on cleaningThreadLocals
-    private boolean drainStaleInto(List<Runnable> sink) {
+    private boolean drainStaleInto(List<Runnable> sink,
+                                   Map<Thread, Boolean> livenessByThread,
+                                   Predicate<Thread> isThreadAlive) {
         if (!trackNonCleaningThreads)
             return true;
 
@@ -243,7 +258,8 @@ public class CleaningThreadLocal<T> extends ThreadLocal<T> {
              mapIt.hasNext(); ) {
 
             Map.Entry<Thread, Object> e = mapIt.next();
-            if (!e.getKey().isAlive()) {
+            boolean isAlive = livenessByThread.computeIfAbsent(e.getKey(), isThreadAlive::test);
+            if (!isAlive) {
                 Object staleValue = e.getValue();
                 sink.add(() -> cleanup(uncheckedCast(staleValue)));
                 mapIt.remove();

--- a/src/test/java/net/openhft/chronicle/core/threads/CleaningThreadLocalIntegrationTest.java
+++ b/src/test/java/net/openhft/chronicle/core/threads/CleaningThreadLocalIntegrationTest.java
@@ -10,8 +10,11 @@ import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -19,11 +22,94 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Predicate;
 import java.util.function.UnaryOperator;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 class CleaningThreadLocalIntegrationTest {
+
+    @Test
+    void cleanupReusesLivenessAcrossLocalsAndRefreshesEachSweep() throws Exception {
+        int localCount = 5;
+        int workerCount = 4;
+        AtomicInteger cleaned = new AtomicInteger();
+        List<CleaningThreadLocal<TrackedResource>> locals = new ArrayList<>();
+        for (int i = 0; i < localCount; i++) {
+            locals.add(new CleaningThreadLocal<>(
+                    TrackedResource::new,
+                    resource -> {
+                        resource.clean();
+                        cleaned.incrementAndGet();
+                    },
+                    UnaryOperator.identity(),
+                    Boolean.TRUE));
+        }
+
+        CountDownLatch populated = new CountDownLatch(workerCount);
+        CountDownLatch releaseWorkers = new CountDownLatch(1);
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        Set<Thread> workers = Collections.newSetFromMap(new IdentityHashMap<>());
+        for (int i = 0; i < workerCount; i++) {
+            Thread worker = new Thread(() -> {
+                try {
+                    for (CleaningThreadLocal<TrackedResource> local : locals)
+                        local.get();
+                    populated.countDown();
+                    releaseWorkers.await();
+                } catch (Throwable t) {
+                    failure.compareAndSet(null, t);
+                }
+            }, "ctl-shared-worker-" + i);
+            workers.add(worker);
+        }
+
+        try {
+            workers.forEach(Thread::start);
+            assertTrue(populated.await(10, TimeUnit.SECONDS), "workers did not populate all locals");
+
+            AtomicInteger workerLivenessChecks = new AtomicInteger();
+            //! Count only these workers so unrelated tracked locals cannot affect the assertion.
+            Predicate<Thread> countingLiveness = thread -> {
+                if (workers.contains(thread))
+                    workerLivenessChecks.incrementAndGet();
+                return thread.isAlive();
+            };
+            CleaningThreadLocal.cleanupNonCleaningThreads(countingLiveness);
+
+            assertEquals(workerCount, workerLivenessChecks.get(),
+                    "each live worker should be checked once across all locals");
+            assertEquals(0, cleaned.get(), "live worker values should be retained");
+            for (CleaningThreadLocal<TrackedResource> local : locals)
+                assertEquals(workerCount, trackedEntryCount(local),
+                        "each local should retain every live worker value");
+
+            releaseWorkers.countDown();
+            for (Thread worker : workers)
+                worker.join();
+            assertNull(failure.get(), () -> "worker should not fail " + failure.get());
+
+            CleaningThreadLocal.cleanupNonCleaningThreads(countingLiveness);
+
+            assertEquals(workerCount * 2, workerLivenessChecks.get(),
+                    "a new sweep should refresh each worker's liveness");
+            assertEquals(localCount * workerCount, cleaned.get(),
+                    "every terminated-worker value should be cleaned once");
+            for (CleaningThreadLocal<TrackedResource> local : locals)
+                assertEquals(0, trackedEntryCount(local),
+                        "terminated-worker values should be removed");
+
+            CleaningThreadLocal.cleanupNonCleaningThreads(countingLiveness);
+            assertEquals(workerCount * 2, workerLivenessChecks.get(),
+                    "an empty sweep should not recheck removed workers");
+            assertEquals(localCount * workerCount, cleaned.get(),
+                    "an empty sweep should not repeat cleanup");
+        } finally {
+            releaseWorkers.countDown();
+            for (Thread worker : workers)
+                worker.join(10_000);
+        }
+    }
 
     @Test
     void cleanupNonCleaningThreadsHandlesConcurrentCallers() throws Exception {


### PR DESCRIPTION
## Summary

Reduce repeated `Thread.isAlive()` calls during `CleaningThreadLocal` orphan cleanup by caching liveness once per distinct thread for the duration of one complete cleanup sweep.

Let:

* `E` be the total number of tracked thread/value entries across all `CleaningThreadLocal` instances.
* `U` be the number of distinct tracked threads.

The sweep still visits all `E` entries, but the number of liveness checks is reduced from `E` to `U` when thread identities are shared across locals.

## Implementation

* Create one short-lived `IdentityHashMap<Thread, Boolean>` after the empty-set check.
* Share that cache while draining every tracked `CleaningThreadLocal` in the sweep.
* Discard the cache after the sweep so liveness is checked again on the next invocation.
* Preserve the existing separation between draining under the global lock and running cleanup callbacks outside it.
* Keep the public API unchanged.

Thread identities are unique within each individual `nonCleaningThreadValues` map. Cache reuse occurs across different `CleaningThreadLocal` instances populated by the same threads.

## Behavioural impact

Cleanup remains best-effort. Liveness is sampled once per distinct thread during a sweep. If a thread is observed alive and then terminates part-way through that sweep, values encountered later for that thread may remain until the next sweep. A fresh cache is created for every sweep.

No long-lived state, expiry policy or additional synchronisation is introduced.

## Validation

The cross-local integration test uses the same four worker threads to populate five locals and verifies:

* four liveness checks per populated sweep rather than twenty;
* live values remain tracked;
* a later sweep refreshes liveness after the workers terminate;
* all twenty values are cleaned exactly once; and
* a subsequent empty sweep performs no repeated cleanup.

Relevant tests pass on Java 8 and Java 21, and the full Maven verification passes on Java 21.

## Performance evidence

The call-count test establishes that the corrected cache eliminates repeated liveness checks when threads are shared across locals. It does not establish an elapsed-time improvement. Any performance claim should be supported separately with before/after measurements on the JVM and workload associated with the reported timeout, including a no-sharing control where each thread appears in only one local.
