### PR TITLE
CORE-61: Add @Address semantics assertion layer

### DIFF
--- a/src/main/java/net/openhft/chronicle/core/aegis/MemoryAegis.java
+++ b/src/main/java/net/openhft/chronicle/core/aegis/MemoryAegis.java
@@ -45,7 +45,8 @@ import org.jetbrains.annotations.NotNull;
  * <h2>Usage patterns</h2>
  *
  * <p>The assertions return {@code true} so they chain cleanly into the
- * {@code assert SKIP_ASSERTIONS || ...} idiom; if assertions are disabled
+ * {@code assert SKIP_ASSERTIONS || ...} idiom; if SKIP_ASSERTIONS is true
+ * the whole line is compiled away and doesn't add to bytecode. if assertions are disabled
  * (the normal production posture) the JIT elides the whole right-hand side.
  * The following examples show the intended adoption pattern for low-level
  * callers such as {@code UnsafeMemory} and helpers built on {@code OS.memory()}.

--- a/src/main/java/net/openhft/chronicle/core/aegis/MemoryAegis.java
+++ b/src/main/java/net/openhft/chronicle/core/aegis/MemoryAegis.java
@@ -1,0 +1,280 @@
+/*
+ * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.core.aegis;
+
+import net.openhft.chronicle.core.annotation.Address;
+import net.openhft.chronicle.core.annotation.NonNegative;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Central assertion helpers for low-level memory access.
+ *
+ * <p>These helpers are intended for use with Chronicle's
+ * {@code assert SKIP_ASSERTIONS || ...} idiom so hot-path checks still
+ * compile out in the normal assertions-disabled build while debug builds
+ * keep precise range validation and failure messages.</p>
+ *
+ * <p>Public surface:</p>
+ * <ul>
+ *   <li>{@link #assertByteArrayRange(byte[], int, int)},
+ *       {@link #assertCharArrayRange(char[], int, int)},
+ *       {@link #assertStringRange(String, int, int)} - on-heap slice bounds
+ *       against the array/string length. Offset and length are {@code int}
+ *       because the backing {@code length} / {@link String#length()} is also
+ *       {@code int}.</li>
+ *   <li>{@link #assertAddressRange(long, long)} - bounded native-address
+ *       range against {@link NativeAddressSpace}.</li>
+ *   <li>{@link #assertObjectRange(Object, long, long)} - object-relative
+ *       byte range bounded by {@link NativeAddressSpace#maxAddressExclusive()}.</li>
+ * </ul>
+ *
+ * <p><b>Unsafe-style on-heap-or-off-heap access:</b> there is no combined
+ * helper because the same {@code offset} argument means two different things
+ * depending on whether the caller is passing an object reference. Inline the
+ * dispatch at the call site so the contract is visible to the reader; see the
+ * "Usage patterns" examples below.</p>
+ *
+ * <p><b>Address-space assumption:</b> these guards intentionally model only
+ * ordinary non-negative user-space ranges. They do not attempt to validate
+ * negative or sign-extended special mappings such as the legacy x86-64
+ * {@code [vsyscall]} mapping visible in {@code /proc/self/maps}. Call sites
+ * that genuinely need to touch those regions should not route through
+ * {@code MemoryAegis} until Chronicle has a separate policy for them.</p>
+ *
+ * <h2>Usage patterns</h2>
+ *
+ * <p>The assertions return {@code true} so they chain cleanly into the
+ * {@code assert SKIP_ASSERTIONS || ...} idiom; if assertions are disabled
+ * (the normal production posture) the JIT elides the whole right-hand side.
+ * The following examples show the intended adoption pattern for low-level
+ * callers such as {@code UnsafeMemory} and helpers built on {@code OS.memory()}.
+ * They document how to wire the checks cleanly without claiming that every
+ * existing caller has already been migrated.</p>
+ *
+ * <p><b>Fixed-width primitive read at a native address.</b> The width is the
+ * {@code TYPE.BYTES} constant so the assertion covers exactly the range that
+ * {@code Unsafe.getXxx} will touch:</p>
+ * <pre>{@code
+ * public static long unsafeGetLong(@Address long address) {
+ *     assert SKIP_ASSERTIONS || MemoryAegis.assertAddressRange(address, Long.BYTES);
+ *     return UNSAFE.getLong(address);
+ * }
+ * }</pre>
+ *
+ * <p><b>Fixed-width primitive write into an on-heap byte array.</b> Use the
+ * array variant so the check runs against the array length rather than the
+ * native-address ceiling:</p>
+ * <pre>{@code
+ * public static void putInt(byte[] bytes, @NonNegative int offset, int value) {
+ *     assert SKIP_ASSERTIONS || MemoryAegis.assertByteArrayRange(bytes, offset, Integer.BYTES);
+ *     UNSAFE.putInt(bytes, ARRAY_BYTE_BASE_OFFSET + offset, value);
+ * }
+ * }</pre>
+ *
+ * <p><b>Native-to-native copy.</b> Each operand has its own assertion because
+ * {@code from} and {@code to} are independent address ranges:</p>
+ * <pre>{@code
+ * public static void copyMemory(@Address long from, @Address long to, @NonNegative int length) {
+ *     assert SKIP_ASSERTIONS || MemoryAegis.assertAddressRange(from, length);
+ *     assert SKIP_ASSERTIONS || MemoryAegis.assertAddressRange(to, length);
+ *     MEMORY.copyMemory(from, to, (long) length);
+ * }
+ * }</pre>
+ *
+ * <p><b>Unsafe-style access that may be on-heap or off-heap.</b> When the
+ * {@code object} reference is {@code null} the offset is an absolute native
+ * address; otherwise it is an object-relative offset (field offset, array
+ * base offset + index, etc.). Inline the dispatch at the call site: the
+ * ternary keeps both contracts visible to the reader and to any static
+ * analyser, which a combined {@code assertObjectOrAddressRange} would
+ * obscure behind one ambiguous entry point:</p>
+ * <pre>{@code
+ * public static void unsafePutBoolean(Object obj, @NonNegative long offset, boolean value) {
+ *     assert SKIP_ASSERTIONS || (obj == null
+ *             ? MemoryAegis.assertAddressRange(offset, Byte.BYTES)
+ *             : MemoryAegis.assertObjectRange(obj, offset, Byte.BYTES));
+ *     UNSAFE.putBoolean(obj, offset, value);
+ * }
+ * }</pre>
+ */
+public final class MemoryAegis {
+
+    private MemoryAegis() {
+    }
+
+    /**
+     * Asserts that an on-heap byte-array slice is valid.
+     *
+     * @param bytes  the source array
+     * @param offset the slice start
+     * @param length the slice length
+     * @return {@code true}
+     * @throws AssertionError if the slice is invalid
+     */
+    public static boolean assertByteArrayRange(final byte @NotNull [] bytes,
+                                               final @NonNegative int offset,
+                                               final @NonNegative int length) {
+        //noinspection ConstantValue
+        if (bytes == null)
+            throw new AssertionError("bytes must not be null");
+        return assertSizedRange("bytes.length", bytes.length, offset, length);
+    }
+
+    /**
+     * Asserts that an on-heap char-array slice is valid.
+     *
+     * @param chars  the source array
+     * @param offset the slice start
+     * @param length the slice length
+     * @return {@code true}
+     * @throws AssertionError if the slice is invalid
+     */
+    public static boolean assertCharArrayRange(final char @NotNull [] chars,
+                                               final @NonNegative int offset,
+                                               final @NonNegative int length) {
+        //noinspection ConstantValue
+        if (chars == null)
+            throw new AssertionError("chars must not be null");
+        return assertSizedRange("chars.length", chars.length, offset, length);
+    }
+
+    /**
+     * Asserts that a string slice is valid.
+     *
+     * <p><b>Unit:</b> {@code start} and {@code length} are counted in
+     * {@link String#length()} units (UTF-16 code units), not bytes. Callers
+     * reading bytes from a compact-string backing array (Java 9+) must use a
+     * byte-unit guard such as {@link #assertObjectRange(Object, long, long)}
+     * against the backing array instead.</p>
+     *
+     * @param text   the source string
+     * @param start  the slice start, in {@link String#length()} units
+     * @param length the slice length, in {@link String#length()} units
+     * @return {@code true}
+     * @throws AssertionError if the slice is invalid
+     */
+    public static boolean assertStringRange(final @NotNull String text,
+                                            final @NonNegative int start,
+                                            final @NonNegative int length) {
+        //noinspection ConstantValue
+        if (text == null)
+            throw new AssertionError("text must not be null");
+        return assertSizedRange("text.length()", text.length(), start, length);
+    }
+
+    /**
+     * Asserts that the byte range {@code [address, address + length)} lies
+     * inside the configured native-address space
+     * {@code [NativeAddressSpace.minAddress(), NativeAddressSpace.maxAddressExclusive())}.
+     *
+     * <p>Rejects: {@code length < 0}; {@code address} in the reserved low
+     * guard area (below {@link NativeAddressSpace#minAddress()}); {@code address}
+     * at or above {@link NativeAddressSpace#maxAddressExclusive()}; and ranges
+     * that would wrap past the ceiling. This deliberately excludes negative
+     * special mappings such as the legacy x86-64 {@code [vsyscall]} mapping;
+     * {@code MemoryAegis} models ordinary user-space addresses only.</p>
+     *
+     * @param address the native start address
+     * @param length  the number of bytes covered
+     * @return {@code true}
+     * @throws AssertionError if the range is invalid
+     */
+    public static boolean assertAddressRange(final @Address long address,
+                                             final @NonNegative long length) {
+        if (length < 0)
+            throw new AssertionError("length must be >= 0: length=" + length);
+        if (address < NativeAddressSpace.minAddress())
+            throw new AssertionError("address must be >= " + NativeAddressSpace.minAddress()
+                    + " (inclusive lower bound): address=" + address);
+        if (address >= NativeAddressSpace.maxAddressExclusive())
+            throw new AssertionError("address must be <= " + NativeAddressSpace.maxAddressInclusive()
+                    + " (inclusive upper bound): address=" + address);
+        if (NativeAddressSpace.wouldOverflow(address, length))
+            throw new AssertionError("native range exceeds configured address space"
+                    + ": address=" + address
+                    + ", length=" + length
+                    + ", maxAddressExclusive=" + NativeAddressSpace.maxAddressExclusive());
+        return true;
+    }
+
+    /**
+     * Asserts that the byte range {@code [offset, offset + length)} is a
+     * valid object-relative Unsafe access on {@code object}.
+     *
+     * <p>Rejects: {@code object == null}; {@code offset < 0}; {@code length < 0};
+     * {@code offset} at or above {@link NativeAddressSpace#maxAddressExclusive()}
+     * (the same ceiling native addresses obey, which keeps object offsets and
+     * native addresses on one consistent bound); and ranges that would wrap
+     * past that ceiling.</p>
+     *
+     * <p><b>On the ceiling's tightness:</b> real object offsets (field offsets,
+     * array base + index) are many orders of magnitude below
+     * {@link NativeAddressSpace#maxAddressExclusive()}. The ceiling here is a
+     * symmetry choice with {@link #assertAddressRange(long, long)}, not a tight
+     * backstop against runaway offsets. The checks that catch real bugs in this
+     * method are the non-null, non-negative, and non-overflow guards; do not
+     * rely on the ceiling to flag out-of-bounds object accesses.</p>
+     *
+     * @param object the target object
+     * @param offset the starting offset
+     * @param length the number of bytes covered
+     * @return {@code true}
+     * @throws AssertionError if the range is invalid
+     */
+    public static boolean assertObjectRange(final @NotNull Object object,
+                                            final @NonNegative long offset,
+                                            final @NonNegative long length) {
+        //noinspection ConstantValue
+        if (object == null)
+            throw new AssertionError("object must not be null");
+        if (offset < 0)
+            throw new AssertionError("offset must be >= 0: offset=" + offset);
+        if (length < 0)
+            throw new AssertionError("length must be >= 0: length=" + length);
+        if (offset >= NativeAddressSpace.maxAddressExclusive())
+            throw new AssertionError("offset must be <= " + NativeAddressSpace.maxAddressInclusive()
+                    + " (inclusive upper bound): offset=" + offset);
+        if (length >= NativeAddressSpace.maxAddressExclusive())
+            throw new AssertionError("length must be <= " + NativeAddressSpace.maxAddressInclusive()
+                    + " (inclusive upper bound): length=" + length);
+        if (NativeAddressSpace.wouldOverflow(offset, length))
+            throw new AssertionError("object range exceeds configured address space"
+                    + ": offset=" + offset
+                    + ", length=" + length
+                    + ", maxAddressExclusive=" + NativeAddressSpace.maxAddressExclusive());
+        return true;
+    }
+
+    // All three parameters are `int`: `size` is `bytes.length` / `chars.length`
+    // / `text.length()`, and the public wrappers now also take `int` offsets /
+    // lengths because slices into on-heap collections are naturally int-bounded.
+    // `length > size` and `offset > size - length` stay numerically correct
+    // given that the earlier negative-checks guarantee both are >= 0 and size
+    // is >= 0 by construction.
+    private static boolean assertSizedRange(final String sizeName,
+                                            final int size,
+                                            final int offset,
+                                            final int length) {
+        if (offset < 0)
+            throw new AssertionError("offset must be >= 0: offset=" + offset);
+        if (length < 0)
+            throw new AssertionError("length must be >= 0: length=" + length);
+        // Check length against size before the combined slice check so the
+        // failure message names the oversized parameter directly rather than
+        // reporting "slice exceeds" for any overflow.
+        if (length > size) {
+            throw new AssertionError("length exceeds " + sizeName
+                    + ": length=" + length
+                    + ", " + sizeName + "=" + size);
+        }
+        if (offset > size - length) {
+            throw new AssertionError("slice exceeds " + sizeName
+                    + ": offset=" + offset
+                    + ", length=" + length
+                    + ", " + sizeName + "=" + size
+                    + ", end=" + (offset + length));
+        }
+        return true;
+    }
+}

--- a/src/main/java/net/openhft/chronicle/core/aegis/NativeAddressSpace.java
+++ b/src/main/java/net/openhft/chronicle/core/aegis/NativeAddressSpace.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.core.aegis;
+
+import net.openhft.chronicle.core.annotation.Address;
+import net.openhft.chronicle.core.annotation.NonNegative;
+import net.openhft.chronicle.core.internal.Bootstrap;
+
+import java.util.Locale;
+
+/**
+ * Shared assumptions and helpers for Chronicle's native-address validation.
+ *
+ * <p>The current model is intentionally conservative: it treats native
+ * addresses as belonging to a bounded user-space range and reserves the first
+ * 64 KiB so null-adjacent addresses are never considered dereferenceable. This
+ * gives {@link MemoryAegis} one consistent notion of "plausible native
+ * address" while still leaving room for small architecture-specific tweaks in
+ * the lazy holder.</p>
+ *
+ * <p>This model intentionally excludes negative or sign-extended special
+ * mappings such as the legacy x86-64 {@code [vsyscall]} mapping visible in
+ * {@code /proc/self/maps}. In other words, the configured range is a
+ * conservative "ordinary user-space" envelope, not a complete model of every
+ * mapping the OS might expose.</p>
+ *
+ * <p>The key bounds live in {@link BoundsHolder} so they are initialized only
+ * if a native-address check is actually executed. Chronicle often compiles
+ * assertion-based checks out of hot paths, so deferring these values keeps the
+ * no-check path free from unnecessary initialization work and leaves room for
+ * more expensive architecture-specific discovery in a later revision.</p>
+ *
+ * <p><b>Inclusive vs exclusive bounds:</b> the address space is modeled as the
+ * half-open interval {@code [minAddress(), maxAddressExclusive())}. Error
+ * messages reporting the upper bound use {@link #maxAddressInclusive()} (the
+ * highest address a caller may legally pass); arithmetic wrap-around checks
+ * use {@link #maxAddressExclusive()} so {@code address + length} never
+ * crosses the ceiling. Do not "unify" the two forms -- they are deliberately
+ * different representations of the same ceiling.</p>
+ *
+ * <p><b>Testability of the holder bounds:</b> {@link BoundsHolder#ADDRESS_BITS}
+ * is resolved once from {@link Bootstrap#OS_ARCH} at class initialisation and
+ * cannot be re-selected for the lifetime of the JVM. Tests that want to cover
+ * a specific address-width policy should drive the pure helper
+ * {@link #addressBitsFor(String)} directly; tests that merely pin the
+ * invariant (for example, that {@link #maxAddressExclusive()} equals
+ * {@code 1L << ADDRESS_BITS}) may read the holder fields freely.</p>
+ */
+final class NativeAddressSpace {
+
+    private NativeAddressSpace() {
+    }
+
+    /**
+     * Returns the lowest address considered dereferenceable by the current
+     * native-address model.
+     *
+     * @return the inclusive lower bound for native addresses
+     */
+    @Address
+    static long minAddress() {
+        return BoundsHolder.MIN_ADDRESS;
+    }
+
+    /**
+     * Returns the exclusive upper bound for the current native-address model.
+     *
+     * @return the exclusive upper bound for native addresses
+     */
+    static long maxAddressExclusive() {
+        return BoundsHolder.MAX_ADDRESS_EXCLUSIVE;
+    }
+
+    /**
+     * Returns the inclusive upper bound for the current native-address model.
+     *
+     * @return the inclusive upper bound for native addresses
+     */
+    @Address
+    static long maxAddressInclusive() {
+        return BoundsHolder.MAX_ADDRESS_INCLUSIVE;
+    }
+
+    /**
+     * Returns {@code true} when {@code baseOffset + length} would cross
+     * {@link #maxAddressExclusive()}. The subtraction form avoids the
+     * signed-overflow hazard of comparing {@code baseOffset + length} against
+     * the ceiling directly.
+     *
+     * <p>The first parameter is deliberately labelled generically: callers
+     * pass a native address ({@link MemoryAegis#assertAddressRange(long, long)})
+     * or an object-relative offset
+     * ({@link MemoryAegis#assertObjectRange(Object, long, long)}); both must
+     * stay below the same configured ceiling.</p>
+     *
+     * @param baseOffset the starting address or object-relative offset
+     * @param length     the byte count covered, must be non-negative
+     * @return {@code true} when the range would exceed the configured ceiling
+     */
+    static boolean wouldOverflow(@NonNegative final long baseOffset,
+                                 @NonNegative final long length) {
+        return length > BoundsHolder.MAX_ADDRESS_EXCLUSIVE - baseOffset;
+    }
+
+    /**
+     * Resolves the address-width assumption for the supplied platform string.
+     *
+     * <p>Only explicit 32-bit architecture aliases ({@code x86_32}, {@code arm_32})
+     * are capped to {@code 2^32}; every other platform - including x86-64 and
+     * arm64 - uses the 56-bit default. The broader ceiling is the safer
+     * choice: some machines expose less than 2^56 of user-space addresses,
+     * while modern x86-64 configurations (Linear Address Masking, 5-level
+     * paging) can exceed 2^47 and a tighter x86-64 cap would reject those
+     * legitimate addresses as bogus. A tag-aware arm64 policy is deferred
+     * until the rest of the stack is ready for it.</p>
+     *
+     * @param rawArch the {@code os.arch} value
+     * @return the assumed number of address bits for the platform
+     */
+    static int addressBitsFor(final String rawArch) {
+        switch (normalizeArch(rawArch)) {
+            case "x86_32":
+            case "arm_32":
+                return 32;
+
+            default:
+                return 56;
+        }
+    }
+
+    /**
+     * Normalizes 32-bit {@code os.arch} aliases into the buckets that
+     * {@link #addressBitsFor(String)} recognises. Anything else - x86-64,
+     * arm64, riscv64, ... - is returned in lower-case trimmed form and falls
+     * through to the 56-bit default.
+     *
+     * @param rawArch the raw architecture string
+     * @return the normalized architecture bucket
+     */
+    static String normalizeArch(final String rawArch) {
+        final String arch = rawArch == null ? "" : rawArch.toLowerCase(Locale.ROOT).trim();
+        switch (arch) {
+            case "x86":
+            case "i386":
+            case "i486":
+            case "i586":
+            case "i686":
+                return "x86_32";
+
+            case "arm":
+            case "arm32":
+            case "armv6":
+            case "armv6l":
+            case "armv7":
+            case "armv7l":
+                return "arm_32";
+
+            default:
+                return arch;
+        }
+    }
+
+    /**
+     * Lazy holder for the default native-address bounds.
+     */
+    static final class BoundsHolder {
+        static final long MIN_ADDRESS = 64L << 10;
+        static final int ADDRESS_BITS = addressBitsFor(Bootstrap.OS_ARCH);
+        static final long MAX_ADDRESS_EXCLUSIVE = 1L << ADDRESS_BITS;
+        static final long MAX_ADDRESS_INCLUSIVE = MAX_ADDRESS_EXCLUSIVE - 1;
+
+        private BoundsHolder() {
+        }
+    }
+}

--- a/src/main/java/net/openhft/chronicle/core/annotation/Address.java
+++ b/src/main/java/net/openhft/chronicle/core/annotation/Address.java
@@ -20,14 +20,14 @@ import java.lang.annotation.Target;
  * such as {@code MemoryAegis.assertAddressRange(...)} when a concrete access
  * width or slice length is known.</p>
  *
- * <pre>{@code
- * @Address long address;
+ * <pre>
+ * {@code @Address} long address;
  *
- * int readInt(@Address long address) {
+ * int readInt({@code @Address} long address) {
  *     assert SKIP_ASSERTIONS || MemoryAegis.assertAddressRange(address, Integer.BYTES);
  *     return ...;
  * }
- * }</pre>
+ * </pre>
  *
  * @see NonNegative
  */

--- a/src/main/java/net/openhft/chronicle/core/annotation/Address.java
+++ b/src/main/java/net/openhft/chronicle/core/annotation/Address.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.core.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * {@code @Address} declares that the annotated value represents a native
+ * memory address or base pointer. It improves API semantics by distinguishing
+ * raw addresses from sizes, indexes, and object-relative offsets.
+ *
+ * <p><b>Retention and effect:</b> Stored in the class file but ignored by the
+ * runtime unless Chronicle tooling checks it.</p>
+ *
+ * <p>This annotation is semantic only. Use it alongside explicit range guards
+ * such as {@code MemoryAegis.assertAddressRange(...)} when a concrete access
+ * width or slice length is known.</p>
+ *
+ * <pre>{@code
+ * @Address long address;
+ *
+ * int readInt(@Address long address) {
+ *     assert SKIP_ASSERTIONS || MemoryAegis.assertAddressRange(address, Integer.BYTES);
+ *     return ...;
+ * }
+ * }</pre>
+ *
+ * @see NonNegative
+ */
+@Retention(RetentionPolicy.CLASS)
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE, ElementType.TYPE_USE})
+public @interface Address {
+
+    /**
+     * Specifies an optional comment to provide additional context or rationale
+     * for why the annotated element represents a native address.
+     *
+     * @return the comment explaining why this address annotation is necessary
+     */
+    String value() default "";
+}

--- a/src/test/java/net/openhft/chronicle/core/aegis/MemoryAegisTest.java
+++ b/src/test/java/net/openhft/chronicle/core/aegis/MemoryAegisTest.java
@@ -13,11 +13,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 // @Before/@After and this project runs only the Jupiter engine (no vintage),
 // so inherited lifecycle methods would silently not fire.
 @DisplayName("MemoryAegis assertion edge coverage tests")
-public class MemoryAegisTest {
+class MemoryAegisTest {
 
     @Test
     @DisplayName("accepts valid byte-array slices, including zero-length at the end")
-    public void byteArrayRangeAcceptsValidSlices() {
+    void byteArrayRangeAcceptsValidSlices() {
         byte[] bytes = new byte[8];
 
         assertTrue(MemoryAegis.assertByteArrayRange(bytes, 0, bytes.length));
@@ -27,119 +27,119 @@ public class MemoryAegisTest {
 
     @Test
     @DisplayName("rejects a null byte array")
-    public void byteArrayRangeRejectsNullArray() {
+    void byteArrayRangeRejectsNullArray() {
         assertAssertionError("bytes must not be null",
                 () -> MemoryAegis.assertByteArrayRange(null, 0, 1));
     }
 
     @Test
     @DisplayName("rejects a negative byte-array offset")
-    public void byteArrayRangeRejectsNegativeOffset() {
+    void byteArrayRangeRejectsNegativeOffset() {
         assertAssertionError("offset must be >= 0",
                 () -> MemoryAegis.assertByteArrayRange(new byte[8], -1, 1));
     }
 
     @Test
     @DisplayName("rejects a negative byte-array length")
-    public void byteArrayRangeRejectsNegativeLength() {
+    void byteArrayRangeRejectsNegativeLength() {
         assertAssertionError("length must be >= 0",
                 () -> MemoryAegis.assertByteArrayRange(new byte[8], 0, -1));
     }
 
     @Test
     @DisplayName("rejects a byte-array length larger than the array")
-    public void byteArrayRangeRejectsLengthBeyondSize() {
+    void byteArrayRangeRejectsLengthBeyondSize() {
         assertAssertionError("length exceeds bytes.length",
                 () -> MemoryAegis.assertByteArrayRange(new byte[8], 0, 9));
     }
 
     @Test
     @DisplayName("rejects a byte-array slice that overruns the end")
-    public void byteArrayRangeRejectsOverflowingSlice() {
+    void byteArrayRangeRejectsOverflowingSlice() {
         assertAssertionError("slice exceeds bytes.length",
                 () -> MemoryAegis.assertByteArrayRange(new byte[8], 6, 3));
     }
 
     @Test
     @DisplayName("rejects Integer.MIN_VALUE byte-array offset")
-    public void byteArrayRangeRejectsIntegerMinOffset() {
+    void byteArrayRangeRejectsIntegerMinOffset() {
         assertAssertionError("offset must be >= 0",
                 () -> MemoryAegis.assertByteArrayRange(new byte[8], Integer.MIN_VALUE, 1));
     }
 
     @Test
     @DisplayName("rejects Integer.MIN_VALUE byte-array length")
-    public void byteArrayRangeRejectsIntegerMinLength() {
+    void byteArrayRangeRejectsIntegerMinLength() {
         assertAssertionError("length must be >= 0",
                 () -> MemoryAegis.assertByteArrayRange(new byte[8], 0, Integer.MIN_VALUE));
     }
 
     @Test
     @DisplayName("rejects Integer.MAX_VALUE byte-array length against a small array")
-    public void byteArrayRangeRejectsIntegerMaxLength() {
+    void byteArrayRangeRejectsIntegerMaxLength() {
         assertAssertionError("length exceeds bytes.length",
                 () -> MemoryAegis.assertByteArrayRange(new byte[8], 0, Integer.MAX_VALUE));
     }
 
     @Test
     @DisplayName("rejects Integer.MAX_VALUE byte-array offset against a small array")
-    public void byteArrayRangeRejectsIntegerMaxOffset() {
+    void byteArrayRangeRejectsIntegerMaxOffset() {
         assertAssertionError("slice exceeds bytes.length",
                 () -> MemoryAegis.assertByteArrayRange(new byte[8], Integer.MAX_VALUE, 1));
     }
 
     @Test
     @DisplayName("rejects a negative byte-array offset even when length is zero")
-    public void byteArrayRangeRejectsNegativeOffsetWithZeroLength() {
+    void byteArrayRangeRejectsNegativeOffsetWithZeroLength() {
         assertAssertionError("offset must be >= 0",
                 () -> MemoryAegis.assertByteArrayRange(new byte[8], -1, 0));
     }
 
     @Test
     @DisplayName("rejects a byte-array offset past the end even when length is zero")
-    public void byteArrayRangeRejectsOffsetPastEndWithZeroLength() {
+    void byteArrayRangeRejectsOffsetPastEndWithZeroLength() {
         assertAssertionError("slice exceeds bytes.length",
                 () -> MemoryAegis.assertByteArrayRange(new byte[8], 9, 0));
     }
 
     @Test
     @DisplayName("accepts a valid char-array slice")
-    public void charArrayRangeAcceptsValidSlice() {
+    void charArrayRangeAcceptsValidSlice() {
         char[] chars = new char[4];
         assertTrue(MemoryAegis.assertCharArrayRange(chars, 1, 2));
     }
 
     @Test
     @DisplayName("rejects a null char array")
-    public void charArrayRangeRejectsNullArray() {
+    void charArrayRangeRejectsNullArray() {
         assertAssertionError("chars must not be null",
                 () -> MemoryAegis.assertCharArrayRange(null, 0, 1));
     }
 
     @Test
     @DisplayName("rejects a char-array slice that overruns the end")
-    public void charArrayRangeRejectsOverflowingSlice() {
+    void charArrayRangeRejectsOverflowingSlice() {
         assertAssertionError("slice exceeds chars.length",
                 () -> MemoryAegis.assertCharArrayRange(new char[4], 3, 2));
     }
 
     @Test
     @DisplayName("rejects a negative char-array offset")
-    public void charArrayRangeRejectsNegativeOffset() {
+    void charArrayRangeRejectsNegativeOffset() {
         assertAssertionError("offset must be >= 0",
                 () -> MemoryAegis.assertCharArrayRange(new char[4], -1, 1));
     }
 
     @Test
     @DisplayName("rejects a negative char-array length")
-    public void charArrayRangeRejectsNegativeLength() {
+    void charArrayRangeRejectsNegativeLength() {
         assertAssertionError("length must be >= 0",
                 () -> MemoryAegis.assertCharArrayRange(new char[4], 0, -1));
     }
 
     @Test
     @DisplayName("rejects Integer.MIN_VALUE char-array offset and length")
-    public void charArrayRangeRejectsIntegerMinEdges() {
+    void charArrayRangeRejectsIntegerMinEdges() {
         assertAssertionError("offset must be >= 0",
                 () -> MemoryAegis.assertCharArrayRange(new char[4], Integer.MIN_VALUE, 1));
         assertAssertionError("length must be >= 0",
@@ -148,7 +148,7 @@ public class MemoryAegisTest {
 
     @Test
     @DisplayName("rejects Integer.MAX_VALUE char-array length and offset against a small array")
-    public void charArrayRangeRejectsIntegerMaxEdges() {
+    void charArrayRangeRejectsIntegerMaxEdges() {
         assertAssertionError("length exceeds chars.length",
                 () -> MemoryAegis.assertCharArrayRange(new char[4], 0, Integer.MAX_VALUE));
         assertAssertionError("slice exceeds chars.length",
@@ -157,7 +157,7 @@ public class MemoryAegisTest {
 
     @Test
     @DisplayName("rejects an invalid char-array offset even when length is zero")
-    public void charArrayRangeRejectsInvalidOffsetWithZeroLength() {
+    void charArrayRangeRejectsInvalidOffsetWithZeroLength() {
         assertAssertionError("offset must be >= 0",
                 () -> MemoryAegis.assertCharArrayRange(new char[4], -1, 0));
         assertAssertionError("slice exceeds chars.length",
@@ -166,27 +166,27 @@ public class MemoryAegisTest {
 
     @Test
     @DisplayName("accepts a valid string slice")
-    public void stringRangeAcceptsValidSlice() {
+    void stringRangeAcceptsValidSlice() {
         assertTrue(MemoryAegis.assertStringRange("abcd", 1, 2));
     }
 
     @Test
     @DisplayName("rejects a null input string")
-    public void stringRangeRejectsNullText() {
+    void stringRangeRejectsNullText() {
         assertAssertionError("text must not be null",
                 () -> MemoryAegis.assertStringRange(null, 0, 1));
     }
 
     @Test
     @DisplayName("rejects a string slice that overruns the end")
-    public void stringRangeRejectsPastEnd() {
+    void stringRangeRejectsPastEnd() {
         assertAssertionError("slice exceeds text.length()",
                 () -> MemoryAegis.assertStringRange("abc", 2, 2));
     }
 
     @Test
     @DisplayName("rejects Integer.MIN_VALUE string start and length")
-    public void stringRangeRejectsIntegerMinEdges() {
+    void stringRangeRejectsIntegerMinEdges() {
         assertAssertionError("offset must be >= 0",
                 () -> MemoryAegis.assertStringRange("abc", Integer.MIN_VALUE, 1));
         assertAssertionError("length must be >= 0",
@@ -195,7 +195,7 @@ public class MemoryAegisTest {
 
     @Test
     @DisplayName("rejects Integer.MAX_VALUE string length and start against a short string")
-    public void stringRangeRejectsIntegerMaxEdges() {
+    void stringRangeRejectsIntegerMaxEdges() {
         assertAssertionError("length exceeds text.length()",
                 () -> MemoryAegis.assertStringRange("abc", 0, Integer.MAX_VALUE));
         assertAssertionError("slice exceeds text.length()",
@@ -204,7 +204,7 @@ public class MemoryAegisTest {
 
     @Test
     @DisplayName("rejects an invalid string start even when length is zero")
-    public void stringRangeRejectsInvalidStartWithZeroLength() {
+    void stringRangeRejectsInvalidStartWithZeroLength() {
         assertAssertionError("offset must be >= 0",
                 () -> MemoryAegis.assertStringRange("abc", -1, 0));
         assertAssertionError("slice exceeds text.length()",
@@ -213,87 +213,87 @@ public class MemoryAegisTest {
 
     @Test
     @DisplayName("accepts the configured native lower bound")
-    public void addressRangeAcceptsConfiguredLowerBound() {
+    void addressRangeAcceptsConfiguredLowerBound() {
         assertTrue(MemoryAegis.assertAddressRange(NativeAddressSpace.minAddress(), 1));
     }
 
     @Test
     @DisplayName("accepts zero-length access at the configured native lower bound")
-    public void addressRangeAcceptsZeroLengthAtLowerBound() {
+    void addressRangeAcceptsZeroLengthAtLowerBound() {
         assertTrue(MemoryAegis.assertAddressRange(NativeAddressSpace.minAddress(), 0));
     }
 
     @Test
     @DisplayName("accepts zero-length access at the inclusive native upper bound")
-    public void addressRangeAcceptsZeroLengthAtConfiguredUpperBound() {
+    void addressRangeAcceptsZeroLengthAtConfiguredUpperBound() {
         assertTrue(MemoryAegis.assertAddressRange(NativeAddressSpace.maxAddressInclusive(), 0));
     }
 
     @Test
     @DisplayName("accepts a single-byte access that ends exactly at the native ceiling")
-    public void addressRangeAcceptsSingleByteRangeEndingAtCeiling() {
+    void addressRangeAcceptsSingleByteRangeEndingAtCeiling() {
         assertTrue(MemoryAegis.assertAddressRange(NativeAddressSpace.maxAddressInclusive(), 1));
     }
 
     @Test
     @DisplayName("rejects a negative native length")
-    public void addressRangeRejectsNegativeLength() {
+    void addressRangeRejectsNegativeLength() {
         assertAssertionError("length must be >= 0",
                 () -> MemoryAegis.assertAddressRange(NativeAddressSpace.minAddress(), -1));
     }
 
     @Test
     @DisplayName("rejects reserved low native address space")
-    public void addressRangeRejectsReservedLowAddressSpace() {
+    void addressRangeRejectsReservedLowAddressSpace() {
         assertAssertionError("address must be >=",
                 () -> MemoryAegis.assertAddressRange(NativeAddressSpace.minAddress() - 1, 1));
     }
 
     @Test
     @DisplayName("rejects the exclusive native upper bound even for zero-length access")
-    public void addressRangeRejectsConfiguredExclusiveUpperBound() {
+    void addressRangeRejectsConfiguredExclusiveUpperBound() {
         assertAssertionError("address must be <=",
                 () -> MemoryAegis.assertAddressRange(NativeAddressSpace.maxAddressExclusive(), 0));
     }
 
     @Test
     @DisplayName("rejects a native range that overflows the configured address space")
-    public void addressRangeRejectsConfiguredUpperBoundOverflow() {
+    void addressRangeRejectsConfiguredUpperBoundOverflow() {
         assertAssertionError("native range exceeds configured address space",
                 () -> MemoryAegis.assertAddressRange(NativeAddressSpace.maxAddressInclusive(), 2));
     }
 
     @Test
     @DisplayName("rejects Long.MIN_VALUE as a native address")
-    public void addressRangeRejectsLongMinAddress() {
+    void addressRangeRejectsLongMinAddress() {
         assertAssertionError("address must be >=",
                 () -> MemoryAegis.assertAddressRange(Long.MIN_VALUE, 1));
     }
 
     @Test
     @DisplayName("rejects Long.MAX_VALUE as a native address")
-    public void addressRangeRejectsLongMaxAddress() {
+    void addressRangeRejectsLongMaxAddress() {
         assertAssertionError("address must be <=",
                 () -> MemoryAegis.assertAddressRange(Long.MAX_VALUE, 1));
     }
 
     @Test
     @DisplayName("rejects Long.MIN_VALUE as a native length")
-    public void addressRangeRejectsLongMinLength() {
+    void addressRangeRejectsLongMinLength() {
         assertAssertionError("length must be >= 0",
                 () -> MemoryAegis.assertAddressRange(NativeAddressSpace.minAddress(), Long.MIN_VALUE));
     }
 
     @Test
     @DisplayName("rejects Long.MAX_VALUE as a native length at a valid address")
-    public void addressRangeRejectsLongMaxLength() {
+    void addressRangeRejectsLongMaxLength() {
         assertAssertionError("native range exceeds configured address space",
                 () -> MemoryAegis.assertAddressRange(NativeAddressSpace.minAddress(), Long.MAX_VALUE));
     }
 
     @Test
     @DisplayName("rejects the legacy x86-64 [vsyscall] address")
-    public void addressRangeRejectsVsyscallMapping() {
+    void addressRangeRejectsVsyscallMapping() {
         // The legacy x86-64 vsyscall page sits at a sign-extended kernel-canonical
         // address (0xFFFFFFFFFF600000). MemoryAegis deliberately models only
         // ordinary non-negative user-space ranges, so the negative long value
@@ -306,7 +306,7 @@ public class MemoryAegisTest {
 
     @Test
     @DisplayName("rejects an invalid native address even when length is zero")
-    public void addressRangeRejectsInvalidAddressWithZeroLength() {
+    void addressRangeRejectsInvalidAddressWithZeroLength() {
         assertAssertionError("address must be >=",
                 () -> MemoryAegis.assertAddressRange(NativeAddressSpace.minAddress() - 1, 0));
         assertAssertionError("address must be >=",
@@ -317,107 +317,107 @@ public class MemoryAegisTest {
 
     @Test
     @DisplayName("accepts zero object-relative offset")
-    public void objectRangeAcceptsZeroOffset() {
+    void objectRangeAcceptsZeroOffset() {
         assertTrue(MemoryAegis.assertObjectRange(new Object(), 0, 4));
     }
 
     @Test
     @DisplayName("accepts zero-length object-relative access at zero offset")
-    public void objectRangeAcceptsZeroLengthAtZeroOffset() {
+    void objectRangeAcceptsZeroLengthAtZeroOffset() {
         assertTrue(MemoryAegis.assertObjectRange(new Object(), 0, 0));
     }
 
     @Test
     @DisplayName("accepts zero-length object-relative access at the inclusive upper bound")
-    public void objectRangeAcceptsZeroLengthAtConfiguredUpperBound() {
+    void objectRangeAcceptsZeroLengthAtConfiguredUpperBound() {
         assertTrue(MemoryAegis.assertObjectRange(new Object(), NativeAddressSpace.maxAddressInclusive(), 0));
     }
 
     @Test
     @DisplayName("accepts a single-byte object-relative access that ends exactly at the ceiling")
-    public void objectRangeAcceptsSingleByteRangeEndingAtCeiling() {
+    void objectRangeAcceptsSingleByteRangeEndingAtCeiling() {
         assertTrue(MemoryAegis.assertObjectRange(new Object(), NativeAddressSpace.maxAddressInclusive(), 1));
     }
 
     @Test
     @DisplayName("accepts a typical object field offset")
-    public void objectRangeAcceptsTypicalFieldOffset() {
+    void objectRangeAcceptsTypicalFieldOffset() {
         assertTrue(MemoryAegis.assertObjectRange(new Object(), 16, Long.BYTES));
     }
 
     @Test
     @DisplayName("rejects a null object target")
-    public void objectRangeRejectsNullObject() {
+    void objectRangeRejectsNullObject() {
         assertAssertionError("object must not be null",
                 () -> MemoryAegis.assertObjectRange(null, 0, 1));
     }
 
     @Test
     @DisplayName("rejects a negative object-relative offset")
-    public void objectRangeRejectsNegativeOffset() {
+    void objectRangeRejectsNegativeOffset() {
         assertAssertionError("offset must be >= 0",
                 () -> MemoryAegis.assertObjectRange(new Object(), -1, 1));
     }
 
     @Test
     @DisplayName("rejects a negative object-relative length")
-    public void objectRangeRejectsNegativeLength() {
+    void objectRangeRejectsNegativeLength() {
         assertAssertionError("length must be >= 0",
                 () -> MemoryAegis.assertObjectRange(new Object(), 0, -1));
     }
 
     @Test
     @DisplayName("rejects the exclusive object-relative upper bound even for zero-length access")
-    public void objectRangeRejectsConfiguredExclusiveUpperBound() {
+    void objectRangeRejectsConfiguredExclusiveUpperBound() {
         assertAssertionError("offset must be <=",
                 () -> MemoryAegis.assertObjectRange(new Object(), NativeAddressSpace.maxAddressExclusive(), 0));
     }
 
     @Test
     @DisplayName("rejects an object-relative range that overflows the configured address space")
-    public void objectRangeRejectsConfiguredUpperBoundOverflow() {
+    void objectRangeRejectsConfiguredUpperBoundOverflow() {
         assertAssertionError("object range exceeds configured address space",
                 () -> MemoryAegis.assertObjectRange(new Object(), NativeAddressSpace.maxAddressInclusive(), 2));
     }
 
     @Test
     @DisplayName("rejects an object-relative length at or above the exclusive upper bound")
-    public void objectRangeRejectsLengthAtConfiguredExclusiveUpperBound() {
+    void objectRangeRejectsLengthAtConfiguredExclusiveUpperBound() {
         assertAssertionError("length must be <=",
                 () -> MemoryAegis.assertObjectRange(new Object(), 0, NativeAddressSpace.maxAddressExclusive()));
     }
 
     @Test
     @DisplayName("rejects Long.MIN_VALUE object-relative offset")
-    public void objectRangeRejectsLongMinOffset() {
+    void objectRangeRejectsLongMinOffset() {
         assertAssertionError("offset must be >= 0",
                 () -> MemoryAegis.assertObjectRange(new Object(), Long.MIN_VALUE, 1));
     }
 
     @Test
     @DisplayName("rejects Long.MAX_VALUE object-relative offset")
-    public void objectRangeRejectsLongMaxOffset() {
+    void objectRangeRejectsLongMaxOffset() {
         assertAssertionError("offset must be <=",
                 () -> MemoryAegis.assertObjectRange(new Object(), Long.MAX_VALUE, 1));
     }
 
     @Test
     @DisplayName("rejects Long.MIN_VALUE object-relative length")
-    public void objectRangeRejectsLongMinLength() {
+    void objectRangeRejectsLongMinLength() {
         assertAssertionError("length must be >= 0",
                 () -> MemoryAegis.assertObjectRange(new Object(), 0, Long.MIN_VALUE));
     }
 
     @Test
     @DisplayName("rejects Long.MAX_VALUE object-relative length")
-    public void objectRangeRejectsLongMaxLength() {
+    void objectRangeRejectsLongMaxLength() {
         assertAssertionError("length must be <=",
                 () -> MemoryAegis.assertObjectRange(new Object(), 0, Long.MAX_VALUE));
     }
 
     @Test
     @DisplayName("rejects an invalid object-relative offset even when length is zero")
-    public void objectRangeRejectsInvalidOffsetWithZeroLength() {
+    void objectRangeRejectsInvalidOffsetWithZeroLength() {
         assertAssertionError("offset must be >= 0",
                 () -> MemoryAegis.assertObjectRange(new Object(), -1, 0));
         assertAssertionError("offset must be >= 0",

--- a/src/test/java/net/openhft/chronicle/core/aegis/MemoryAegisTest.java
+++ b/src/test/java/net/openhft/chronicle/core/aegis/MemoryAegisTest.java
@@ -1,0 +1,437 @@
+/*
+ * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.core.aegis;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+// Intentionally does not extend CoreTestCommon: that base class uses JUnit 4
+// @Before/@After and this project runs only the Jupiter engine (no vintage),
+// so inherited lifecycle methods would silently not fire.
+@DisplayName("MemoryAegis assertion edge coverage tests")
+public class MemoryAegisTest {
+
+    @Test
+    @DisplayName("accepts valid byte-array slices, including zero-length at the end")
+    public void byteArrayRangeAcceptsValidSlices() {
+        byte[] bytes = new byte[8];
+
+        assertTrue(MemoryAegis.assertByteArrayRange(bytes, 0, bytes.length));
+        assertTrue(MemoryAegis.assertByteArrayRange(bytes, bytes.length, 0));
+        assertTrue(MemoryAegis.assertByteArrayRange(bytes, 3, 4));
+    }
+
+    @Test
+    @DisplayName("rejects a null byte array")
+    public void byteArrayRangeRejectsNullArray() {
+        assertAssertionError("bytes must not be null",
+                () -> MemoryAegis.assertByteArrayRange(null, 0, 1));
+    }
+
+    @Test
+    @DisplayName("rejects a negative byte-array offset")
+    public void byteArrayRangeRejectsNegativeOffset() {
+        assertAssertionError("offset must be >= 0",
+                () -> MemoryAegis.assertByteArrayRange(new byte[8], -1, 1));
+    }
+
+    @Test
+    @DisplayName("rejects a negative byte-array length")
+    public void byteArrayRangeRejectsNegativeLength() {
+        assertAssertionError("length must be >= 0",
+                () -> MemoryAegis.assertByteArrayRange(new byte[8], 0, -1));
+    }
+
+    @Test
+    @DisplayName("rejects a byte-array length larger than the array")
+    public void byteArrayRangeRejectsLengthBeyondSize() {
+        assertAssertionError("length exceeds bytes.length",
+                () -> MemoryAegis.assertByteArrayRange(new byte[8], 0, 9));
+    }
+
+    @Test
+    @DisplayName("rejects a byte-array slice that overruns the end")
+    public void byteArrayRangeRejectsOverflowingSlice() {
+        assertAssertionError("slice exceeds bytes.length",
+                () -> MemoryAegis.assertByteArrayRange(new byte[8], 6, 3));
+    }
+
+    @Test
+    @DisplayName("rejects Integer.MIN_VALUE byte-array offset")
+    public void byteArrayRangeRejectsIntegerMinOffset() {
+        assertAssertionError("offset must be >= 0",
+                () -> MemoryAegis.assertByteArrayRange(new byte[8], Integer.MIN_VALUE, 1));
+    }
+
+    @Test
+    @DisplayName("rejects Integer.MIN_VALUE byte-array length")
+    public void byteArrayRangeRejectsIntegerMinLength() {
+        assertAssertionError("length must be >= 0",
+                () -> MemoryAegis.assertByteArrayRange(new byte[8], 0, Integer.MIN_VALUE));
+    }
+
+    @Test
+    @DisplayName("rejects Integer.MAX_VALUE byte-array length against a small array")
+    public void byteArrayRangeRejectsIntegerMaxLength() {
+        assertAssertionError("length exceeds bytes.length",
+                () -> MemoryAegis.assertByteArrayRange(new byte[8], 0, Integer.MAX_VALUE));
+    }
+
+    @Test
+    @DisplayName("rejects Integer.MAX_VALUE byte-array offset against a small array")
+    public void byteArrayRangeRejectsIntegerMaxOffset() {
+        assertAssertionError("slice exceeds bytes.length",
+                () -> MemoryAegis.assertByteArrayRange(new byte[8], Integer.MAX_VALUE, 1));
+    }
+
+    @Test
+    @DisplayName("rejects a negative byte-array offset even when length is zero")
+    public void byteArrayRangeRejectsNegativeOffsetWithZeroLength() {
+        assertAssertionError("offset must be >= 0",
+                () -> MemoryAegis.assertByteArrayRange(new byte[8], -1, 0));
+    }
+
+    @Test
+    @DisplayName("rejects a byte-array offset past the end even when length is zero")
+    public void byteArrayRangeRejectsOffsetPastEndWithZeroLength() {
+        assertAssertionError("slice exceeds bytes.length",
+                () -> MemoryAegis.assertByteArrayRange(new byte[8], 9, 0));
+    }
+
+    @Test
+    @DisplayName("accepts a valid char-array slice")
+    public void charArrayRangeAcceptsValidSlice() {
+        char[] chars = new char[4];
+        assertTrue(MemoryAegis.assertCharArrayRange(chars, 1, 2));
+    }
+
+    @Test
+    @DisplayName("rejects a null char array")
+    public void charArrayRangeRejectsNullArray() {
+        assertAssertionError("chars must not be null",
+                () -> MemoryAegis.assertCharArrayRange(null, 0, 1));
+    }
+
+    @Test
+    @DisplayName("rejects a char-array slice that overruns the end")
+    public void charArrayRangeRejectsOverflowingSlice() {
+        assertAssertionError("slice exceeds chars.length",
+                () -> MemoryAegis.assertCharArrayRange(new char[4], 3, 2));
+    }
+
+    @Test
+    @DisplayName("rejects a negative char-array offset")
+    public void charArrayRangeRejectsNegativeOffset() {
+        assertAssertionError("offset must be >= 0",
+                () -> MemoryAegis.assertCharArrayRange(new char[4], -1, 1));
+    }
+
+    @Test
+    @DisplayName("rejects a negative char-array length")
+    public void charArrayRangeRejectsNegativeLength() {
+        assertAssertionError("length must be >= 0",
+                () -> MemoryAegis.assertCharArrayRange(new char[4], 0, -1));
+    }
+
+    @Test
+    @DisplayName("rejects Integer.MIN_VALUE char-array offset and length")
+    public void charArrayRangeRejectsIntegerMinEdges() {
+        assertAssertionError("offset must be >= 0",
+                () -> MemoryAegis.assertCharArrayRange(new char[4], Integer.MIN_VALUE, 1));
+        assertAssertionError("length must be >= 0",
+                () -> MemoryAegis.assertCharArrayRange(new char[4], 0, Integer.MIN_VALUE));
+    }
+
+    @Test
+    @DisplayName("rejects Integer.MAX_VALUE char-array length and offset against a small array")
+    public void charArrayRangeRejectsIntegerMaxEdges() {
+        assertAssertionError("length exceeds chars.length",
+                () -> MemoryAegis.assertCharArrayRange(new char[4], 0, Integer.MAX_VALUE));
+        assertAssertionError("slice exceeds chars.length",
+                () -> MemoryAegis.assertCharArrayRange(new char[4], Integer.MAX_VALUE, 1));
+    }
+
+    @Test
+    @DisplayName("rejects an invalid char-array offset even when length is zero")
+    public void charArrayRangeRejectsInvalidOffsetWithZeroLength() {
+        assertAssertionError("offset must be >= 0",
+                () -> MemoryAegis.assertCharArrayRange(new char[4], -1, 0));
+        assertAssertionError("slice exceeds chars.length",
+                () -> MemoryAegis.assertCharArrayRange(new char[4], 5, 0));
+    }
+
+    @Test
+    @DisplayName("accepts a valid string slice")
+    public void stringRangeAcceptsValidSlice() {
+        assertTrue(MemoryAegis.assertStringRange("abcd", 1, 2));
+    }
+
+    @Test
+    @DisplayName("rejects a null input string")
+    public void stringRangeRejectsNullText() {
+        assertAssertionError("text must not be null",
+                () -> MemoryAegis.assertStringRange(null, 0, 1));
+    }
+
+    @Test
+    @DisplayName("rejects a string slice that overruns the end")
+    public void stringRangeRejectsPastEnd() {
+        assertAssertionError("slice exceeds text.length()",
+                () -> MemoryAegis.assertStringRange("abc", 2, 2));
+    }
+
+    @Test
+    @DisplayName("rejects Integer.MIN_VALUE string start and length")
+    public void stringRangeRejectsIntegerMinEdges() {
+        assertAssertionError("offset must be >= 0",
+                () -> MemoryAegis.assertStringRange("abc", Integer.MIN_VALUE, 1));
+        assertAssertionError("length must be >= 0",
+                () -> MemoryAegis.assertStringRange("abc", 0, Integer.MIN_VALUE));
+    }
+
+    @Test
+    @DisplayName("rejects Integer.MAX_VALUE string length and start against a short string")
+    public void stringRangeRejectsIntegerMaxEdges() {
+        assertAssertionError("length exceeds text.length()",
+                () -> MemoryAegis.assertStringRange("abc", 0, Integer.MAX_VALUE));
+        assertAssertionError("slice exceeds text.length()",
+                () -> MemoryAegis.assertStringRange("abc", Integer.MAX_VALUE, 1));
+    }
+
+    @Test
+    @DisplayName("rejects an invalid string start even when length is zero")
+    public void stringRangeRejectsInvalidStartWithZeroLength() {
+        assertAssertionError("offset must be >= 0",
+                () -> MemoryAegis.assertStringRange("abc", -1, 0));
+        assertAssertionError("slice exceeds text.length()",
+                () -> MemoryAegis.assertStringRange("abc", 4, 0));
+    }
+
+    @Test
+    @DisplayName("accepts the configured native lower bound")
+    public void addressRangeAcceptsConfiguredLowerBound() {
+        assertTrue(MemoryAegis.assertAddressRange(NativeAddressSpace.minAddress(), 1));
+    }
+
+    @Test
+    @DisplayName("accepts zero-length access at the configured native lower bound")
+    public void addressRangeAcceptsZeroLengthAtLowerBound() {
+        assertTrue(MemoryAegis.assertAddressRange(NativeAddressSpace.minAddress(), 0));
+    }
+
+    @Test
+    @DisplayName("accepts zero-length access at the inclusive native upper bound")
+    public void addressRangeAcceptsZeroLengthAtConfiguredUpperBound() {
+        assertTrue(MemoryAegis.assertAddressRange(NativeAddressSpace.maxAddressInclusive(), 0));
+    }
+
+    @Test
+    @DisplayName("accepts a single-byte access that ends exactly at the native ceiling")
+    public void addressRangeAcceptsSingleByteRangeEndingAtCeiling() {
+        assertTrue(MemoryAegis.assertAddressRange(NativeAddressSpace.maxAddressInclusive(), 1));
+    }
+
+    @Test
+    @DisplayName("rejects a negative native length")
+    public void addressRangeRejectsNegativeLength() {
+        assertAssertionError("length must be >= 0",
+                () -> MemoryAegis.assertAddressRange(NativeAddressSpace.minAddress(), -1));
+    }
+
+    @Test
+    @DisplayName("rejects reserved low native address space")
+    public void addressRangeRejectsReservedLowAddressSpace() {
+        assertAssertionError("address must be >=",
+                () -> MemoryAegis.assertAddressRange(NativeAddressSpace.minAddress() - 1, 1));
+    }
+
+    @Test
+    @DisplayName("rejects the exclusive native upper bound even for zero-length access")
+    public void addressRangeRejectsConfiguredExclusiveUpperBound() {
+        assertAssertionError("address must be <=",
+                () -> MemoryAegis.assertAddressRange(NativeAddressSpace.maxAddressExclusive(), 0));
+    }
+
+    @Test
+    @DisplayName("rejects a native range that overflows the configured address space")
+    public void addressRangeRejectsConfiguredUpperBoundOverflow() {
+        assertAssertionError("native range exceeds configured address space",
+                () -> MemoryAegis.assertAddressRange(NativeAddressSpace.maxAddressInclusive(), 2));
+    }
+
+    @Test
+    @DisplayName("rejects Long.MIN_VALUE as a native address")
+    public void addressRangeRejectsLongMinAddress() {
+        assertAssertionError("address must be >=",
+                () -> MemoryAegis.assertAddressRange(Long.MIN_VALUE, 1));
+    }
+
+    @Test
+    @DisplayName("rejects Long.MAX_VALUE as a native address")
+    public void addressRangeRejectsLongMaxAddress() {
+        assertAssertionError("address must be <=",
+                () -> MemoryAegis.assertAddressRange(Long.MAX_VALUE, 1));
+    }
+
+    @Test
+    @DisplayName("rejects Long.MIN_VALUE as a native length")
+    public void addressRangeRejectsLongMinLength() {
+        assertAssertionError("length must be >= 0",
+                () -> MemoryAegis.assertAddressRange(NativeAddressSpace.minAddress(), Long.MIN_VALUE));
+    }
+
+    @Test
+    @DisplayName("rejects Long.MAX_VALUE as a native length at a valid address")
+    public void addressRangeRejectsLongMaxLength() {
+        assertAssertionError("native range exceeds configured address space",
+                () -> MemoryAegis.assertAddressRange(NativeAddressSpace.minAddress(), Long.MAX_VALUE));
+    }
+
+    @Test
+    @DisplayName("rejects the legacy x86-64 [vsyscall] address")
+    public void addressRangeRejectsVsyscallMapping() {
+        // The legacy x86-64 vsyscall page sits at a sign-extended kernel-canonical
+        // address (0xFFFFFFFFFF600000). MemoryAegis deliberately models only
+        // ordinary non-negative user-space ranges, so the negative long value
+        // must be rejected by the lower-bound guard.
+        final long vsyscallAddress = 0xFFFFFFFFFF600000L;
+        assertTrue(vsyscallAddress < 0, "vsyscall address should be negative in signed long");
+        assertAssertionError("address must be >=",
+                () -> MemoryAegis.assertAddressRange(vsyscallAddress, 1));
+    }
+
+    @Test
+    @DisplayName("rejects an invalid native address even when length is zero")
+    public void addressRangeRejectsInvalidAddressWithZeroLength() {
+        assertAssertionError("address must be >=",
+                () -> MemoryAegis.assertAddressRange(NativeAddressSpace.minAddress() - 1, 0));
+        assertAssertionError("address must be >=",
+                () -> MemoryAegis.assertAddressRange(Long.MIN_VALUE, 0));
+        assertAssertionError("address must be <=",
+                () -> MemoryAegis.assertAddressRange(Long.MAX_VALUE, 0));
+    }
+
+    @Test
+    @DisplayName("accepts zero object-relative offset")
+    public void objectRangeAcceptsZeroOffset() {
+        assertTrue(MemoryAegis.assertObjectRange(new Object(), 0, 4));
+    }
+
+    @Test
+    @DisplayName("accepts zero-length object-relative access at zero offset")
+    public void objectRangeAcceptsZeroLengthAtZeroOffset() {
+        assertTrue(MemoryAegis.assertObjectRange(new Object(), 0, 0));
+    }
+
+    @Test
+    @DisplayName("accepts zero-length object-relative access at the inclusive upper bound")
+    public void objectRangeAcceptsZeroLengthAtConfiguredUpperBound() {
+        assertTrue(MemoryAegis.assertObjectRange(new Object(), NativeAddressSpace.maxAddressInclusive(), 0));
+    }
+
+    @Test
+    @DisplayName("accepts a single-byte object-relative access that ends exactly at the ceiling")
+    public void objectRangeAcceptsSingleByteRangeEndingAtCeiling() {
+        assertTrue(MemoryAegis.assertObjectRange(new Object(), NativeAddressSpace.maxAddressInclusive(), 1));
+    }
+
+    @Test
+    @DisplayName("accepts a typical object field offset")
+    public void objectRangeAcceptsTypicalFieldOffset() {
+        assertTrue(MemoryAegis.assertObjectRange(new Object(), 16, Long.BYTES));
+    }
+
+    @Test
+    @DisplayName("rejects a null object target")
+    public void objectRangeRejectsNullObject() {
+        assertAssertionError("object must not be null",
+                () -> MemoryAegis.assertObjectRange(null, 0, 1));
+    }
+
+    @Test
+    @DisplayName("rejects a negative object-relative offset")
+    public void objectRangeRejectsNegativeOffset() {
+        assertAssertionError("offset must be >= 0",
+                () -> MemoryAegis.assertObjectRange(new Object(), -1, 1));
+    }
+
+    @Test
+    @DisplayName("rejects a negative object-relative length")
+    public void objectRangeRejectsNegativeLength() {
+        assertAssertionError("length must be >= 0",
+                () -> MemoryAegis.assertObjectRange(new Object(), 0, -1));
+    }
+
+    @Test
+    @DisplayName("rejects the exclusive object-relative upper bound even for zero-length access")
+    public void objectRangeRejectsConfiguredExclusiveUpperBound() {
+        assertAssertionError("offset must be <=",
+                () -> MemoryAegis.assertObjectRange(new Object(), NativeAddressSpace.maxAddressExclusive(), 0));
+    }
+
+    @Test
+    @DisplayName("rejects an object-relative range that overflows the configured address space")
+    public void objectRangeRejectsConfiguredUpperBoundOverflow() {
+        assertAssertionError("object range exceeds configured address space",
+                () -> MemoryAegis.assertObjectRange(new Object(), NativeAddressSpace.maxAddressInclusive(), 2));
+    }
+
+    @Test
+    @DisplayName("rejects an object-relative length at or above the exclusive upper bound")
+    public void objectRangeRejectsLengthAtConfiguredExclusiveUpperBound() {
+        assertAssertionError("length must be <=",
+                () -> MemoryAegis.assertObjectRange(new Object(), 0, NativeAddressSpace.maxAddressExclusive()));
+    }
+
+    @Test
+    @DisplayName("rejects Long.MIN_VALUE object-relative offset")
+    public void objectRangeRejectsLongMinOffset() {
+        assertAssertionError("offset must be >= 0",
+                () -> MemoryAegis.assertObjectRange(new Object(), Long.MIN_VALUE, 1));
+    }
+
+    @Test
+    @DisplayName("rejects Long.MAX_VALUE object-relative offset")
+    public void objectRangeRejectsLongMaxOffset() {
+        assertAssertionError("offset must be <=",
+                () -> MemoryAegis.assertObjectRange(new Object(), Long.MAX_VALUE, 1));
+    }
+
+    @Test
+    @DisplayName("rejects Long.MIN_VALUE object-relative length")
+    public void objectRangeRejectsLongMinLength() {
+        assertAssertionError("length must be >= 0",
+                () -> MemoryAegis.assertObjectRange(new Object(), 0, Long.MIN_VALUE));
+    }
+
+    @Test
+    @DisplayName("rejects Long.MAX_VALUE object-relative length")
+    public void objectRangeRejectsLongMaxLength() {
+        assertAssertionError("length must be <=",
+                () -> MemoryAegis.assertObjectRange(new Object(), 0, Long.MAX_VALUE));
+    }
+
+    @Test
+    @DisplayName("rejects an invalid object-relative offset even when length is zero")
+    public void objectRangeRejectsInvalidOffsetWithZeroLength() {
+        assertAssertionError("offset must be >= 0",
+                () -> MemoryAegis.assertObjectRange(new Object(), -1, 0));
+        assertAssertionError("offset must be >= 0",
+                () -> MemoryAegis.assertObjectRange(new Object(), Long.MIN_VALUE, 0));
+        assertAssertionError("offset must be <=",
+                () -> MemoryAegis.assertObjectRange(new Object(), Long.MAX_VALUE, 0));
+    }
+
+    private static void assertAssertionError(final String messagePart,
+                                             final Runnable action) {
+        final AssertionError actual = assertThrows(AssertionError.class, action::run);
+        final String actualMessage = actual.getMessage();
+        assertTrue(actualMessage != null && actualMessage.contains(messagePart),
+                () -> "expected message to contain: \"" + messagePart
+                        + "\", actual: \"" + actualMessage + "\"");
+    }
+}

--- a/src/test/java/net/openhft/chronicle/core/aegis/MemoryAegisUsageTest.java
+++ b/src/test/java/net/openhft/chronicle/core/aegis/MemoryAegisUsageTest.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  * has already been wired to {@link MemoryAegis}.</p>
  */
 @DisplayName("MemoryAegis canonical `assert SKIP_ASSERTIONS || ...` usage")
-public class MemoryAegisUsageTest {
+class MemoryAegisUsageTest {
 
     private static final Memory MEMORY = OS.memory();
 
@@ -47,7 +47,7 @@ public class MemoryAegisUsageTest {
 
     @Test
     @DisplayName("primitive read at a native address uses assertAddressRange with TYPE.BYTES")
-    public void demonstratesAddressRangePrimitiveRead() {
+    void demonstratesAddressRangePrimitiveRead() {
         final long address = MEMORY.allocate(Long.BYTES);
         try {
             MEMORY.writeLong(address, 0x0102_0304_0506_0708L);
@@ -60,7 +60,7 @@ public class MemoryAegisUsageTest {
 
     @Test
     @DisplayName("on-heap byte-array slice uses assertByteArrayRange with TYPE.BYTES")
-    public void demonstratesByteArrayRangePrimitiveWrite() {
+    void demonstratesByteArrayRangePrimitiveWrite() {
         final byte[] bytes = new byte[16];
         final long baseOffset = MEMORY.arrayBaseOffset(byte[].class);
 
@@ -75,7 +75,7 @@ public class MemoryAegisUsageTest {
 
     @Test
     @DisplayName("native-to-native copy guards source and destination independently")
-    public void demonstratesTwoAssertAddressRangeCalls() {
+    void demonstratesTwoAssertAddressRangeCalls() {
         final long from = MEMORY.allocate(Long.BYTES);
         final long to = MEMORY.allocate(Long.BYTES);
         try {
@@ -94,7 +94,7 @@ public class MemoryAegisUsageTest {
 
     @Test
     @DisplayName("Unsafe-style access inlines the on-heap / off-heap dispatch at the call site")
-    public void demonstratesObjectOrAddressRangeDispatch() {
+    void demonstratesObjectOrAddressRangeDispatch() {
         final ByteFieldHolder onHeap = new ByteFieldHolder();
         final long fieldOffset = UnsafeMemory.unsafeObjectFieldOffset(
                 Jvm.getField(ByteFieldHolder.class, "value"));
@@ -112,7 +112,7 @@ public class MemoryAegisUsageTest {
 
     @Test
     @DisplayName("assertion guards still fire under hostile inputs when assertions are enabled")
-    public void sampleHelpersStillRejectBadInputs() {
+    void sampleHelpersStillRejectBadInputs() {
         // Passing an address below the reserved lower bound must still trip
         // the assertion when the idiom is active.
         assertThrows(AssertionError.class,

--- a/src/test/java/net/openhft/chronicle/core/aegis/MemoryAegisUsageTest.java
+++ b/src/test/java/net/openhft/chronicle/core/aegis/MemoryAegisUsageTest.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.core.aegis;
+
+import net.openhft.chronicle.core.Jvm;
+import net.openhft.chronicle.core.Memory;
+import net.openhft.chronicle.core.OS;
+import net.openhft.chronicle.core.UnsafeMemory;
+import net.openhft.chronicle.core.annotation.Address;
+import net.openhft.chronicle.core.annotation.NonNegative;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Demonstrates the {@code assert SKIP_ASSERTIONS || MemoryAegis.assertXxx(...)}
+ * idiom against real {@link OS#memory()} operations.
+ *
+ * <p>The fixtures below deliberately use the same public memory primitives that
+ * downstream code already has today: primitive read at a native address,
+ * primitive write into an on-heap byte array, native-to-native copy, and
+ * object-or-address dispatch. Each test runs with assertions enabled (the
+ * default for {@code mvn test}) so the guarded branches execute; in the normal
+ * assertion-disabled production run the JIT elides the whole right-hand side
+ * and the helpers become the equivalent of their bodies minus the guard.</p>
+ *
+ * <p>These samples document the intended integration pattern for future
+ * migration work. They are not evidence that every existing low-level caller
+ * has already been wired to {@link MemoryAegis}.</p>
+ */
+@DisplayName("MemoryAegis canonical `assert SKIP_ASSERTIONS || ...` usage")
+public class MemoryAegisUsageTest {
+
+    private static final Memory MEMORY = OS.memory();
+
+    // Deliberately shadows {@link net.openhft.chronicle.assertions.AssertUtil#SKIP_ASSERTIONS}
+    // with a {@code false} local so the aegis branches actually execute in
+    // this test. Chronicle-Core's test classpath ships the assertions-disabled
+    // twin (where the shared constant is {@code true}); importing it would
+    // constant-fold every guard to a no-op, and the hostile-input fixtures
+    // below would then reach {@link Memory#readLong(long)} with bogus
+    // addresses and crash the JVM instead of tripping an AssertionError.
+    private static final boolean SKIP_ASSERTIONS = false;
+
+    @Test
+    @DisplayName("primitive read at a native address uses assertAddressRange with TYPE.BYTES")
+    public void demonstratesAddressRangePrimitiveRead() {
+        final long address = MEMORY.allocate(Long.BYTES);
+        try {
+            MEMORY.writeLong(address, 0x0102_0304_0506_0708L);
+            final long sample = sampleUnsafeGetLong(address);
+            assertEquals(0x0102_0304_0506_0708L, sample);
+        } finally {
+            MEMORY.freeMemory(address, Long.BYTES);
+        }
+    }
+
+    @Test
+    @DisplayName("on-heap byte-array slice uses assertByteArrayRange with TYPE.BYTES")
+    public void demonstratesByteArrayRangePrimitiveWrite() {
+        final byte[] bytes = new byte[16];
+        final long baseOffset = MEMORY.arrayBaseOffset(byte[].class);
+
+        samplePutInt(bytes, 4, 0x01020304);
+
+        assertEquals(0, bytes[0]);
+        assertEquals(0, bytes[3]);
+        assertEquals(0x01020304, MEMORY.readInt(bytes, baseOffset + 4));
+        assertEquals(0, bytes[8]);
+        assertEquals(0, bytes[15]);
+    }
+
+    @Test
+    @DisplayName("native-to-native copy guards source and destination independently")
+    public void demonstratesTwoAssertAddressRangeCalls() {
+        final long from = MEMORY.allocate(Long.BYTES);
+        final long to = MEMORY.allocate(Long.BYTES);
+        try {
+            MEMORY.writeLong(from, 0x1122_3344_5566_7788L);
+
+            // Exercising both guards in one call verifies that `to` does not
+            // silently piggy-back on the `from` check when they differ.
+            sampleCopyMemory(from, to, Long.BYTES);
+
+            assertEquals(0x1122_3344_5566_7788L, MEMORY.readLong(to));
+        } finally {
+            MEMORY.freeMemory(to, Long.BYTES);
+            MEMORY.freeMemory(from, Long.BYTES);
+        }
+    }
+
+    @Test
+    @DisplayName("Unsafe-style access inlines the on-heap / off-heap dispatch at the call site")
+    public void demonstratesObjectOrAddressRangeDispatch() {
+        final ByteFieldHolder onHeap = new ByteFieldHolder();
+        final long fieldOffset = UnsafeMemory.unsafeObjectFieldOffset(
+                Jvm.getField(ByteFieldHolder.class, "value"));
+        sampleUnsafePutByte(onHeap, fieldOffset);
+        assertEquals((byte) 1, MEMORY.readByte(onHeap, fieldOffset));
+
+        final long nativeAddress = MEMORY.allocate(Byte.BYTES);
+        try {
+            sampleUnsafePutByte(null, nativeAddress);
+            assertEquals((byte) 1, MEMORY.readByte(nativeAddress));
+        } finally {
+            MEMORY.freeMemory(nativeAddress, Byte.BYTES);
+        }
+    }
+
+    @Test
+    @DisplayName("assertion guards still fire under hostile inputs when assertions are enabled")
+    public void sampleHelpersStillRejectBadInputs() {
+        // Passing an address below the reserved lower bound must still trip
+        // the assertion when the idiom is active.
+        assertThrows(AssertionError.class,
+                () -> sampleUnsafeGetLong(NativeAddressSpace.minAddress() - 1));
+        assertThrows(AssertionError.class,
+                () -> samplePutInt(new byte[4], 2, 0));
+    }
+
+    /* ------------------------------------------------------------------ *
+     * Hand-rolled fixtures that mirror real UnsafeMemory call sites.     *
+     * ------------------------------------------------------------------ */
+
+    /**
+     * Fixture showing the intended native-read pattern. The address range is
+     * checked for {@link Long#BYTES} bytes, matching the width of the
+     * subsequent read.
+     */
+    private static long sampleUnsafeGetLong(@Address final long address) {
+        assert SKIP_ASSERTIONS || MemoryAegis.assertAddressRange(address, Long.BYTES);
+        return MEMORY.readLong(address);
+    }
+
+    /**
+     * Fixture showing the intended on-heap byte-array pattern. The byte-array
+     * range is checked for {@link Integer#BYTES} bytes at the caller-supplied
+     * offset.
+     */
+    private static void samplePutInt(final byte[] bytes,
+                                     @NonNegative final int offset,
+                                     final int value) {
+        assert SKIP_ASSERTIONS || MemoryAegis.assertByteArrayRange(bytes, offset, Integer.BYTES);
+        MEMORY.writeInt(bytes, MEMORY.arrayBaseOffset(byte[].class) + offset, value);
+    }
+
+    /**
+     * Fixture showing the intended native-to-native copy pattern. The caller
+     * uses two separate assertions because {@code from} and {@code to} are
+     * independent native-address ranges.
+     */
+    private static void sampleCopyMemory(@Address final long from,
+                                         @Address final long to,
+                                         @NonNegative final int length) {
+        assert SKIP_ASSERTIONS || MemoryAegis.assertAddressRange(from, length);
+        assert SKIP_ASSERTIONS || MemoryAegis.assertAddressRange(to, length);
+        MEMORY.copyMemory(from, to, (long) length);
+    }
+
+    /**
+     * Fixture showing the intended object-or-address dispatch pattern. The
+     * call site inlines the null-check: when {@code obj == null} the offset is
+     * an absolute native address and goes through
+     * {@link MemoryAegis#assertAddressRange(long, long)}; otherwise it is an
+     * object-relative offset and goes through
+     * {@link MemoryAegis#assertObjectRange(Object, long, long)}. Keeping the
+     * ternary at the call site makes the two contracts visible to both the
+     * reader and static analysis.
+     */
+    private static void sampleUnsafePutByte(final Object obj,
+                                               @NonNegative final long offset) {
+        assert SKIP_ASSERTIONS || (obj == null
+                ? MemoryAegis.assertAddressRange(offset, Byte.BYTES)
+                : MemoryAegis.assertObjectRange(obj, offset, Byte.BYTES));
+        if (obj == null) {
+            MEMORY.writeByte(offset, (byte) 1);
+        } else {
+            MEMORY.writeByte(obj, offset, (byte) 1);
+        }
+    }
+
+    private static final class ByteFieldHolder {
+        volatile byte value;
+    }
+}

--- a/src/test/java/net/openhft/chronicle/core/aegis/MemoryAegisUsageTest.java
+++ b/src/test/java/net/openhft/chronicle/core/aegis/MemoryAegisUsageTest.java
@@ -115,8 +115,9 @@ class MemoryAegisUsageTest {
     void sampleHelpersStillRejectBadInputs() {
         // Passing an address below the reserved lower bound must still trip
         // the assertion when the idiom is active.
+        long minAddress = NativeAddressSpace.minAddress();
         assertThrows(AssertionError.class,
-                () -> sampleUnsafeGetLong(NativeAddressSpace.minAddress() - 1));
+                () -> sampleUnsafeGetLong(minAddress - 1));
         assertThrows(AssertionError.class,
                 () -> samplePutInt(new byte[4], 2, 0));
     }

--- a/src/test/java/net/openhft/chronicle/core/aegis/MemoryAegisUsageTest.java
+++ b/src/test/java/net/openhft/chronicle/core/aegis/MemoryAegisUsageTest.java
@@ -9,6 +9,7 @@ import net.openhft.chronicle.core.OS;
 import net.openhft.chronicle.core.UnsafeMemory;
 import net.openhft.chronicle.core.annotation.Address;
 import net.openhft.chronicle.core.annotation.NonNegative;
+import net.openhft.chronicle.core.annotation.UsedViaReflection;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -142,8 +143,8 @@ class MemoryAegisUsageTest {
      * offset.
      */
     private static void samplePutInt(final byte[] bytes,
-                                     @NonNegative final int offset,
-                                     final int value) {
+                                     final @NonNegative int offset,
+                                     final @NonNegative int value) {
         assert SKIP_ASSERTIONS || MemoryAegis.assertByteArrayRange(bytes, offset, Integer.BYTES);
         MEMORY.writeInt(bytes, MEMORY.arrayBaseOffset(byte[].class) + offset, value);
     }
@@ -153,9 +154,9 @@ class MemoryAegisUsageTest {
      * uses two separate assertions because {@code from} and {@code to} are
      * independent native-address ranges.
      */
-    private static void sampleCopyMemory(@Address final long from,
-                                         @Address final long to,
-                                         @NonNegative final int length) {
+    private static void sampleCopyMemory(final @Address long from,
+                                         final @Address long to,
+                                         final @NonNegative int length) {
         assert SKIP_ASSERTIONS || MemoryAegis.assertAddressRange(from, length);
         assert SKIP_ASSERTIONS || MemoryAegis.assertAddressRange(to, length);
         MEMORY.copyMemory(from, to, (long) length);
@@ -172,7 +173,7 @@ class MemoryAegisUsageTest {
      * reader and static analysis.
      */
     private static void sampleUnsafePutByte(final Object obj,
-                                               @NonNegative final long offset) {
+                                            final @NonNegative long offset) {
         assert SKIP_ASSERTIONS || (obj == null
                 ? MemoryAegis.assertAddressRange(offset, Byte.BYTES)
                 : MemoryAegis.assertObjectRange(obj, offset, Byte.BYTES));
@@ -184,6 +185,7 @@ class MemoryAegisUsageTest {
     }
 
     private static final class ByteFieldHolder {
+        @UsedViaReflection
         volatile byte value;
     }
 }

--- a/src/test/java/net/openhft/chronicle/core/aegis/NativeAddressSpaceTest.java
+++ b/src/test/java/net/openhft/chronicle/core/aegis/NativeAddressSpaceTest.java
@@ -11,11 +11,11 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DisplayName("NativeAddressSpace policy helper behavior tests")
-public class NativeAddressSpaceTest {
+class NativeAddressSpaceTest {
 
     @Test
     @DisplayName("passes x86-64 aliases through unchanged (falls through to the 56-bit default)")
-    public void normalizesCommonX8664Aliases() {
+    void normalizesCommonX8664Aliases() {
         assertEquals("amd64", NativeAddressSpace.normalizeArch("amd64"));
         assertEquals("x64", NativeAddressSpace.normalizeArch("x64"));
         assertEquals("x86_64", NativeAddressSpace.normalizeArch("x86_64"));
@@ -23,7 +23,7 @@ public class NativeAddressSpaceTest {
 
     @Test
     @DisplayName("normalizes common 32-bit aliases")
-    public void normalizesCommon32BitAliases() {
+    void normalizesCommon32BitAliases() {
         assertEquals("x86_32", NativeAddressSpace.normalizeArch("i686"));
         assertEquals("x86_32", NativeAddressSpace.normalizeArch("x86"));
         assertEquals("arm_32", NativeAddressSpace.normalizeArch("armv7l"));
@@ -32,13 +32,13 @@ public class NativeAddressSpaceTest {
 
     @Test
     @DisplayName("handles a null architecture string")
-    public void normalizeArchHandlesNull() {
+    void normalizeArchHandlesNull() {
         assertEquals("", NativeAddressSpace.normalizeArch(null));
     }
 
     @Test
     @DisplayName("trims and lowercases architecture strings")
-    public void normalizeArchTrimsAndLowercases() {
+    void normalizeArchTrimsAndLowercases() {
         // x86-64 aliases have no dedicated bucket, so "  AMD64  " comes back
         // lower-cased and trimmed; only the 32-bit buckets do explicit mapping.
         assertEquals("amd64", NativeAddressSpace.normalizeArch("  AMD64  "));
@@ -47,104 +47,104 @@ public class NativeAddressSpaceTest {
 
     @Test
     @DisplayName("leaves unknown architecture values normalized but otherwise intact")
-    public void normalizeArchLeavesUnknownValuesUntouched() {
+    void normalizeArchLeavesUnknownValuesUntouched() {
         assertEquals("aarch64", NativeAddressSpace.normalizeArch("AArch64"));
         assertEquals("riscv64", NativeAddressSpace.normalizeArch("riscv64"));
     }
 
     @Test
     @DisplayName("keeps the 56-bit default for x86-64 aliases")
-    public void keeps56BitDefaultForX8664() {
+    void keeps56BitDefaultForX8664() {
         assertEquals(56, NativeAddressSpace.addressBitsFor("amd64"));
         assertEquals(56, NativeAddressSpace.addressBitsFor("x86_64"));
     }
 
     @Test
     @DisplayName("uses 32 bits for obvious 32-bit architectures")
-    public void uses32BitsForObvious32BitArchitectures() {
+    void uses32BitsForObvious32BitArchitectures() {
         assertEquals(32, NativeAddressSpace.addressBitsFor("i686"));
         assertEquals(32, NativeAddressSpace.addressBitsFor("armv7l"));
     }
 
     @Test
     @DisplayName("keeps the 56-bit default for arm64 and unknown architectures")
-    public void keeps56BitDefaultForArm64AndUnknownArchitectures() {
+    void keeps56BitDefaultForArm64AndUnknownArchitectures() {
         assertEquals(56, NativeAddressSpace.addressBitsFor("aarch64"));
         assertEquals(56, NativeAddressSpace.addressBitsFor("riscv64"));
     }
 
     @Test
     @DisplayName("defaults null architecture input to the 56-bit fallback")
-    public void addressBitsForHandlesNullArch() {
+    void addressBitsForHandlesNullArch() {
         assertEquals(56, NativeAddressSpace.addressBitsFor(null));
     }
 
     @Test
     @DisplayName("normalizes the empty architecture string to the empty bucket")
-    public void normalizeArchHandlesEmpty() {
+    void normalizeArchHandlesEmpty() {
         assertEquals("", NativeAddressSpace.normalizeArch(""));
         assertEquals("", NativeAddressSpace.normalizeArch("   "));
     }
 
     @Test
     @DisplayName("defaults the empty architecture string to the 56-bit fallback")
-    public void addressBitsForHandlesEmpty() {
+    void addressBitsForHandlesEmpty() {
         assertEquals(56, NativeAddressSpace.addressBitsFor(""));
     }
 
     @Test
     @DisplayName("reserves the first 64 KiB of address space")
-    public void minAddressReservesFirst64KiB() {
+    void minAddressReservesFirst64KiB() {
         assertEquals(64L << 10, NativeAddressSpace.minAddress());
     }
 
     @Test
     @DisplayName("defines the inclusive upper bound as one below the exclusive upper bound")
-    public void maxAddressInclusiveIsOneBelowExclusive() {
+    void maxAddressInclusiveIsOneBelowExclusive() {
         assertEquals(NativeAddressSpace.maxAddressExclusive() - 1,
                 NativeAddressSpace.maxAddressInclusive());
     }
 
     @Test
     @DisplayName("computes the exclusive upper bound from the configured address bits")
-    public void maxAddressExclusiveMatchesBoundsHolderBits() {
+    void maxAddressExclusiveMatchesBoundsHolderBits() {
         final long expected = 1L << NativeAddressSpace.BoundsHolder.ADDRESS_BITS;
         assertEquals(expected, NativeAddressSpace.maxAddressExclusive());
     }
 
     @Test
     @DisplayName("keeps the reserved lower bound below the inclusive upper bound")
-    public void minAddressIsBelowMaxAddressInclusive() {
+    void minAddressIsBelowMaxAddressInclusive() {
         assertTrue(NativeAddressSpace.minAddress() < NativeAddressSpace.maxAddressInclusive());
     }
 
     @Test
     @DisplayName("reports overflow when a range extends past the ceiling")
-    public void wouldOverflowAtCeiling() {
+    void wouldOverflowAtCeiling() {
         assertTrue(NativeAddressSpace.wouldOverflow(NativeAddressSpace.maxAddressInclusive(), 2));
     }
 
     @Test
     @DisplayName("does not report overflow for a range that fits below the ceiling")
-    public void wouldOverflowFalseForFittingRange() {
+    void wouldOverflowFalseForFittingRange() {
         assertFalse(NativeAddressSpace.wouldOverflow(NativeAddressSpace.minAddress(), 8));
     }
 
     @Test
     @DisplayName("does not report overflow for a single-byte range ending exactly at the ceiling")
-    public void wouldOverflowFalseForRangeEndingExactlyAtCeiling() {
+    void wouldOverflowFalseForRangeEndingExactlyAtCeiling() {
         assertFalse(NativeAddressSpace.wouldOverflow(NativeAddressSpace.maxAddressInclusive(), 1));
     }
 
     @Test
     @DisplayName("reports overflow at the exclusive upper bound when length is positive")
-    public void wouldOverflowTrueAtExclusiveUpperBoundWithPositiveLength() {
+    void wouldOverflowTrueAtExclusiveUpperBoundWithPositiveLength() {
         assertTrue(NativeAddressSpace.wouldOverflow(NativeAddressSpace.maxAddressExclusive(), 1));
     }
 
     @Test
     @DisplayName("does not report overflow for zero-length access at the exclusive upper bound")
-    public void wouldOverflowFalseForZeroLengthAtCeiling() {
+    void wouldOverflowFalseForZeroLengthAtCeiling() {
         assertFalse(NativeAddressSpace.wouldOverflow(NativeAddressSpace.maxAddressExclusive(), 0));
     }
 }

--- a/src/test/java/net/openhft/chronicle/core/aegis/NativeAddressSpaceTest.java
+++ b/src/test/java/net/openhft/chronicle/core/aegis/NativeAddressSpaceTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.core.aegis;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DisplayName("NativeAddressSpace policy helper behavior tests")
+public class NativeAddressSpaceTest {
+
+    @Test
+    @DisplayName("passes x86-64 aliases through unchanged (falls through to the 56-bit default)")
+    public void normalizesCommonX8664Aliases() {
+        assertEquals("amd64", NativeAddressSpace.normalizeArch("amd64"));
+        assertEquals("x64", NativeAddressSpace.normalizeArch("x64"));
+        assertEquals("x86_64", NativeAddressSpace.normalizeArch("x86_64"));
+    }
+
+    @Test
+    @DisplayName("normalizes common 32-bit aliases")
+    public void normalizesCommon32BitAliases() {
+        assertEquals("x86_32", NativeAddressSpace.normalizeArch("i686"));
+        assertEquals("x86_32", NativeAddressSpace.normalizeArch("x86"));
+        assertEquals("arm_32", NativeAddressSpace.normalizeArch("armv7l"));
+        assertEquals("arm_32", NativeAddressSpace.normalizeArch("arm32"));
+    }
+
+    @Test
+    @DisplayName("handles a null architecture string")
+    public void normalizeArchHandlesNull() {
+        assertEquals("", NativeAddressSpace.normalizeArch(null));
+    }
+
+    @Test
+    @DisplayName("trims and lowercases architecture strings")
+    public void normalizeArchTrimsAndLowercases() {
+        // x86-64 aliases have no dedicated bucket, so "  AMD64  " comes back
+        // lower-cased and trimmed; only the 32-bit buckets do explicit mapping.
+        assertEquals("amd64", NativeAddressSpace.normalizeArch("  AMD64  "));
+        assertEquals("arm_32", NativeAddressSpace.normalizeArch("ARMv7l"));
+    }
+
+    @Test
+    @DisplayName("leaves unknown architecture values normalized but otherwise intact")
+    public void normalizeArchLeavesUnknownValuesUntouched() {
+        assertEquals("aarch64", NativeAddressSpace.normalizeArch("AArch64"));
+        assertEquals("riscv64", NativeAddressSpace.normalizeArch("riscv64"));
+    }
+
+    @Test
+    @DisplayName("keeps the 56-bit default for x86-64 aliases")
+    public void keeps56BitDefaultForX8664() {
+        assertEquals(56, NativeAddressSpace.addressBitsFor("amd64"));
+        assertEquals(56, NativeAddressSpace.addressBitsFor("x86_64"));
+    }
+
+    @Test
+    @DisplayName("uses 32 bits for obvious 32-bit architectures")
+    public void uses32BitsForObvious32BitArchitectures() {
+        assertEquals(32, NativeAddressSpace.addressBitsFor("i686"));
+        assertEquals(32, NativeAddressSpace.addressBitsFor("armv7l"));
+    }
+
+    @Test
+    @DisplayName("keeps the 56-bit default for arm64 and unknown architectures")
+    public void keeps56BitDefaultForArm64AndUnknownArchitectures() {
+        assertEquals(56, NativeAddressSpace.addressBitsFor("aarch64"));
+        assertEquals(56, NativeAddressSpace.addressBitsFor("riscv64"));
+    }
+
+    @Test
+    @DisplayName("defaults null architecture input to the 56-bit fallback")
+    public void addressBitsForHandlesNullArch() {
+        assertEquals(56, NativeAddressSpace.addressBitsFor(null));
+    }
+
+    @Test
+    @DisplayName("normalizes the empty architecture string to the empty bucket")
+    public void normalizeArchHandlesEmpty() {
+        assertEquals("", NativeAddressSpace.normalizeArch(""));
+        assertEquals("", NativeAddressSpace.normalizeArch("   "));
+    }
+
+    @Test
+    @DisplayName("defaults the empty architecture string to the 56-bit fallback")
+    public void addressBitsForHandlesEmpty() {
+        assertEquals(56, NativeAddressSpace.addressBitsFor(""));
+    }
+
+    @Test
+    @DisplayName("reserves the first 64 KiB of address space")
+    public void minAddressReservesFirst64KiB() {
+        assertEquals(64L << 10, NativeAddressSpace.minAddress());
+    }
+
+    @Test
+    @DisplayName("defines the inclusive upper bound as one below the exclusive upper bound")
+    public void maxAddressInclusiveIsOneBelowExclusive() {
+        assertEquals(NativeAddressSpace.maxAddressExclusive() - 1,
+                NativeAddressSpace.maxAddressInclusive());
+    }
+
+    @Test
+    @DisplayName("computes the exclusive upper bound from the configured address bits")
+    public void maxAddressExclusiveMatchesBoundsHolderBits() {
+        final long expected = 1L << NativeAddressSpace.BoundsHolder.ADDRESS_BITS;
+        assertEquals(expected, NativeAddressSpace.maxAddressExclusive());
+    }
+
+    @Test
+    @DisplayName("keeps the reserved lower bound below the inclusive upper bound")
+    public void minAddressIsBelowMaxAddressInclusive() {
+        assertTrue(NativeAddressSpace.minAddress() < NativeAddressSpace.maxAddressInclusive());
+    }
+
+    @Test
+    @DisplayName("reports overflow when a range extends past the ceiling")
+    public void wouldOverflowAtCeiling() {
+        assertTrue(NativeAddressSpace.wouldOverflow(NativeAddressSpace.maxAddressInclusive(), 2));
+    }
+
+    @Test
+    @DisplayName("does not report overflow for a range that fits below the ceiling")
+    public void wouldOverflowFalseForFittingRange() {
+        assertFalse(NativeAddressSpace.wouldOverflow(NativeAddressSpace.minAddress(), 8));
+    }
+
+    @Test
+    @DisplayName("does not report overflow for a single-byte range ending exactly at the ceiling")
+    public void wouldOverflowFalseForRangeEndingExactlyAtCeiling() {
+        assertFalse(NativeAddressSpace.wouldOverflow(NativeAddressSpace.maxAddressInclusive(), 1));
+    }
+
+    @Test
+    @DisplayName("reports overflow at the exclusive upper bound when length is positive")
+    public void wouldOverflowTrueAtExclusiveUpperBoundWithPositiveLength() {
+        assertTrue(NativeAddressSpace.wouldOverflow(NativeAddressSpace.maxAddressExclusive(), 1));
+    }
+
+    @Test
+    @DisplayName("does not report overflow for zero-length access at the exclusive upper bound")
+    public void wouldOverflowFalseForZeroLengthAtCeiling() {
+        assertFalse(NativeAddressSpace.wouldOverflow(NativeAddressSpace.maxAddressExclusive(), 0));
+    }
+}


### PR DESCRIPTION
This PR adds a new semantic `@Address` annotation plus a reviewed helper layer for address and range assertions in Chronicle-Core.

It does **not** yet claim broad call-site migration. This change is intentionally additive and introduces the building blocks for future adoption:

* `@Address`
* `MemoryAegis`
* `NativeAddressSpace`
* focused JUnit 5 coverage, including real `OS.memory()` usage examples

Together, these formalise the `assert SKIP_ASSERTIONS || MemoryAegis.assertXxx(...)` idiom for guarding native-address and object-offset primitives in Chronicle-Core and downstream consumers.

## What changed

Added:

* `net.openhft.chronicle.core.annotation.Address`
* `net.openhft.chronicle.core.aegis.MemoryAegis`
* `net.openhft.chronicle.core.aegis.NativeAddressSpace`

Added JUnit 5 tests:

* `MemoryAegisTest`
* `NativeAddressSpaceTest`
* `MemoryAegisUsageTest`

## Design notes

* **`@Address` semantics**
  `@Address` marks actual native addresses/base pointers. It is not intended for sizes, indexes, or end-exclusive sentinels.

* **Range helper split**
  `MemoryAegis` keeps on-heap slice checks and native/object-relative checks separate:

  * `assertByteArrayRange`, `assertCharArrayRange`, `assertStringRange` use `int` offset/length
  * `assertAddressRange`, `assertObjectRange` use `long`

* **No union helper**
  There is intentionally no `assertObjectOrAddressRange(...)`. Call sites in the dispatch:
  `obj == null ? assertAddressRange(...) : assertObjectRange(...)`
  so the contract stays visible.

* **Address-space model**
  `NativeAddressSpace` models a conservative ordinary user-space envelope:

  * reserves the first 64 KiB
  * explicit 32-bit aliases map to `2^32`
  * everything else currently uses a conservative `2^56` ceiling
  * x86-64 is intentionally **not** hard-capped to 47 bits in this revision

* **Inclusive vs exclusive bounds**
  `maxAddressInclusive()` is for reporting / diagnostics.
  `maxAddressExclusive()` and `wouldOverflow(...)` are for arithmetic and wrap prevention.
  These are intentionally separate and should not be unified.

* **Runtime model**
  `@Address` uses `@Retention(CLASS)`: semantic in class files, not runtime-visible by default.

## Reviewer focus

Please check these points closely:

### `@Address` semantics

* It should mark actual native addresses/base pointers, not sizes, indexes, or end-exclusive sentinels.
* `maxAddressExclusive()` is intentionally **not** annotated with `@Address`.

### `MemoryAegis` contract

* `assertAddressRange()` models ordinary non-negative user-space addresses only.
* It intentionally excludes negative/special mappings such as the legacy `[vsyscall]` entry visible in `/proc/self/maps`.
* `assertObjectRange()` is a sanity/overflow guard for object-relative offsets, not a precise object-bounds proof.

### `NativeAddressSpace` policy

* Explicit 32-bit aliases map to `2^32`.
* Everything else currently keeps the conservative 56-bit default.
* x86-64 is not hard-capped to 47 bits in this revision.
* Inclusive / exclusive ceiling handling in `maxAddressInclusive()`, `maxAddressExclusive()`, and `wouldOverflow()` should be checked carefully.

### Unit conventions

* array/string helpers use `int` offset/length to match `length()` / array-length semantics
* native/object helpers remain byte-oriented

### Usage examples and rollout wording

* `MemoryAegisUsageTest` now uses real `OS.memory()` operations.
* Docs/examples are intended to show the adoption pattern, not to imply that all existing `UnsafeMemory` call sites are already migrated.

### Test quality

* new tests are JUnit 5
* edge cases cover nulls, negatives, inclusive/exclusive boundaries, overflow, and `[vsyscall]` rejection

## Test coverage

* `MemoryAegisTest` covers happy paths and rejection paths across all helpers, including hostile boundary values such as `Integer.MIN_VALUE`, `Integer.MAX_VALUE`, `Long.MIN_VALUE`, `Long.MAX_VALUE`, and the legacy x86-64 `[vsyscall]` address `0xFFFFFFFFFF600000L`.
* `NativeAddressSpaceTest` covers architecture normalisation/width policy, inclusive vs exclusive bound invariants, and `wouldOverflow(...)` edge cases.
* `MemoryAegisUsageTest` demonstrates the intended `assert SKIP_ASSERTIONS || ...` idiom against real `OS.memory()` operations: native read, on-heap write, native-to-native copy, and object-or-address dispatch.

## Notes on `MemoryAegisUsageTest`

`MemoryAegisUsageTest` deliberately shadows `SKIP_ASSERTIONS` locally with `false`.

Chronicle-Core’s test classpath includes the `assertions-disabled` flavour, so importing the shared constant would constant-fold the guards away. In this test, that would let hostile-input fixtures reach raw memory operations directly and risk a JVM crash instead of tripping `AssertionError`.

That local shadow is intentional and should not be “simplified” away.

## Non-goals

* No broad downstream migration in this PR
* No claim that existing `UnsafeMemory` call sites are already wired through `MemoryAegis`
* Architecture-specific refinements such as tag-aware arm64 handling are deferred to follow-up work

