### PR TITLE
Tighten over-broad exception catches across Chronicle Core and bundle minor utility cleanups

### DIFF
--- a/src/main/java/net/openhft/chronicle/core/Jvm.java
+++ b/src/main/java/net/openhft/chronicle/core/Jvm.java
@@ -529,7 +529,8 @@ public final class Jvm {
      * @see SecurityManager#checkPermission
      * @see RuntimePermission
      */
-    @SuppressWarnings("java:S3011") // Justification: delegates to centralised ClassUtil.setAccessible for audited bypass.
+    @SuppressWarnings("java:S3011")
+    // Justification: delegates to centralised ClassUtil.setAccessible for audited bypass.
     public static void setAccessible(@NotNull final AccessibleObject accessibleObject) {
         ClassUtil.setAccessible(accessibleObject);
     }
@@ -1647,7 +1648,9 @@ public final class Jvm {
     static class ReserveMemoryHolder {
         private ReserveMemoryHolder() {
         }
+
         static final Supplier<Long> reservedMemory;
+
         static {
             Supplier<Long> reservedMemoryGetter;
             try {
@@ -1669,9 +1672,11 @@ public final class Jvm {
             reservedMemory = reservedMemoryGetter;
         }
     }
+
     static class MaxMemoryHolder {
         private MaxMemoryHolder() {
         }
+
         static final long MAX_DIRECT_MEMORY = maxDirectMemory0();
 
         private static long maxDirectMemory0() {
@@ -1685,10 +1690,9 @@ public final class Jvm {
 
                 final Field f = getField(clz, "directMemory");
                 return f.getLong(null);
-            } catch (ClassNotFoundException | IllegalAccessException e) {
-                // ignore
+            } catch (Throwable e) {
+                System.err.println(Jvm.class.getName() + ": Unable to determine max direct memory, will always report 0, " + e);
             }
-            System.err.println(Jvm.class.getName() + ": Unable to determine max direct memory, will always report 0");
             return 0L;
         }
     }

--- a/src/main/java/net/openhft/chronicle/core/Jvm.java
+++ b/src/main/java/net/openhft/chronicle/core/Jvm.java
@@ -27,6 +27,7 @@ import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import java.lang.reflect.*;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.ByteBuffer;
@@ -159,12 +160,12 @@ public final class Jvm {
             if (isJava9Plus())
                 //noinspection JavaLangInvokeHandleSignature
                 return lookup.findStatic(Thread.class, "onSpinWait", voidType);
-        } catch (Exception ignored) {
+        } catch (NoSuchMethodException | IllegalAccessException ignored) {
             // ignore
         }
         try {
             return lookup.findStatic(Safepoint.class, "force", voidType);
-        } catch (Exception ignored) {
+        } catch (NoSuchMethodException | IllegalAccessException ignored) {
             // ignore
         }
         return null;
@@ -1224,7 +1225,7 @@ public final class Jvm {
                     // added in Java 23+
                 }
             });
-        } catch (Throwable e) {
+        } catch (NoSuchFieldException | IllegalAccessException | IllegalArgumentException | AssertionError e) {
             Jvm.warn().on(clazz, "Couldn't disable close on interrupt", e);
         }
     }
@@ -1247,7 +1248,7 @@ public final class Jvm {
                             ci.interrupt();
                         return ObjectUtils.defaultValue(m.getReturnType());
                     }));
-        } catch (Throwable e) {
+        } catch (NoSuchFieldException | IllegalAccessException | IllegalArgumentException | AssertionError e) {
             Jvm.warn().on(clazz, "Couldn't disable close on interrupt", e);
         }
     }
@@ -1279,7 +1280,7 @@ public final class Jvm {
                         debug().on(Jvm.class, "Adding " + path + " to the classpath");
                     classpath.append(File.pathSeparator).append(path);
                 }
-            } catch (Throwable e) {
+            } catch (URISyntaxException | IllegalArgumentException e) {
                 debug().on(Jvm.class, "Could not add URL " + url + " to classpath");
             }
         }
@@ -1348,7 +1349,7 @@ public final class Jvm {
             }
 
             return false;
-        } catch (Exception ex) {
+        } catch (IOException ex) {
             return true;
         }
     }
@@ -1659,7 +1660,8 @@ public final class Jvm {
                 } else {
                     reservedMemoryGetter = ThrowingSupplier.asSupplier(() -> f.getLong(null));
                 }
-            } catch (Exception e) {
+                // CSWarnAndContinue keep this degraded fallback because reserved-memory introspection is optional and callers accept reporting zero when the platform does not expose it.
+            } catch (ClassNotFoundException | IllegalAccessException e) {
                 if (MAX_DIRECT_MEMORY > 0)
                     System.err.println(Jvm.class.getName() + ": Unable to determine the reservedMemory value, will always report 0");
                 reservedMemoryGetter = () -> 0L;
@@ -1683,7 +1685,7 @@ public final class Jvm {
 
                 final Field f = getField(clz, "directMemory");
                 return f.getLong(null);
-            } catch (Exception e) {
+            } catch (ClassNotFoundException | IllegalAccessException e) {
                 // ignore
             }
             System.err.println(Jvm.class.getName() + ": Unable to determine max direct memory, will always report 0");

--- a/src/main/java/net/openhft/chronicle/core/OS.java
+++ b/src/main/java/net/openhft/chronicle/core/OS.java
@@ -122,7 +122,7 @@ public final class OS {
                 && new File(tmp).isDirectory()
                 && new File(tmp).canWrite())
             return tmp;
-        new File("tmp").mkdirs();
+        new File("tmp").mkdir();
         return "tmp";
     }
 

--- a/src/main/java/net/openhft/chronicle/core/OS.java
+++ b/src/main/java/net/openhft/chronicle/core/OS.java
@@ -18,10 +18,7 @@ import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.net.DatagramSocket;
-import java.net.InetAddress;
-import java.net.InetSocketAddress;
-import java.net.Socket;
+import java.net.*;
 import java.nio.channels.FileChannel;
 import java.security.SecureRandom;
 import java.util.Scanner;
@@ -117,7 +114,7 @@ public final class OS {
         String target = Jvm.getProperty("project.build.directory");
         if (target != null) {
             final File tmp = new File(target, "tmp");
-            tmp.mkdir();
+            tmp.mkdirs();
             return tmp.getPath();
         }
         final String tmp = Jvm.getProperty("java.io.tmpdir");
@@ -702,7 +699,7 @@ public final class OS {
         static String getIpAddressByLocalHost() {
             try {
                 return InetAddress.getLocalHost().getHostAddress();
-            } catch (Throwable e) {
+            } catch (UnknownHostException e) {
                 return "";
             }
         }
@@ -714,7 +711,7 @@ public final class OS {
                     socket.connect(new InetSocketAddress("google.com", 80));
                     return socket.getLocalAddress().getHostAddress();
                 }
-            } catch (Throwable e) {
+            } catch (IOException e) {
                 return "";
             }
         }
@@ -726,7 +723,7 @@ public final class OS {
                     socket.connect(InetAddress.getByName(GOOGLE_DNS), 10002);
                     return socket.getLocalAddress().getHostAddress();
                 }
-            } catch (Throwable e) {
+            } catch (IOException e) {
                 return null;
             }
         }
@@ -746,7 +743,7 @@ public final class OS {
             }
             try {
                 return InetAddress.getLocalHost().getHostName();
-            } catch (Throwable e) {
+            } catch (UnknownHostException e) {
                 try {
                     return execHostname();
                 } catch (IOException ioe) {

--- a/src/main/java/net/openhft/chronicle/core/internal/AnnotationFinder.java
+++ b/src/main/java/net/openhft/chronicle/core/internal/AnnotationFinder.java
@@ -59,7 +59,7 @@ public class AnnotationFinder {
                 return annotation;
             }
 
-        } catch (Exception ex) {
+        } catch (RuntimeException ex) {
             return null; // Opt to return null on any exception during retrieval.
         }
         return null;

--- a/src/main/java/net/openhft/chronicle/core/internal/Bootstrap.java
+++ b/src/main/java/net/openhft/chronicle/core/internal/Bootstrap.java
@@ -123,11 +123,13 @@ public final class Bootstrap {
             // ignore and fall back to pre-jdk9
         }
         try {
-            return Integer.parseInt(Runtime.class.getPackage().getSpecificationVersion().split("\\.")[1]);
-        } catch (Exception e) {
-            System.err.println("Unable to get the major version, defaulting to 8 " + e);
-            return 8;
+            String specificationVersion = Runtime.class.getPackage().getSpecificationVersion();
+            if (specificationVersion != null)
+                return Integer.parseInt(specificationVersion.split("\\.")[1]);
+        } catch (NumberFormatException | ArrayIndexOutOfBoundsException e) {
+            System.err.println(Bootstrap.class.getName() + ": Unable to get the major version, defaulting to 8 " + e);
         }
+        return 8;
     }
 
     public static boolean is64bit0() {

--- a/src/main/java/net/openhft/chronicle/core/internal/ClassUtil.java
+++ b/src/main/java/net/openhft/chronicle/core/internal/ClassUtil.java
@@ -104,14 +104,11 @@ public final class ClassUtil {
 
         } catch (NoSuchMethodException e) {
             final Class<?> superclass = clazz.getSuperclass();
-            if (superclass != null)
-                try {
-                    final Method m = getMethod0(superclass, name, args, false);
-                    if (m != null)
-                        return m;
-                } catch (Exception ignored) {
-                    // Ignore
-                }
+            if (superclass != null) {
+                final Method m = getMethod0(superclass, name, args, false);
+                if (m != null)
+                    return m;
+            }
             if (first)
                 throw new AssertionError(e);
             return null;

--- a/src/main/java/net/openhft/chronicle/core/internal/ReferenceCountedUtils.java
+++ b/src/main/java/net/openhft/chronicle/core/internal/ReferenceCountedUtils.java
@@ -83,7 +83,7 @@ public final class ReferenceCountedUtils {
 
                 try {
                     key.throwExceptionIfNotReleased();
-                } catch (Exception e) {
+                } catch (IllegalStateException e) {
                     openFiles.addSuppressed(e);
                 }
             }

--- a/src/main/java/net/openhft/chronicle/core/internal/pom/InternalPomProperties.java
+++ b/src/main/java/net/openhft/chronicle/core/internal/pom/InternalPomProperties.java
@@ -3,9 +3,11 @@
  */
 package net.openhft.chronicle.core.internal.pom;
 
+import net.openhft.chronicle.core.Jvm;
 import net.openhft.chronicle.core.util.ObjectUtils;
 import org.jetbrains.annotations.NotNull;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.Map;
 import java.util.Properties;
@@ -24,15 +26,15 @@ public final class InternalPomProperties {
         ObjectUtils.requireNonNull(groupId);
         ObjectUtils.requireNonNull(artifactId);
         final Properties properties = new Properties();
+        final String resourceName = resourceName(groupId, artifactId);
         try {
-            final String resourceName = resourceName(groupId, artifactId);
             try (InputStream inputStream = InternalPomProperties.class.getResourceAsStream(resourceName)) {
                 if (inputStream != null) {
                     properties.load(inputStream);
                 }
             }
-        } catch (Exception ignore) {
-            ignore.printStackTrace();
+        } catch (IOException | IllegalArgumentException e) {
+            Jvm.debug().on(InternalPomProperties.class, "Error reading " + resourceName, e);
             // Returns an empty set of properties if we fail.
         }
         return properties;

--- a/src/main/java/net/openhft/chronicle/core/io/AbstractReferenceCounted.java
+++ b/src/main/java/net/openhft/chronicle/core/io/AbstractReferenceCounted.java
@@ -137,7 +137,8 @@ public abstract class AbstractReferenceCounted implements ReferenceCountedTracer
     void inThreadPerformRelease() {
         try {
             performRelease();
-        } catch (Exception e) {
+            // CSCatchThrowable keep this catch-all boundary because this is the last-resort containment point before the background release task ends
+        } catch (Throwable e) {
             Jvm.warn().on(getClass(), e);
         }
     }

--- a/src/main/java/net/openhft/chronicle/core/io/BackgroundResourceReleaser.java
+++ b/src/main/java/net/openhft/chronicle/core/io/BackgroundResourceReleaser.java
@@ -155,9 +155,13 @@ public final class BackgroundResourceReleaser {
                 offerPoisonPill(false);
 
             if (!interrupted)
-                for (int i = 0; i < 1000 && COUNTER.get() > 0; i++)
-                    //noinspection BusyWait
-                    Thread.sleep(1);
+                for (int i = 0; i < 1000 && COUNTER.get() > 0; i++) {
+                    Jvm.pause(1);
+                    if (Thread.currentThread().isInterrupted()) {
+                        interrupted = true;
+                        break;
+                    }
+                }
             long left = COUNTER.get();
             if (left != 0)
                 Jvm.perf().on(BackgroundResourceReleaser.class, "Still got " + left + " resources to clean");

--- a/src/main/java/net/openhft/chronicle/core/pool/ClassLookup.java
+++ b/src/main/java/net/openhft/chronicle/core/pool/ClassLookup.java
@@ -112,7 +112,7 @@ public interface ClassLookup {
     default CharSequence applyAlias(CharSequence name) {
         try {
             return nameFor(forName(name));
-        } catch (Exception cnfe) {
+        } catch (ClassNotFoundRuntimeException cnfe) {
             return name;
         }
     }

--- a/src/main/java/net/openhft/chronicle/core/pool/DynamicEnumClass.java
+++ b/src/main/java/net/openhft/chronicle/core/pool/DynamicEnumClass.java
@@ -99,12 +99,6 @@ public class DynamicEnumClass<E extends CoreDynamicEnum<E>> extends EnumCache<E>
      * @param name the name of the enum instance to be retrieved.
      * @return the enum instance with the specified name, or {@code null} if not present.
      */
-    /**
-     * Returns the enum instance if it exists in the map.
-     *
-     * @param name the enum name to retrieve
-     * @return the enum instance or {@code null}
-     */
     @Override
     @Nullable
     public E get(String name) {

--- a/src/main/java/net/openhft/chronicle/core/pool/StaticEnumClass.java
+++ b/src/main/java/net/openhft/chronicle/core/pool/StaticEnumClass.java
@@ -49,12 +49,6 @@ public class StaticEnumClass<E extends Enum<E>> extends EnumCache<E> {
      * @param name the name of the enum instance to be retrieved.
      * @return the enum instance with the specified name, or {@code null} if not present.
      */
-    /**
-     * Returns the enum instance with the specified name or {@code null}.
-     *
-     * @param name the enum name to lookup
-     * @return the enum instance or {@code null}
-     */
     @Override
     @Nullable
     public E valueOf(String name) {
@@ -66,11 +60,6 @@ public class StaticEnumClass<E extends Enum<E>> extends EnumCache<E> {
      * to the count of enum constants in the original enum class.
      *
      * @return the number of enum instances.
-     */
-    /**
-     * Returns the number of enum constants.
-     *
-     * @return the constant count
      */
     @Override
     public int size() {
@@ -84,13 +73,6 @@ public class StaticEnumClass<E extends Enum<E>> extends EnumCache<E> {
      * @return the enum instance at the given index.
      * @throws ArrayIndexOutOfBoundsException if the index is out of range.
      */
-    /**
-     * Retrieves the enum at the specified ordinal.
-     *
-     * @param index the ordinal index of the enum instance to retrieve
-     * @return the enum instance at the given index
-     * @throws ArrayIndexOutOfBoundsException if the index is out of range
-     */
     @Override
     public E forIndex(int index) {
         return values[index];
@@ -102,21 +84,11 @@ public class StaticEnumClass<E extends Enum<E>> extends EnumCache<E> {
      *
      * @return an array containing the enum instances.
      */
-    /**
-     * Returns all enum instances in declaration order.
-     *
-     * @return an array containing the enum instances
-     */
     @Override
     public E[] asArray() {
         return values;
     }
 
-    /**
-     * Creates a map with enum instances as keys.
-     *
-     * @return a map where the keys are enum instances.
-     */
     /**
      * Creates a map keyed by enum constants.
      *
@@ -128,11 +100,6 @@ public class StaticEnumClass<E extends Enum<E>> extends EnumCache<E> {
         return new EnumMap<>(type);
     }
 
-    /**
-     * Creates a set for holding enum instances.
-     *
-     * @return a set for holding enum instances.
-     */
     /**
      * Creates a set for holding enum instances.
      *

--- a/src/main/java/net/openhft/chronicle/core/shutdown/PriorityHook.java
+++ b/src/main/java/net/openhft/chronicle/core/shutdown/PriorityHook.java
@@ -91,7 +91,7 @@ public class PriorityHook {
      * Execute registered hooklets in priority order.
      */
     public void onShutdown() {
-        for (Hooklet hooklet : hookletPool.keySet())
+        for (Hooklet hooklet : new ArrayList<>(hookletPool.keySet()))
             hooklet.onShutdown();
     }
 

--- a/src/main/java/net/openhft/chronicle/core/threads/CleaningThreadLocal.java
+++ b/src/main/java/net/openhft/chronicle/core/threads/CleaningThreadLocal.java
@@ -325,9 +325,10 @@ public class CleaningThreadLocal<T> extends ThreadLocal<T> {
         if (value == null) return;
         try {
             cleanup.accept(value);
-        } catch (Exception ex) {
+            // CSCatchThrowable keep this catch-all cleanup boundary because this is the last attempt to clean up resources when a cleaning thread dies or when a test finishes and cleanup tracking must continue
+        } catch (Throwable ex) {
             Jvm.warn().on(getClass(),
-                    "Exception during cleanup of " + value.getClass(), ex);
+                    "Throwable during cleanup of " + value.getClass(), ex);
         }
     }
 

--- a/src/main/java/net/openhft/chronicle/core/util/AbstractInvocationHandler.java
+++ b/src/main/java/net/openhft/chronicle/core/util/AbstractInvocationHandler.java
@@ -76,7 +76,7 @@ public abstract class AbstractInvocationHandler implements InvocationHandler {
             final Field field = MethodHandles.Lookup.class.getDeclaredField("IMPL_LOOKUP");
             ClassUtil.setAccessible(field);
             return (MethodHandles.Lookup) field.get(null);
-        } catch (Exception e) {
+        } catch (NoSuchFieldException | IllegalAccessException e) {
             // use the default to produce an error message.
             return MethodHandles.lookup();
         }

--- a/src/main/java/net/openhft/chronicle/core/util/Mocker.java
+++ b/src/main/java/net/openhft/chronicle/core/util/Mocker.java
@@ -143,7 +143,8 @@ public final class Mocker {
                         consumer.accept(method.getName(), args);
                         if (t != null)
                             return method.invoke(t, args);
-                        return null;
+                        // Assume the mocked method returns the default value
+                        return ObjectUtils.defaultValue(method.getReturnType());
                     }
                 }));
     }
@@ -186,7 +187,8 @@ public final class Mocker {
                         classes.toArray(NO_CLASSES), new AbstractInvocationHandler(interfaceType) {
                             @Override
                             protected Object doInvoke(Object proxy, Method method, Object[] args) {
-                                return null;
+                                // Assume the mocked method returns the default value
+                                return ObjectUtils.defaultValue(method.getReturnType());
                             }
                         }));
     }

--- a/src/main/java/net/openhft/chronicle/core/util/ObjectUtils.java
+++ b/src/main/java/net/openhft/chronicle/core/util/ObjectUtils.java
@@ -109,8 +109,6 @@ public final class ObjectUtils {
             return m;
         } catch (NoSuchMethodException expected) {
             return null;
-        } catch (Exception e) {
-            throw new AssertionError(e);
         }
     });
     private static final Map<Class<?>, Immutability> IMMUTABILITY_MAP = new ConcurrentHashMap<>();
@@ -193,7 +191,8 @@ public final class ObjectUtils {
             ClassUtil.setAccessible(constructor);
             return ThrowingSupplier.asSupplier(constructor::newInstance);
 
-        } catch (Exception e) {
+            // RuntimeException required to catch InaccessibleObjectException not present in JDK 8, but can be thrown in JDK 9+
+        } catch (NoSuchMethodException | RuntimeException e) {
             return () -> {
                 try {
                     return OS.memory().allocateInstance(c);
@@ -605,6 +604,7 @@ public final class ObjectUtils {
         try {
             return newInstance(type);
         } catch (Exception e) {
+            Jvm.debug().on(ObjectUtils.class, "Failed to create type", e);
             return null;
         }
     }
@@ -893,7 +893,7 @@ public final class ObjectUtils {
                 final Constructor<?> constructor = c.getDeclaredConstructor(String.class);
                 ClassUtil.setAccessible(constructor);
                 return constructor::newInstance;
-            } catch (Exception e) {
+            } catch (NoSuchMethodException e) {
                 return new ThrowsCCE(e);
             }
         }


### PR DESCRIPTION
This PR reviews over-broad exception handling across Chronicle Core and replaces generic `catch (Exception)` / `catch (Throwable)` clauses with the concrete failure types expected at each call site, wherever that can be done safely.

A small number of broad boundaries are intentionally retained where the code is acting as a last-resort cleanup or best-effort platform fallback. Those sites are now commented, so the rationale is explicit during future security or Sonar-driven cleanup passes.

Alongside that review, this PR also bundles a handful of adjacent, low-risk cleanups in the same files. Those are itemised separately below so they can be reviewed independently from the main exception-boundary work.

## Primary change: exception broadness review

* Narrow broad reflective, networking, filesystem, and optional-platform catches across:

  * `Jvm`
  * `OS`
  * `AnnotationFinder`
  * `Bootstrap`
  * `ReferenceCountedUtils`
  * `InternalPomProperties`
  * `ClassLookup`
  * `AbstractInvocationHandler`
  * `ObjectUtils`
* Keep broad handling only where it is intentional:

  * `AbstractReferenceCounted.inThreadPerformRelease()` now explicitly uses `catch (Throwable)` as the last-resort containment boundary for background release work.
  * `CleaningThreadLocal.cleanup(...)` now explicitly uses `catch (Throwable)` as the final cleanup boundary when tracked resource cleanup must continue even after serious failures.
  * `ObjectUtils.newInstanceOrNull(...)` keeps its broad null-on-failure contract, but now emits a debug log before returning `null`.
  * `MaxMemoryHolder.maxDirectMemory0()` broadens the catch after user feedback that this was causing a problem. #634 
* Tighten `Jvm.addToClassPath(...)` so it only swallows URL/URI-to-path conversion failures instead of unrelated throwables.
* Keep the optional JVM-internals fallback paths in `Jvm` best-effort: if direct-memory / reserved-memory introspection is unavailable, the existing degraded fallback remains.
* Make Java-version fallback parsing in `Bootstrap` more explicit by handling null or malformed specification-version strings before defaulting to Java 8.

## Bundled minor non-exception-review changes

* `Mocker`

  * return `ObjectUtils.defaultValue(...)` for ignored proxy methods so primitive-returning methods no longer fail by returning `null`
* `BackgroundResourceReleaser`

  * replace direct `Thread.sleep(1)` polling with `Jvm.pause(1)`
  * stop the wait loop if the current thread becomes interrupted while waiting for resource cleanup
* `PriorityHook`

  * snapshot `hookletPool.keySet()` before iteration so shutdown hooks can mutate the pool without concurrent-modification risk
* `InternalPomProperties`

  * replace `printStackTrace()` with Chronicle debug logging when pom properties cannot be loaded
* `OS`

  * collapse the touched `java.net` imports into a wildcard to match the newly referenced networking exception types
* `ClassUtil`

  * remove a redundant inner `try/catch` around recursive superclass method lookup
* `StaticEnumClass` / `DynamicEnumClass`

  * remove duplicated Javadoc blocks

## Behaviour/impact notes

The main intent of this PR is to make exception boundaries more precise, not to change steady-state behaviour.

The places with real behavioural or diagnostic impact are:

* ignored mock proxies now return primitive defaults instead of `null`
* shutdown hook execution is resilient to pool mutation during shutdown
* background resource release now uses `Jvm.pause(...)` and exits its wait loop on interrupt
* pom-property load failures now go to Chronicle debug logging instead of stderr stack traces
* the build `tmp` directory creation path now uses `mkdirs()`
* the two explicit cleanup boundaries now catch `Throwable`, not just `Exception`, to prioritise cleanup containment

## Notes for reviewers

Please focus the review on the catch-boundary choices rather than the small housekeeping changes.

Areas I’d especially appreciate eyes on:

1. `Jvm` optional platform/reflection paths, especially:

   * direct-memory / reserved-memory fallback handling
   * the do-not-close-on-interrupt reflection paths
   * classpath URL handling
2. The two deliberate `catch (Throwable)` cleanup boundaries in:

   * `AbstractReferenceCounted`
   * `CleaningThreadLocal`
3. The bundled behavioural fixes in:

   * `Mocker`
   * `PriorityHook`
   * `BackgroundResourceReleaser`
   * `InternalPomProperties`
   * `OS`
4. `ObjectUtils.newInstanceOrNull(...)`, which intentionally keeps a broad catch because its contract is still “return null on failure”