### PR TITLE
Polishes wording across the README, supporting AsciiDoc files, and Java comments/Javadocs.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -52,7 +52,7 @@ See the section on <<os-calls,OS Calls>>
 
 See the section on <<jvm-access-methods,JVM Access Methods>>
 
-*Memory Mapped Files:* The library offers an interface for managing memory mapped files, which is useful for high-performance I/O operations.
+*Memory-Mapped Files:* The library offers an interface for managing memory-mapped files, which is useful for high-performance I/O operations.
 
 [source,java]
 ----
@@ -104,10 +104,10 @@ public class AbstractReferenceCountedTest {
 
 See the section on <<resource-reference-counting,Resource Reference Counting>>
 
-*Thread safety checks:* The library enables the use of thread safety checks for single-threaded components.
+*Thread-safety checks:* The library enables the use of thread-safety checks for single-threaded components.
 See the section on <<thread-safety-checks,Thread Safety Checks>>
 
-This library also wraps up low level access to
+This library also wraps up low-level access to
 
 * <<system-properties-from-file,System properties from a file>>
 * <<off-heap-memory-access,Off Heap Memory Access>>
@@ -115,7 +115,7 @@ This library also wraps up low level access to
 * <<class-local-caching,Class Local Caching>>
 * <<maths-functions,Maths Functions>> for casting types, rounding double, faster hashing.
 * <<serializable-lambdas,Serializable Lambdas>>
-* <<histogram,Histogram>> A high performance wide range histogram.
+* <<histogram,Histogram>> A high-performance wide range histogram.
 
 == System properties from file
 
@@ -137,7 +137,7 @@ For example with Jvm.getInteger or Jvm.getLong.
 
 A number of relevant system properties are listed in link:docs/systemProperties.adoc[systemProperties.adoc].
 
-NOTE: Command line-specified system properties override those in the `system.properties` file.
+NOTE: Command-line-specified system properties override those in the `system.properties` file.
 
 == Chronicle-Core Initialization
 
@@ -163,7 +163,7 @@ It can provide both init and post-init functionalities by implementing the `Chro
 
 == Off Heap Memory Access
 
-This allows you to access native memory using primitives and some thread safe operations.
+This allows you to access native memory using primitives and some thread-safe operations.
 
 [source,java]
 ----
@@ -225,7 +225,7 @@ String username = OS.getUserName();
 String targetDir = OS.getTarget(); // location the target directory during builds
 ----
 
-Memory mapped files
+Memory-mapped files
 
 [source,java]
 ----
@@ -496,11 +496,11 @@ There are a number of implementations of this in Chronicle-Core, including `net.
 When the user calls a method which _must_ be called single-threaded, these methods call a private method to check that `Thread.currentThread()` is the same as the first thread that used the object, and throws an exception if not.
 `AbstractCloseable` also provides very helpful functionality (if resource tracing is on) to keep track of the stack trace of where it was used first by the use-by thread - this provides invaluable when diagnosing unexpected sharing of an object between threads.
 
-Thread safety checking can be turned off with the system property `disable.single.threaded.check`, once the application is thoroughly tested.
+Thread-safety checking can be turned off with the system property `disable.single.threaded.check`, once the application is thoroughly tested.
 
 An object can be handed-off between threads by calling `singleThreadedCheckReset`.
 
-=== Thread safety patterns
+=== Thread-safety patterns
 
 Some patterns which are commonly used in Chronicle's libraries are below.
 

--- a/docs/systemProperties.adoc
+++ b/docs/systemProperties.adoc
@@ -15,7 +15,7 @@ A property is considered enabled if it is set using `-Dflag`, `-Dflag=true`, or 
 | `disable.discard.warning` | `true` | Called from finalise() implementations. If `false`, message is displayed stating that resource cannot be closed, and IllegalStateException is thrown  | `DISABLE_DISCARD_WARNING` (boolean)
 | `disable.perf.info` | `false` | if enabled, returns NullExceptionHandler | `disablePerfInfo` (boolean)
 | `disable.resource.warning` | `false` | If enabled, returns that resource tracing is turned on | boolean
-| `disable.single.threaded.check` | `false` | Disables thread safety checks | boolean
+| `disable.single.threaded.check` | `false` | Disables thread-safety checks | boolean
 | `jfr` | `false` | Returns if the JVM is running in flight recorder mode | `IS_FLIGHT_RECORDER` (boolean)
 | `jvm.resources.tracing` | `false` | Returns if certain chronicle resources (such as memory regions) are traced. Reference counting can be enabled, which incurs slightly less performance, but it provides a means of detecting proper release of resources | RESOURCE_TRACING (boolean)
 | `jvm.safepoint.enabled` | `false` | If enabled, inserts a low-cost Java safe-point, which can help to find blockages. Jvm.safepoint can also be added when monitoring the event loop in link:https://github.com/OpenHFT/Chronicle-Threads#monitoring-the-event-loop[Chronicle-Threads] to help identify hotspots in the code | `SAFEPOINT_ENABLED` (boolean)

--- a/src/main/docs/StackTrace-user-guide.adoc
+++ b/src/main/docs/StackTrace-user-guide.adoc
@@ -242,7 +242,7 @@ Creating a stack trace can take microseconds to milliseconds.
 Test in your environment.
 
 . *Memory*
-Each `StackTraceElement` can hold a class name, method name, file name, line number, etc. A large number of frames can consume memory.
+Each `StackTraceElement` can hold a class name, method name, filename, line number, etc. A large number of frames can consume memory.
 
 . *Thread-Safety*
 `forThread(Thread)` is thread-safe, but if the thread is in native code or unwinding, frames might be incomplete.

--- a/src/main/docs/decision-log.adoc
+++ b/src/main/docs/decision-log.adoc
@@ -109,7 +109,7 @@ Context::
 * Initialisation steps for some applications must run before Chronicle reads any system properties.
 * Other hooks must execute after `Jvm` static initialisation completes.
 Decision Statement::
-* Provide `ChronicleInit` to load and run classes specified by
+* Provide `ChronicleInit` to load and run classes named by
 `chronicle.init.runnable` and `chronicle.postinit.runnable` system properties.
 * Support `ChronicleInitRunnable` implementations discovered via `ServiceLoader`.
 Alternatives Considered::

--- a/src/main/docs/deterministic-resource-management.adoc
+++ b/src/main/docs/deterministic-resource-management.adoc
@@ -18,7 +18,7 @@ Resource tracing helps diagnose leaks and incorrect resource usage by tracking r
 * **Enabling**: Set system property `jvm.resource.tracing=true`.
 Alternatively, call `AbstractCloseable.enableCloseableTracing()` and `AbstractReferenceCounted.enableReferenceTracing()`.
 * **Debugging**: In tests, use `CloseableUtils.assertCloseablesClosed()` and `ReferenceCountedUtils.assertReferencesReleased()` to verify all tracked resources are properly released.
-* **Tracking Mechanism**: Utilizes `WeakIdentityHashMap` to store references to managed resources without preventing them from being garbage collected if all other references are gone.
+* **Tracking Mechanism**: Uses `WeakIdentityHashMap` to store references to managed resources without preventing them from being garbage collected if all other references are gone.
 
 == 2. `Closeable` Resources with `AbstractCloseable`
 

--- a/src/main/docs/thread-safety-guarantees.adoc
+++ b/src/main/docs/thread-safety-guarantees.adoc
@@ -80,4 +80,4 @@ When a `ThreadingIllegalStateException` is thrown:
 == 6. Related Requirements and Properties
 * **Project Requirements**: `CORE-FN-040`, `CORE-FN-041`, `CORE-FN-042`, `CORE-FN-043` detail these features.
 * **System Property**: `disable.single.threaded.check` can disable these checks globally (see `systemProperties.adoc`).
-* **Further Reading**: See the `README.adoc` for an initial overview of thread safety checks.
+* **Further Reading**: See the `README.adoc` for an initial overview of thread-safety checks.

--- a/src/main/java/net/openhft/chronicle/core/Jvm.java
+++ b/src/main/java/net/openhft/chronicle/core/Jvm.java
@@ -1392,7 +1392,7 @@ public final class Jvm {
     }
 
     /**
-     * Retrieve an annotation of the specified {@code annotationType} that is present on the given
+     * Returns an annotation of the specified {@code annotationType} that is present on the given
      * {@code annotatedElement}, including considering nested annotations and method inheritance.
      * If the annotation isn't found, this method returns {@code null}.
      *

--- a/src/main/java/net/openhft/chronicle/core/Memory.java
+++ b/src/main/java/net/openhft/chronicle/core/Memory.java
@@ -56,11 +56,11 @@ public interface Memory {
     void freeMemory(long address, long size);
 
     /**
-     * Allocates memory and returns the low level base address of the newly allocated
+     * Allocates memory and returns the low-level base address of the newly allocated
      * memory region.
      *
      * @param capacity to allocate
-     * @return the low level base address of the newly allocated memory region
+     * @return the low-level base address of the newly allocated memory region
      * @throws IllegalArgumentException If the capacity is non-positive
      * @throws OutOfMemoryError         if there are not enough memory to allocate
      */

--- a/src/main/java/net/openhft/chronicle/core/OS.java
+++ b/src/main/java/net/openhft/chronicle/core/OS.java
@@ -33,7 +33,7 @@ import static net.openhft.chronicle.core.util.Longs.requireNonNegative;
 import static net.openhft.chronicle.core.util.Longs.requirePositive;
 
 /**
- * Low level access to OS class. The OS class provides utility methods related to the operating system.
+ * Low-level access to OS class. The OS class provides utility methods related to the operating system.
  */
 @SuppressWarnings("java:S1191") // Justification: uses Sun internal classes for performance-critical file mapping on select JDKs; guarded by version checks and fallbacks.
 public final class OS {

--- a/src/main/java/net/openhft/chronicle/core/StackTrace.java
+++ b/src/main/java/net/openhft/chronicle/core/StackTrace.java
@@ -51,7 +51,7 @@ import java.util.concurrent.TimeUnit;
  *
  * StackTrace can be used to diagnose resource leaks, single-threaded resource enforcement,
  * diagnosing when a resource is used after closing and monitoring long-running threads on demand.
- * Taking a StackTrace isn't free; however, if used judiciously, it can be utilized in production
+ * Taking a StackTrace isn't free; however, if used judiciously, it can be used in production
  * to provide on-demand profiling.
  * <p>
  * For a deep dive into the StackTrace class see <a href="https://github.com/OpenHFT/Chronicle-Core/tree/ea/src/main/docs/StackTrace-user-guide.adoc">StackTrace User Guide.adoc</a>

--- a/src/main/java/net/openhft/chronicle/core/analytics/AnalyticsFacade.java
+++ b/src/main/java/net/openhft/chronicle/core/analytics/AnalyticsFacade.java
@@ -247,7 +247,7 @@ public interface AnalyticsFacade {
         Builder withDebugLogger(@NotNull Consumer<? super String> debugLogger);
 
         /**
-         * Specifies a custom file name to use when storing a persistent client id
+         * Specifies a custom filename to use when storing a persistent client id
          * used to identify returning users.
          * <p>
          * By default, a file named "chronicle.analytics.client.id" located

--- a/src/main/java/net/openhft/chronicle/core/internal/AnnotationFinder.java
+++ b/src/main/java/net/openhft/chronicle/core/internal/AnnotationFinder.java
@@ -16,7 +16,7 @@ import java.util.Set;
 public class AnnotationFinder {
 
     /**
-     * Retrieve an annotation of the specified {@code annotationType} that is present on the given
+     * Returns an annotation of the specified {@code annotationType} that is present on the given
      * {@code annotatedElement}, including considering nested annotations and method inheritance.
      * If the annotation isn't found, this method returns {@code null}.
      *

--- a/src/main/java/net/openhft/chronicle/core/internal/CloseableUtils.java
+++ b/src/main/java/net/openhft/chronicle/core/internal/CloseableUtils.java
@@ -29,7 +29,7 @@ public final class CloseableUtils {
      * Set of closeable resources being tracked.
      * <p>
      * NOTE: This assumes the collection will not be replaced concurrently, and a particular lifecycle is used.
-     * It is set and reset between tests in a single threaded manner. The set itself could be changed concurrently.
+     * It is set and reset between tests in a single-threaded manner. The set itself could be changed concurrently.
      */
     private static final AtomicReference<Set<ManagedCloseable>> CLOSEABLES = new AtomicReference<>();
 

--- a/src/main/java/net/openhft/chronicle/core/internal/util/DirectBufferUtil.java
+++ b/src/main/java/net/openhft/chronicle/core/internal/util/DirectBufferUtil.java
@@ -11,7 +11,7 @@ import static net.openhft.chronicle.core.util.ObjectUtils.requireNonNull;
 
 /**
  * This utility class provides centralized access to the
- * internal class sun.nio.ch.DirectBuffer in order to reduce
+ * internal class sun.nio.ch.DirectBuffer to reduce
  * compile time warnings.
  */
 public final class DirectBufferUtil {

--- a/src/main/java/net/openhft/chronicle/core/io/AbstractCloseable.java
+++ b/src/main/java/net/openhft/chronicle/core/io/AbstractCloseable.java
@@ -231,7 +231,7 @@ public abstract class AbstractCloseable implements ReferenceOwner, ManagedClosea
      * that requires it to be open.
      *
      * @throws ClosedIllegalStateException    If the resource has been released or closed.
-     * @throws ThreadingIllegalStateException If the thread safety check fails.
+     * @throws ThreadingIllegalStateException If the thread-safety check fails.
      */
     @Override
     public void throwExceptionIfClosed() throws ClosedIllegalStateException, ThreadingIllegalStateException {
@@ -249,7 +249,7 @@ public abstract class AbstractCloseable implements ReferenceOwner, ManagedClosea
      * This method is used to ensure that the resource is open before attempting to modify its state.
      *
      * @throws ClosedIllegalStateException    If the resource has been released or closed.
-     * @throws ThreadingIllegalStateException If the thread safety check fails.
+     * @throws ThreadingIllegalStateException If the thread-safety check fails.
      */
     public void throwExceptionIfClosedInSetter() throws ClosedIllegalStateException, ThreadingIllegalStateException {
         if (isClosed())
@@ -336,7 +336,7 @@ public abstract class AbstractCloseable implements ReferenceOwner, ManagedClosea
     }
 
     /**
-     * Performs a thread safety check on the component.
+     * Performs a thread-safety check on the component.
      * If the component is not thread-safe and is accessed by multiple threads,
      * an {@link ThreadingIllegalStateException} is thrown.
      * This method is intended to be called before operations that require thread safety.
@@ -367,8 +367,8 @@ public abstract class AbstractCloseable implements ReferenceOwner, ManagedClosea
     }
 
     /**
-     * Resets the state of the thread safety check.
-     * After calling this method, the component's thread safety check state will be cleared,
+     * Resets the state of the thread-safety check.
+     * After calling this method, the component's thread-safety check state will be cleared,
      * and it will no longer remember which thread it was last accessed by.
      */
     public void singleThreadedCheckReset() {

--- a/src/main/java/net/openhft/chronicle/core/io/AbstractCloseableReferenceCounted.java
+++ b/src/main/java/net/openhft/chronicle/core/io/AbstractCloseableReferenceCounted.java
@@ -55,7 +55,7 @@ public abstract class AbstractCloseableReferenceCounted
      * @param from resource
      * @param to   resource
      * @throws ClosedIllegalStateException    If the resource has been released or closed.
-     * @throws ThreadingIllegalStateException If used in a non thread safe way
+     * @throws ThreadingIllegalStateException If used in a non-thread-safe way
      */
     @Override
     public void reserveTransfer(ReferenceOwner from, ReferenceOwner to) throws ClosedIllegalStateException, ThreadingIllegalStateException {

--- a/src/main/java/net/openhft/chronicle/core/io/IOTools.java
+++ b/src/main/java/net/openhft/chronicle/core/io/IOTools.java
@@ -361,10 +361,10 @@ public final class IOTools {
 
     /**
      * Creates a temporary name for a file by appending the system's current
-     * nanosecond time to the file name.
+     * nanosecond time to the filename.
      *
-     * @param filename The original file name
-     * @return A temporary file name
+     * @param filename The original filename
+     * @return A temporary filename
      */
     @NotNull
     public static String tempName(@NotNull String filename) {

--- a/src/main/java/net/openhft/chronicle/core/io/ManagedCloseable.java
+++ b/src/main/java/net/openhft/chronicle/core/io/ManagedCloseable.java
@@ -47,7 +47,7 @@ public interface ManagedCloseable extends Closeable {
      * The exception message indicates whether the resource is already closed or is currently in the process of closing.
      *
      * @throws ClosedIllegalStateException    If the resource has been released or closed.
-     * @throws ThreadingIllegalStateException If the thread safety check fails.
+     * @throws ThreadingIllegalStateException If the thread-safety check fails.
      */
     default void throwExceptionIfClosed() throws ClosedIllegalStateException, ThreadingIllegalStateException {
         if (isClosing())

--- a/src/main/java/net/openhft/chronicle/core/io/ReferenceOwner.java
+++ b/src/main/java/net/openhft/chronicle/core/io/ReferenceOwner.java
@@ -32,13 +32,13 @@ public interface ReferenceOwner {
     ReferenceOwner TMP = new VanillaReferenceOwner("tmp");
 
     /**
-     * Creates and returns a temporary  with the given name.
+     * Creates and returns a temporary reference owner with the given name.
      * <p>
      * When resource tracing is enabled, a new {@link VanillaReferenceOwner} is created with the specified name.
      * Otherwise, the predefined {@link ReferenceOwner#TMP} instance is returned, regardless of the provided name.
      *
      * @param name The name to be assigned to the temporary reference owner, used for identification and debugging purposes.
-     * @return A temporary  instance.
+     * @return A temporary reference owner instance.
      */
     static ReferenceOwner temporary(String name) {
         return Jvm.isResourceTracing() ? new VanillaReferenceOwner(name) : TMP;

--- a/src/main/java/net/openhft/chronicle/core/io/SingleThreadedChecked.java
+++ b/src/main/java/net/openhft/chronicle/core/io/SingleThreadedChecked.java
@@ -32,7 +32,7 @@ public interface SingleThreadedChecked {
      * When set to {@code true}, this resource can be shared between threads
      * as long as the users ensure that it is used in a thread-safe manner.
      *
-     * @param singleThreadedCheckDisabled {@code true} to turn off the thread safety check,
+     * @param singleThreadedCheckDisabled {@code true} to turn off the thread-safety check,
      *                                    {@code false} to enable it.
      */
     void singleThreadedCheckDisabled(boolean singleThreadedCheckDisabled);

--- a/src/main/java/net/openhft/chronicle/core/io/UnsafeCloseable.java
+++ b/src/main/java/net/openhft/chronicle/core/io/UnsafeCloseable.java
@@ -43,7 +43,7 @@ public abstract class UnsafeCloseable extends AbstractCloseable {
      *
      * @return The long value.
      * @throws ClosedIllegalStateException    If the resource has been released or closed.
-     * @throws ThreadingIllegalStateException If used in a non thread safe way
+     * @throws ThreadingIllegalStateException If used in a non-thread-safe way
      */
     public long getLong() throws ClosedIllegalStateException, ThreadingIllegalStateException {
         try {
@@ -59,7 +59,7 @@ public abstract class UnsafeCloseable extends AbstractCloseable {
      *
      * @param value The long value to set.
      * @throws ClosedIllegalStateException    If the resource has been released or closed.
-     * @throws ThreadingIllegalStateException If used in a non thread safe way
+     * @throws ThreadingIllegalStateException If used in a non-thread-safe way
      */
     public void setLong(long value) throws ClosedIllegalStateException, ThreadingIllegalStateException {
         try {
@@ -75,7 +75,7 @@ public abstract class UnsafeCloseable extends AbstractCloseable {
      *
      * @return The volatile long value.
      * @throws ClosedIllegalStateException    If the resource has been released or closed.
-     * @throws ThreadingIllegalStateException If used in a non thread safe way
+     * @throws ThreadingIllegalStateException If used in a non-thread-safe way
      */
     public long getVolatileLong() throws ClosedIllegalStateException, ThreadingIllegalStateException {
         try {
@@ -91,7 +91,7 @@ public abstract class UnsafeCloseable extends AbstractCloseable {
      *
      * @param value The volatile long value to set.
      * @throws ClosedIllegalStateException    If the resource has been released or closed.
-     * @throws ThreadingIllegalStateException If used in a non thread safe way
+     * @throws ThreadingIllegalStateException If used in a non-thread-safe way
      */
     public void setVolatileLong(long value) throws ClosedIllegalStateException, ThreadingIllegalStateException {
         try {
@@ -108,7 +108,7 @@ public abstract class UnsafeCloseable extends AbstractCloseable {
      * @param closedLong The default value to return if the resource is closed.
      * @return The volatile long value or the default value if closed.
      * @throws ClosedIllegalStateException    If the resource has been released or closed.
-     * @throws ThreadingIllegalStateException If used in a non thread safe way
+     * @throws ThreadingIllegalStateException If used in a non-thread-safe way
      */
     public long getVolatileLong(long closedLong) throws ClosedIllegalStateException {
         if (isClosed())
@@ -125,7 +125,7 @@ public abstract class UnsafeCloseable extends AbstractCloseable {
      *
      * @param value The ordered long value to set.
      * @throws ClosedIllegalStateException    If the resource has been released or closed.
-     * @throws ThreadingIllegalStateException If used in a non thread safe way
+     * @throws ThreadingIllegalStateException If used in a non-thread-safe way
      */
     public void setOrderedLong(long value) throws ClosedIllegalStateException, ThreadingIllegalStateException {
         try {
@@ -142,7 +142,7 @@ public abstract class UnsafeCloseable extends AbstractCloseable {
      * @param delta The value to add.
      * @return The updated value.
      * @throws ClosedIllegalStateException    If the resource has been released or closed.
-     * @throws ThreadingIllegalStateException If used in a non thread safe way
+     * @throws ThreadingIllegalStateException If used in a non-thread-safe way
      */
     public long addLong(long delta) throws ClosedIllegalStateException, ThreadingIllegalStateException {
         try {
@@ -160,7 +160,7 @@ public abstract class UnsafeCloseable extends AbstractCloseable {
      * @param delta The value to add.
      * @return The updated value.
      * @throws ClosedIllegalStateException    If the resource has been released or closed.
-     * @throws ThreadingIllegalStateException If used in a non thread safe way
+     * @throws ThreadingIllegalStateException If used in a non-thread-safe way
      */
     public long addAtomicLong(long delta) throws ClosedIllegalStateException, ThreadingIllegalStateException {
         try {
@@ -178,7 +178,7 @@ public abstract class UnsafeCloseable extends AbstractCloseable {
      * @param value    The new value to set.
      * @return {@code true} if the swap was successful, {@code false} otherwise.
      * @throws ClosedIllegalStateException    If the resource has been released or closed.
-     * @throws ThreadingIllegalStateException If used in a non thread safe way
+     * @throws ThreadingIllegalStateException If used in a non-thread-safe way
      */
     public boolean compareAndSwapLong(long expected, long value) throws ClosedIllegalStateException, ThreadingIllegalStateException {
         try {

--- a/src/main/java/net/openhft/chronicle/core/pool/ClassLookup.java
+++ b/src/main/java/net/openhft/chronicle/core/pool/ClassLookup.java
@@ -60,7 +60,7 @@ public interface ClassLookup {
      * Retrieves the alias for the given class. This method is intended for use with
      * non-lambda classes. For lambda classes, this method will throw an IllegalArgumentException.
      *
-     * @param clazz The class to retrieve the alias for.
+     * @param clazz The class whose alias is returned.
      * @return A String representing the alias for the given class.
      * @throws IllegalArgumentException If this method is used on a lambda function.
      */
@@ -86,7 +86,7 @@ public interface ClassLookup {
     /**
      * Applies an alias transformation to the given class name if an alias exists. This method
      * searches for an alias of the specified class name and returns the alias if found. If no alias
-     * is found, it returns the original class name. This mechanism allows for the flexible use of
+     * is found, it returns the original class name. This mechanism allows the flexible use of
      * aliases in place of fully qualified class names, simplifying the referencing of classes within
      * an application.
      *

--- a/src/main/java/net/openhft/chronicle/core/pool/StringInterner.java
+++ b/src/main/java/net/openhft/chronicle/core/pool/StringInterner.java
@@ -16,7 +16,7 @@ import java.util.stream.Stream;
  * <p>
  * It doesn't guarantee that all threads see the same data, nor that multiple threads will return the same String object for the same string. It is designed to be a best-effort basis so it can be as lightweight as possible.
  * <p>
- * So while technically not thread safe, it doesn't prevent it operating correctly when used from multiple threads, but it is faster than added explicit locking or thread safety. NOTE: It does rely on String being thread safe, something which was guaranteed from Java 5.0 onwards c.f. JSR 133.
+ * So while technically not thread-safe, it doesn't prevent it operating correctly when used from multiple threads, but it is faster than added explicit locking or thread safety. NOTE: It does rely on String being thread-safe, something which was guaranteed from Java 5.0 onwards c.f. JSR 133.
  * <p>
  * Discussion <a href="https://stackoverflow.com/questions/63383745/string-array-needless-synchronization/63383983">...</a>
  * <p>

--- a/src/main/java/net/openhft/chronicle/core/shutdown/Hooklet.java
+++ b/src/main/java/net/openhft/chronicle/core/shutdown/Hooklet.java
@@ -29,7 +29,7 @@ public abstract class Hooklet implements Comparable<Hooklet> {
      * Hooks with lesser priority will be called before hooks with greater priority.
      * <p>
      * It is advised to allocate an unique priority in the range of 0-100.
-     * In general, more high level code needs to do its shutdown routines before lower level code.
+     * In general, more high-level code needs to do its shutdown routines before lower level code.
      * An example priority layout is given below:
      * <p>
      * 0: Run before all hooks. For test/example use.

--- a/src/main/java/net/openhft/chronicle/core/time/PosixTimeProvider.java
+++ b/src/main/java/net/openhft/chronicle/core/time/PosixTimeProvider.java
@@ -7,7 +7,7 @@ import net.openhft.posix.ClockId;
 import net.openhft.posix.PosixAPI;
 
 /**
- * Provides time based on the Posix standard, particularly utilizing native code
+ * Provides time based on the Posix standard, particularly using native code
  * to access high-resolution time.
  * <p>
  * This provider interfaces directly with the native method {@code clock_gettime}

--- a/src/main/java/net/openhft/chronicle/core/util/GenericReflection.java
+++ b/src/main/java/net/openhft/chronicle/core/util/GenericReflection.java
@@ -17,7 +17,7 @@ import java.util.stream.Stream;
  *
  * <p>This enum serves as a utility class for obtaining generic type information of methods
  * and classes at runtime. This is especially useful for reflective operations that deal with
- * generic types, as Java utilizes type erasure.
+ * generic types, as Java uses type erasure.
  *
  * <p>Note: This is an enum with a single instance (a singleton), but used purely as a namespace
  * for utility methods, and cannot be instantiated.

--- a/src/main/java/net/openhft/chronicle/core/util/Histogram.java
+++ b/src/main/java/net/openhft/chronicle/core/util/Histogram.java
@@ -401,7 +401,7 @@ public class Histogram implements NanoSampler {
     @NotNull
     private String p(double v) {
         double v2 = v * 100 / (1 << fractionBits);
-        // Uses non thread safe static fields.
+        // Uses non-thread-safe static fields.
         synchronized (Histogram.class) {
             return v2 < 1 ? F3.format(v) :
                     v2 < 10 ? F2.format(v) :

--- a/src/main/java/net/openhft/chronicle/core/util/Ints.java
+++ b/src/main/java/net/openhft/chronicle/core/util/Ints.java
@@ -79,7 +79,7 @@ public final class Ints {
      * Returns a human-readable form of a failure message provided that the provided {@code value} <em>did not</em>
      * satisfy the provided {@code requirement}.
      *
-     * @param requirement to imposed on the provided values
+     * @param requirement to impose on the provided values
      * @param value       the value to check
      * @return a human-readable form of a failure message provided that the provided {@code value} <em>did not</em>
      * satisfy the provided {@code requirement}

--- a/src/main/java/net/openhft/chronicle/core/util/Longs.java
+++ b/src/main/java/net/openhft/chronicle/core/util/Longs.java
@@ -98,7 +98,7 @@ public final class Longs {
      * Returns a human-readable form of a failure message provided that the provided {@code value} <em>did not</em>
      * satisfy the provided {@code requirement}.
      *
-     * @param requirement to imposed on the provided values
+     * @param requirement to impose on the provided values
      * @param value       the value to check
      * @return a human-readable form of a failure message provided that the provided {@code value} <em>did not</em>
      * satisfy the provided {@code requirement}

--- a/src/main/java/net/openhft/chronicle/core/util/ObjectUtils.java
+++ b/src/main/java/net/openhft/chronicle/core/util/ObjectUtils.java
@@ -497,7 +497,7 @@ public final class ObjectUtils {
     /**
      * Retrieves the element type of array class or Object if it's not an array.
      *
-     * @param eClass The class to retrieve the element type from.
+     * @param eClass The class whose element type is returned.
      * @param <E>    The type of the class.
      * @return The element type of the array class or Object if it's not an array.
      */
@@ -647,7 +647,7 @@ public final class ObjectUtils {
     /**
      * Returns the default value associated with the specified primitive type.
      *
-     * @param type The class type for which to return the default value.
+     * @param type The class type whose default value is returned.
      *             Must be a primitive type or its corresponding wrapper type.
      * @param <T>  The type of the class. Note: primitive classes return their boxed type.
      * @return The default value for the given primitive class, or null for object classes.
@@ -738,7 +738,7 @@ public final class ObjectUtils {
     /**
      * Retrieves all the interfaces implemented by the given object or class.
      *
-     * @param o The object or class for which to retrieve the implemented interfaces.
+     * @param o The object or class whose implemented interfaces are returned.
      * @return An array of Class objects representing all the interfaces implemented by the given object or class.
      * @throws AssertionError If an illegal argument is encountered.
      */
@@ -751,7 +751,7 @@ public final class ObjectUtils {
     /**
      * Recursively accumulates all interfaces implemented by the given object or class.
      *
-     * @param o           The object or class for which to retrieve the implemented interfaces.
+     * @param o           The object or class whose implemented interfaces are returned.
      * @param accumulator A function that accumulates the interfaces.
      * @throws IllegalArgumentException If the accumulator is null.
      */
@@ -772,7 +772,7 @@ public final class ObjectUtils {
     /**
      * Recursively accumulates all interfaces for a given class.
      *
-     * @param clazz       The class for which to retrieve the implemented interfaces.
+     * @param clazz       The class whose implemented interfaces are returned.
      * @param accumulator A function that accumulates the interfaces.
      */
     private static void getAllInterfacesForClass(Class<?> clazz, Function<Class<?>, Boolean> accumulator) {
@@ -842,7 +842,7 @@ public final class ObjectUtils {
      * Retrieves the implementation class to use for a given class.
      *
      * @param <T>    The type of the class.
-     * @param tClass The class for which to retrieve the implementation.
+     * @param tClass The class whose implementation is returned.
      * @return The implementation class to use.
      */
     public static <T> Class<T> implementationToUse(Class<T> tClass) {

--- a/src/main/java/net/openhft/chronicle/core/util/TypeOf.java
+++ b/src/main/java/net/openhft/chronicle/core/util/TypeOf.java
@@ -9,7 +9,7 @@ import java.lang.reflect.Type;
 /**
  * Utility class for capturing and retaining a generic type.
  *
- * <p> This class is intended to be subclassed and allows for type information
+ * <p> This class is intended to be subclassed and allows type information
  * to be retained at runtime. When subclassing, the generic type parameter should be specified.
  *
  * <p> Example usage:

--- a/src/main/java/net/openhft/chronicle/core/values/StringValue.java
+++ b/src/main/java/net/openhft/chronicle/core/values/StringValue.java
@@ -7,11 +7,11 @@ import org.jetbrains.annotations.NotNull;
 
 /**
  * The StringValue interface represents a reference to a String value. It provides methods to
- * retrieve and set the String value. Implementations of this interface may handle the storage
+ * get and set the String value. Implementations of this interface may handle the storage
  * and retrieval of the String value in various formats or mediums.
  *
  * <p>The {@code getValue} method retrieves the String value and the {@code setValue} method
- * sets the String value. The {@code getUsingValue} method retrieves the String value into a
+ * sets the String value. The {@code getUsingValue} method copies the String value into a
  * supplied {@code StringBuilder} instance, which can be beneficial in scenarios where minimizing
  * object allocations is desirable.
  *
@@ -49,7 +49,7 @@ public interface StringValue {
     void setValue(@MaxBytes CharSequence value);
 
     /**
-     * Retrieves the String value into a supplied {@code StringBuilder} instance. This is useful
+     * Copies the String value into a supplied {@code StringBuilder} instance. This is useful
      * in scenarios where minimizing object allocations is desirable.
      *
      * @param stringBuilder The {@code StringBuilder} instance to populate with the String value.

--- a/src/main/java/net/openhft/chronicle/core/values/TwoLongValue.java
+++ b/src/main/java/net/openhft/chronicle/core/values/TwoLongValue.java
@@ -29,7 +29,7 @@ import net.openhft.chronicle.core.io.ThreadingIllegalStateException;
  * Additionally, the interface provides default implementations for setting the second value to the maximum or minimum
  * of the current value and a specified value, and for atomically setting and retrieving both values.
  * <p>
- * Implementations can also include additional behaviors or optimizations not specified in this interface.
+ * Implementations can also include additional behaviors or optimizations not defined in this interface.
  * Note: The {@link #getValue()} and {@link #setValue(long)} methods inherited from {@link LongValue} are applicable
  * to the first {@code long} value. Implementations must ensure that all methods are thread-safe and that changes
  * to the values are correctly synchronized across threads.


### PR DESCRIPTION
This is a documentation-only cleanup. It standardises terminology such as thread-safety, memory-mapped, low-level, and filename, and tightens a number of API descriptions without changing runtime behaviour.

## What changed

* Updated `README.adoc` wording for consistency and readability
* Polished supporting documentation, including:

  * `docs/systemProperties.adoc`
  * `src/main/docs/StackTrace-user-guide.adoc`
  * `src/main/docs/decision-log.adoc`
  * `src/main/docs/deterministic-resource-management.adoc`
  * `src/main/docs/thread-safety-guarantees.adoc`
* Cleaned up Java comments and Javadocs across core, IO, pool, util, analytics, shutdown, time, and values packages
* Standardised common terms and phrasing, including:

  * `memory mapped` -> `memory-mapped`
  * `thread safety` / `non thread safe` -> `thread-safety` / `non-thread-safe`
  * `low level` -> `low-level`
  * `file name` -> `filename`
* Tightened a number of descriptions to better match method behaviour, for example:

  * “retrieve” -> “returns” where a method returns a value
  * “retrieves into” -> “copies into” where a target object is populated
  * parameter docs updated from “the class to retrieve … for” to “the class whose … is returned”
* Fixed a handful of small grammar/style issues in Javadocs and comments

## Impact

* No intended production or runtime behaviour change
* No API semantics change
* Improves consistency across README, AsciiDoc docs, and generated Javadocs
* Makes terminology and method descriptions easier to scan and more precise

## Reviewer notes

* Java source files touched in this PR are comment/Javadoc wording cleanups only; there are no intended logic changes
* The main thing to check is that any wording tightenings still accurately describe current behaviour
* In particular, it is worth sanity-checking the places where wording shifts from “retrieve” to “returns” / “copies”, to ensure the docs remain semantically exact

## Validation

* `git diff --check origin/develop..HEAD`

## Notes

This PR intentionally keeps scope to wording and documentation polish. Any behavioural or API changes should be handled separately.