### PR TITLE
CORE-62: Fix StringBuilder corruption after non-Latin-1 content

### DIFF
--- a/src/main/java/net/openhft/chronicle/core/util/StringUtils.java
+++ b/src/main/java/net/openhft/chronicle/core/util/StringUtils.java
@@ -42,6 +42,7 @@ public final class StringUtils {
     private static final String VALUE_FIELD_NAME = "value";
     private static final String COUNT_FIELD_NAME = "count";
     private static final String CODER_FIELD_NAME = "coder";
+    private static final byte LATIN1_CODER = 0; // java.lang.String.LATIN1
 
     private static final Field S_VALUE;
     private static final Field SB_COUNT;
@@ -127,12 +128,27 @@ public final class StringUtils {
      * @throws AssertionError if there is an IllegalAccessException or IllegalArgumentException.
      */
     public static void setLength(@NotNull StringBuilder sb, int length) {
-        if (Jvm.maxDirectMemory() == 0) {
+        if (SB_CODER == null || Jvm.maxDirectMemory() == 0) {
             sb.setLength(length);
             return;
         }
+        // A StringBuilder reused after holding a non-latin1 char keeps UTF-16 storage (2 bytes/char)
+        // filling that as 8-bit would otherwise corrupt the result (see StringUtilsTest).
+        forceLatin1Coder(sb);
+        sb.ensureCapacity(length);
         try {
             SB_COUNT.set(sb, length);
+        } catch (IllegalAccessException | IllegalArgumentException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    private static void forceLatin1Coder(@NotNull StringBuilder sb) {
+        if (SB_CODER == null)
+            return; // pre-Java 9: no compact-string coder
+        try {
+            if (SB_CODER.getByte(sb) != LATIN1_CODER)
+                SB_CODER.setByte(sb, LATIN1_CODER);
         } catch (IllegalAccessException | IllegalArgumentException e) {
             throw new AssertionError(e);
         }

--- a/src/test/java/net/openhft/chronicle/core/util/StringUtilsTest.java
+++ b/src/test/java/net/openhft/chronicle/core/util/StringUtilsTest.java
@@ -4,6 +4,7 @@
 package net.openhft.chronicle.core.util;
 
 import net.openhft.chronicle.core.CoreTestCommon;
+import net.openhft.chronicle.core.Jvm;
 import net.openhft.chronicle.core.Maths;
 import org.junit.jupiter.api.Test;
 
@@ -11,6 +12,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.function.BiFunction;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 class StringUtilsTest extends CoreTestCommon {
 
@@ -29,6 +31,27 @@ class StringUtilsTest extends CoreTestCommon {
         StringUtils.setLength(sb, 2);
 
         assertEquals("te", sb.toString());
+    }
+
+    /**
+     * Reproducer: after {@code setLength}, the 8-bit fast-fill pattern (write raw bytes into
+     * {@link StringUtils#extractBytes(StringBuilder)}) must address the right bytes even when the
+     * StringBuilder was previously left in UTF-16 storage (e.g. a pooled builder reused after holding
+     * a non-latin1 char). Without a coder-aware setLength this corrupts the result.
+     */
+    @Test
+    void setLengthPreparesLatin1BufferForReusedUtf16Builder() {
+        assumeTrue(Jvm.isJava9Plus() && Jvm.maxDirectMemory() > 0);
+        StringBuilder sb = new StringBuilder("√"); // '√' forces UTF-16 storage
+        sb.setLength(0);                                // reused: UTF-16 coder retained
+
+        StringUtils.setLength(sb, 3);
+        byte[] bytes = StringUtils.extractBytes(sb);
+        bytes[0] = 'a';
+        bytes[1] = 'b';
+        bytes[2] = 'c';
+
+        assertEquals("abc", sb.toString());
     }
 
     @Test


### PR DESCRIPTION
This PR fixes CORE-62, where a reused `StringBuilder` could corrupt subsequent Latin-1 content after previously containing a non-Latin-1 character.

On Java 9+, `StringBuilder` can retain UTF-16 internal storage after holding a multi-byte character. Chronicle’s fast 8-bit parsing paths write directly into the builder’s backing storage, so reusing a builder in this state could write Latin-1 bytes into UTF-16 storage incorrectly. This caused binary wire decoding to truncate or corrupt field names/values, with the rest of a DTO potentially being ignored after a multi-byte string field.

### Changes

* Updated `StringUtils.setLength` to handle Java 9+ compact-string coder state correctly.
* Added `forceLatin1Coder(...)` before using the direct byte-fill path so reused builders are prepared for Latin-1 writes.
* Preserved the safe fallback to `StringBuilder.setLength(...)` when compact-string internals are unavailable or direct memory is disabled.
* Updated `BytesInternal.parse8bit1(...)` to distinguish between Latin-1 and UTF-16 `StringBuilder` storage before writing parsed 8-bit data.
* Fixed native/direct byte parsing to treat bytes as unsigned when converting to chars.
* Added regression coverage for reused UTF-16-backed `StringBuilder` instances receiving Latin-1 / 8-bit data. 
* Added `BinaryMultiByteStringTruncationTest` to verify binary wire round-tripping preserves all DTO fields after a multi-byte string value.
* Covered on-heap binary wire, direct-memory binary wire, ASCII binary wire, long field names, and text wire round-tripping.

### Related PRs

* Chronicle-Bytes: OpenHFT/Chronicle-Bytes#724
* Chronicle-Wire: OpenHFT/Chronicle-Wire#1260
* Chronicle-Core: OpenHFT/Chronicle-Core#853

### Testing

Added regression tests covering the original corruption scenario:

* `StringUtilsTest.setLengthPreparesLatin1BufferForReusedUtf16Builder`
* `AppendableUtilTest.read8bitPreservesTextWhenStringBuilderUsesUtf16Storage`
* `AppendableUtilTest.parse8bitPreservesExtendedByteWhenStringBuilderUsesUtf16Storage`
* `AppendableUtilTest.parse8bitFromNativeBytesPreservesExtendedByteWhenStringBuilderUsesUtf16Storage`
* `BinaryMultiByteStringTruncationTest`

These tests verify that reused builders previously containing `√` correctly decode subsequent Latin-1 / ASCII content and that binary wire DTO decoding no longer drops fields after a multi-byte string.
