### PR TITLE
Revert "CORE-62: Ensure StringBuilder handles Latin1 encoding in setL…

### DIFF
--- a/src/main/java/net/openhft/chronicle/core/util/StringUtils.java
+++ b/src/main/java/net/openhft/chronicle/core/util/StringUtils.java
@@ -42,7 +42,6 @@ public final class StringUtils {
     private static final String VALUE_FIELD_NAME = "value";
     private static final String COUNT_FIELD_NAME = "count";
     private static final String CODER_FIELD_NAME = "coder";
-    private static final byte LATIN1_CODER = 0; // java.lang.String.LATIN1
 
     private static final Field S_VALUE;
     private static final Field SB_COUNT;
@@ -128,27 +127,12 @@ public final class StringUtils {
      * @throws AssertionError if there is an IllegalAccessException or IllegalArgumentException.
      */
     public static void setLength(@NotNull StringBuilder sb, int length) {
-        if (SB_CODER == null || Jvm.maxDirectMemory() == 0) {
+        if (Jvm.maxDirectMemory() == 0) {
             sb.setLength(length);
             return;
         }
-        // A StringBuilder reused after holding a non-latin1 char keeps UTF-16 storage (2 bytes/char)
-        // filling that as 8-bit would otherwise corrupt the result (see StringUtilsTest).
-        forceLatin1Coder(sb);
-        sb.ensureCapacity(length);
         try {
             SB_COUNT.set(sb, length);
-        } catch (IllegalAccessException | IllegalArgumentException e) {
-            throw new AssertionError(e);
-        }
-    }
-
-    private static void forceLatin1Coder(@NotNull StringBuilder sb) {
-        if (SB_CODER == null)
-            return; // pre-Java 9: no compact-string coder
-        try {
-            if (SB_CODER.getByte(sb) != LATIN1_CODER)
-                SB_CODER.setByte(sb, LATIN1_CODER);
         } catch (IllegalAccessException | IllegalArgumentException e) {
             throw new AssertionError(e);
         }

--- a/src/test/java/net/openhft/chronicle/core/util/StringUtilsTest.java
+++ b/src/test/java/net/openhft/chronicle/core/util/StringUtilsTest.java
@@ -4,7 +4,6 @@
 package net.openhft.chronicle.core.util;
 
 import net.openhft.chronicle.core.CoreTestCommon;
-import net.openhft.chronicle.core.Jvm;
 import net.openhft.chronicle.core.Maths;
 import org.junit.jupiter.api.Test;
 
@@ -12,7 +11,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.function.BiFunction;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 class StringUtilsTest extends CoreTestCommon {
 
@@ -31,27 +29,6 @@ class StringUtilsTest extends CoreTestCommon {
         StringUtils.setLength(sb, 2);
 
         assertEquals("te", sb.toString());
-    }
-
-    /**
-     * Reproducer: after {@code setLength}, the 8-bit fast-fill pattern (write raw bytes into
-     * {@link StringUtils#extractBytes(StringBuilder)}) must address the right bytes even when the
-     * StringBuilder was previously left in UTF-16 storage (e.g. a pooled builder reused after holding
-     * a non-latin1 char). Without a coder-aware setLength this corrupts the result.
-     */
-    @Test
-    void setLengthPreparesLatin1BufferForReusedUtf16Builder() {
-        assumeTrue(Jvm.isJava9Plus() && Jvm.maxDirectMemory() > 0);
-        StringBuilder sb = new StringBuilder("√"); // '√' forces UTF-16 storage
-        sb.setLength(0);                                // reused: UTF-16 coder retained
-
-        StringUtils.setLength(sb, 3);
-        byte[] bytes = StringUtils.extractBytes(sb);
-        bytes[0] = 'a';
-        bytes[1] = 'b';
-        bytes[2] = 'c';
-
-        assertEquals("abc", sb.toString());
     }
 
     @Test


### PR DESCRIPTION
Reverts changes of CORE-62 to unblock build all