### PR TITLE
CORE-67: warn when selected ByteBuffer cleaner cannot free direct memory

### DIFF
--- a/src/main/java/net/openhft/chronicle/core/cleaner/CleanerServiceLocator.java
+++ b/src/main/java/net/openhft/chronicle/core/cleaner/CleanerServiceLocator.java
@@ -136,6 +136,6 @@ public final class CleanerServiceLocator {
 
     private static void warnLeakingCleaner(final String name) {
         Jvm.warn().on(CleanerServiceLocator.class, "Selected ByteBuffer cleaner " + name +
-                " does not free direct memory; direct ByteBuffers will leak until GC.");
+                " does not free direct memory.");
     }
 }

--- a/src/main/java/net/openhft/chronicle/core/cleaner/CleanerServiceLocator.java
+++ b/src/main/java/net/openhft/chronicle/core/cleaner/CleanerServiceLocator.java
@@ -8,8 +8,10 @@ import net.openhft.chronicle.core.annotation.TargetMajorVersion;
 import net.openhft.chronicle.core.internal.cleaner.ReflectionBasedByteBufferCleanerService;
 import net.openhft.chronicle.core.cleaner.spi.ByteBufferCleanerService;
 
+import java.nio.ByteBuffer;
 import java.util.ServiceConfigurationError;
 import java.util.ServiceLoader;
+import java.util.function.LongSupplier;
 
 /**
  * A utility class to locate the appropriate {@link ByteBufferCleanerService} implementation.
@@ -65,6 +67,8 @@ public final class CleanerServiceLocator {
                 Jvm.warn().on(CleanerServiceLocator.class, "Unable to find suitable cleaner service, falling back to using reflection");
             }
 
+            verifySelectedCleaner(cleanerService);
+
             instance = cleanerService;
             initialised = true;
         }
@@ -86,5 +90,53 @@ public final class CleanerServiceLocator {
                 version.majorVersion() == Jvm.majorVersion() ||
                 (version.includeNewer() && Jvm.majorVersion() > version.majorVersion()) ||
                 (version.includeOlder() && Jvm.majorVersion() < version.majorVersion());
+    }
+
+    /**
+     * Logs the selected cleaner and warns if it cannot actually free direct memory, surfacing a
+     * silent off-heap leak. Diagnostic only: it never changes the selected service.
+     */
+    static void verifySelectedCleaner(final ByteBufferCleanerService svc) {
+        verifySelectedCleaner(svc, Jvm::usedDirectMemory);
+    }
+
+    // usedDirectMemory is injectable so the accounting-unavailable path is testable.
+    static void verifySelectedCleaner(final ByteBufferCleanerService svc, final LongSupplier usedDirectMemory) {
+        final String name = svc.getClass().getName();
+        try {
+            if (svc.impact() == ByteBufferCleanerService.Impact.UNAVAILABLE) {
+                warnLeakingCleaner(name);
+                return;
+            }
+
+            final int probeSize = 1 << 12;
+            final long before = usedDirectMemory.getAsLong();
+            final ByteBuffer buffer = ByteBuffer.allocateDirect(probeSize);
+            final long afterAllocation = usedDirectMemory.getAsLong();
+            svc.clean(buffer);
+            final long afterClean = usedDirectMemory.getAsLong();
+
+            if (afterAllocation <= before) {
+                // accounting unavailable: can't prove a leak, so stay quiet
+                Jvm.debug().on(CleanerServiceLocator.class, "Selected ByteBuffer cleaner: " + name +
+                        " (impact=" + svc.impact() + "); effectiveness unverified as direct-memory accounting is unavailable");
+                return;
+            }
+
+            if (afterClean < afterAllocation) {
+                Jvm.debug().on(CleanerServiceLocator.class, "Selected ByteBuffer cleaner: " + name +
+                        " (impact=" + svc.impact() + ", verified to free direct memory)");
+            } else {
+                warnLeakingCleaner(name);
+            }
+        } catch (Throwable t) {
+            // diagnostic only — must not affect selection
+            Jvm.debug().on(CleanerServiceLocator.class, "Could not verify ByteBuffer cleaner " + name, t);
+        }
+    }
+
+    private static void warnLeakingCleaner(final String name) {
+        Jvm.warn().on(CleanerServiceLocator.class, "Selected ByteBuffer cleaner " + name +
+                " does not free direct memory; direct ByteBuffers will leak until GC.");
     }
 }

--- a/src/main/java/net/openhft/chronicle/core/cleaner/CleanerServiceLocator.java
+++ b/src/main/java/net/openhft/chronicle/core/cleaner/CleanerServiceLocator.java
@@ -129,9 +129,8 @@ public final class CleanerServiceLocator {
             } else {
                 warnLeakingCleaner(name);
             }
-        } catch (Throwable t) {
-            // diagnostic only — must not affect selection
-            Jvm.debug().on(CleanerServiceLocator.class, "Could not verify ByteBuffer cleaner " + name, t);
+        } catch (Throwable t) { // NOSONAR — diagnostic probe must never destabilise selection, incl. Errors
+            Jvm.error().on(CleanerServiceLocator.class, "Could not verify ByteBuffer cleaner " + name, t);
         }
     }
 

--- a/src/test/java/net/openhft/chronicle/core/cleaner/CleanerServiceLocatorTest.java
+++ b/src/test/java/net/openhft/chronicle/core/cleaner/CleanerServiceLocatorTest.java
@@ -3,13 +3,24 @@
  */
 package net.openhft.chronicle.core.cleaner;
 
+import net.openhft.chronicle.core.Jvm;
 import net.openhft.chronicle.core.cleaner.spi.ByteBufferCleanerService;
+import net.openhft.chronicle.core.cleaner.testimpl.AllowedCleaner;
+import net.openhft.chronicle.core.cleaner.testimpl.SomeImpactCleaner;
+import net.openhft.chronicle.core.cleaner.testimpl.WorkingCleaner;
+import net.openhft.chronicle.core.internal.cleaner.Jdk9ByteBufferCleanerService;
+import net.openhft.chronicle.core.onoes.ExceptionKey;
+import net.openhft.chronicle.core.onoes.LogLevel;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
+import java.nio.ByteBuffer;
+import java.util.Map;
+import java.util.function.LongSupplier;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 class CleanerServiceLocatorTest {
 
@@ -22,19 +33,159 @@ class CleanerServiceLocatorTest {
         inst.set(null, null);
     }
 
+    /** Counts recorded {@link CleanerServiceLocator} log lines at {@code level} whose message contains {@code needle}. */
+    private static int countFrom(Map<ExceptionKey, Integer> recorded, LogLevel level, String needle) {
+        return recorded.keySet().stream()
+                .filter(k -> k.level == level)
+                .filter(k -> k.clazz == CleanerServiceLocator.class)
+                .filter(k -> k.message != null && k.message.contains(needle))
+                .mapToInt(k -> 1)
+                .sum();
+    }
+
     @AfterEach
     void tearDown() throws Exception {
+        Jvm.resetExceptionHandlers();
         resetLocator();
     }
 
     @Test
     void picksAllowedServiceWithLowestImpact() throws Exception {
         resetLocator();
+        final Map<ExceptionKey, Integer> recorded = Jvm.recordExceptions();
         ByteBufferCleanerService svc = CleanerServiceLocator.cleanerService();
         assertNotNull(svc);
         // Should be our test implementation from META-INF/services
         assertEquals("net.openhft.chronicle.core.cleaner.testimpl.AllowedCleaner", svc.getClass().getName());
         assertEquals(ByteBufferCleanerService.Impact.NO_IMPACT, svc.impact());
+        assertTrue(countFrom(recorded, LogLevel.WARN, "leak") >= 1,
+                "expected a leak warning for the no-op AllowedCleaner; recorded=" + recorded.keySet());
+    }
+
+    @Test
+    void noOpCleanerSelectedEmitsLeakWarning() throws Exception {
+        resetLocator();
+        final Map<ExceptionKey, Integer> recorded = Jvm.recordExceptions();
+        ByteBufferCleanerService svc = CleanerServiceLocator.cleanerService();
+        assertNotNull(svc);
+        assertTrue(countFrom(recorded, LogLevel.WARN, "leak") >= 1,
+                "expected a leak warning naming the no-op cleaner; recorded=" + recorded.keySet());
+        assertTrue(recorded.keySet().stream()
+                        .anyMatch(k -> k.level == LogLevel.WARN && k.message != null
+                                && k.message.contains(svc.getClass().getName())),
+                "leak warning should name the selected cleaner class");
+    }
+
+    @Test
+    void verifiedWorkingCleanerLogsAtDebugAndDoesNotWarn() {
+        final Map<ExceptionKey, Integer> recorded = Jvm.recordExceptions();
+        CleanerServiceLocator.verifySelectedCleaner(new WorkingCleaner(), Jvm::usedDirectMemory);
+        assertEquals(0, countFrom(recorded, LogLevel.WARN, "leak"),
+                "a cleaner that genuinely frees memory must not warn; recorded=" + recorded.keySet());
+        assertTrue(countFrom(recorded, LogLevel.DEBUG, "Selected") >= 1,
+                "expected a debug line naming the verified cleaner; recorded=" + recorded.keySet());
+    }
+
+    @Test
+    void cleanerReportingUnavailableWarnsWithoutProbe() {
+        final Map<ExceptionKey, Integer> recorded = Jvm.recordExceptions();
+        CleanerServiceLocator.verifySelectedCleaner(new UnavailableCleaner());
+        assertTrue(countFrom(recorded, LogLevel.WARN, "leak") >= 1,
+                "an UNAVAILABLE cleaner must warn via the short-circuit; recorded=" + recorded.keySet());
+    }
+
+    @Test
+    void probeExceptionDoesNotBreakSelection() {
+        assertDoesNotThrow(() ->
+                CleanerServiceLocator.verifySelectedCleaner(new ThrowingCleaner(), Jvm::usedDirectMemory));
+    }
+
+    @Test
+    void noFalseWarningWhenAccountingUnavailable() {
+        final Map<ExceptionKey, Integer> recorded = Jvm.recordExceptions();
+        final LongSupplier accountingOff = () -> 0L; // 0 == direct-memory accounting unavailable
+        CleanerServiceLocator.verifySelectedCleaner(new AllowedCleaner(), accountingOff);
+        assertEquals(0, countFrom(recorded, LogLevel.WARN, "leak"),
+                "must not warn when accounting is unavailable; recorded=" + recorded.keySet());
+    }
+
+    @Test
+    void allowedCleanerProbedDirectlyWarns() {
+        final Map<ExceptionKey, Integer> recorded = Jvm.recordExceptions();
+        CleanerServiceLocator.verifySelectedCleaner(new AllowedCleaner(), Jvm::usedDirectMemory);
+        assertTrue(countFrom(recorded, LogLevel.WARN, "leak") >= 1,
+                "AllowedCleaner (NO_IMPACT, no-op) must be detected as leaking; recorded=" + recorded.keySet());
+    }
+
+    @Test
+    void someImpactNoOpCleanerStillWarns() {
+        final Map<ExceptionKey, Integer> recorded = Jvm.recordExceptions();
+        // the probe ignores self-reported impact, so a SOME_IMPACT no-op is still caught
+        CleanerServiceLocator.verifySelectedCleaner(new SomeImpactCleaner(), Jvm::usedDirectMemory);
+        assertTrue(countFrom(recorded, LogLevel.WARN, "leak") >= 1,
+                "a SOME_IMPACT cleaner that frees nothing must still warn; recorded=" + recorded.keySet());
+    }
+
+    @Test
+    void someImpactWorkingCleanerDoesNotWarn() {
+        final Map<ExceptionKey, Integer> recorded = Jvm.recordExceptions();
+        CleanerServiceLocator.verifySelectedCleaner(new SomeImpactWorkingCleaner(), Jvm::usedDirectMemory);
+        assertEquals(0, countFrom(recorded, LogLevel.WARN, "leak"),
+                "a working SOME_IMPACT cleaner must not warn; recorded=" + recorded.keySet());
+        assertTrue(countFrom(recorded, LogLevel.DEBUG, "Selected") >= 1,
+                "expected a debug line naming the verified cleaner; recorded=" + recorded.keySet());
+    }
+
+    @Test
+    void realJdk9CleanerVerifiedSilent() {
+        assumeTrue(Jvm.isJava9Plus()); // Jdk9 cleaner only frees on Java 9+
+        final Map<ExceptionKey, Integer> recorded = Jvm.recordExceptions();
+        CleanerServiceLocator.verifySelectedCleaner(new Jdk9ByteBufferCleanerService(), Jvm::usedDirectMemory);
+        assertEquals(0, countFrom(recorded, LogLevel.WARN, "leak"),
+                "the real JDK9 cleaner must not warn; recorded=" + recorded.keySet());
+        assertTrue(countFrom(recorded, LogLevel.DEBUG, "Selected") >= 1,
+                "expected a debug line for the verified JDK9 cleaner; recorded=" + recorded.keySet());
+    }
+
+    /** Reports SOME_IMPACT but genuinely frees (delegates to WorkingCleaner). */
+    private static final class SomeImpactWorkingCleaner implements ByteBufferCleanerService {
+        private static final WorkingCleaner DELEGATE = new WorkingCleaner();
+
+        @Override
+        public Impact impact() {
+            return Impact.SOME_IMPACT;
+        }
+
+        @Override
+        public void clean(ByteBuffer buffer) {
+            DELEGATE.clean(buffer);
+        }
+    }
+
+    /** Reports UNAVAILABLE; clean() does nothing. */
+    private static final class UnavailableCleaner implements ByteBufferCleanerService {
+        @Override
+        public Impact impact() {
+            return Impact.UNAVAILABLE;
+        }
+
+        @Override
+        public void clean(ByteBuffer buffer) {
+            // no-op
+        }
+    }
+
+    /** Reports NO_IMPACT (so it reaches the probe) but throws on clean(). */
+    private static final class ThrowingCleaner implements ByteBufferCleanerService {
+        @Override
+        public Impact impact() {
+            return Impact.NO_IMPACT;
+        }
+
+        @Override
+        public void clean(ByteBuffer buffer) {
+            throw new RuntimeException("probe should swallow this");
+        }
     }
 
     @Test

--- a/src/test/java/net/openhft/chronicle/core/cleaner/CleanerServiceLocatorTest.java
+++ b/src/test/java/net/openhft/chronicle/core/cleaner/CleanerServiceLocatorTest.java
@@ -58,7 +58,7 @@ class CleanerServiceLocatorTest {
         // Should be our test implementation from META-INF/services
         assertEquals("net.openhft.chronicle.core.cleaner.testimpl.AllowedCleaner", svc.getClass().getName());
         assertEquals(ByteBufferCleanerService.Impact.NO_IMPACT, svc.impact());
-        assertTrue(countFrom(recorded, LogLevel.WARN, "leak") >= 1,
+        assertTrue(countFrom(recorded, LogLevel.WARN, "does not free direct memory") >= 1,
                 "expected a leak warning for the no-op AllowedCleaner; recorded=" + recorded.keySet());
     }
 
@@ -68,7 +68,7 @@ class CleanerServiceLocatorTest {
         final Map<ExceptionKey, Integer> recorded = Jvm.recordExceptions();
         ByteBufferCleanerService svc = CleanerServiceLocator.cleanerService();
         assertNotNull(svc);
-        assertTrue(countFrom(recorded, LogLevel.WARN, "leak") >= 1,
+        assertTrue(countFrom(recorded, LogLevel.WARN, "does not free direct memory") >= 1,
                 "expected a leak warning naming the no-op cleaner; recorded=" + recorded.keySet());
         assertTrue(recorded.keySet().stream()
                         .anyMatch(k -> k.level == LogLevel.WARN && k.message != null
@@ -80,7 +80,7 @@ class CleanerServiceLocatorTest {
     void verifiedWorkingCleanerLogsAtDebugAndDoesNotWarn() {
         final Map<ExceptionKey, Integer> recorded = Jvm.recordExceptions();
         CleanerServiceLocator.verifySelectedCleaner(new WorkingCleaner(), Jvm::usedDirectMemory);
-        assertEquals(0, countFrom(recorded, LogLevel.WARN, "leak"),
+        assertEquals(0, countFrom(recorded, LogLevel.WARN, "does not free direct memory"),
                 "a cleaner that genuinely frees memory must not warn; recorded=" + recorded.keySet());
         assertTrue(countFrom(recorded, LogLevel.DEBUG, "Selected") >= 1,
                 "expected a debug line naming the verified cleaner; recorded=" + recorded.keySet());
@@ -90,7 +90,7 @@ class CleanerServiceLocatorTest {
     void cleanerReportingUnavailableWarnsWithoutProbe() {
         final Map<ExceptionKey, Integer> recorded = Jvm.recordExceptions();
         CleanerServiceLocator.verifySelectedCleaner(new UnavailableCleaner());
-        assertTrue(countFrom(recorded, LogLevel.WARN, "leak") >= 1,
+        assertTrue(countFrom(recorded, LogLevel.WARN, "does not free direct memory") >= 1,
                 "an UNAVAILABLE cleaner must warn via the short-circuit; recorded=" + recorded.keySet());
     }
 
@@ -105,7 +105,7 @@ class CleanerServiceLocatorTest {
         final Map<ExceptionKey, Integer> recorded = Jvm.recordExceptions();
         final LongSupplier accountingOff = () -> 0L; // 0 == direct-memory accounting unavailable
         CleanerServiceLocator.verifySelectedCleaner(new AllowedCleaner(), accountingOff);
-        assertEquals(0, countFrom(recorded, LogLevel.WARN, "leak"),
+        assertEquals(0, countFrom(recorded, LogLevel.WARN, "does not free direct memory"),
                 "must not warn when accounting is unavailable; recorded=" + recorded.keySet());
     }
 
@@ -113,7 +113,7 @@ class CleanerServiceLocatorTest {
     void allowedCleanerProbedDirectlyWarns() {
         final Map<ExceptionKey, Integer> recorded = Jvm.recordExceptions();
         CleanerServiceLocator.verifySelectedCleaner(new AllowedCleaner(), Jvm::usedDirectMemory);
-        assertTrue(countFrom(recorded, LogLevel.WARN, "leak") >= 1,
+        assertTrue(countFrom(recorded, LogLevel.WARN, "does not free direct memory") >= 1,
                 "AllowedCleaner (NO_IMPACT, no-op) must be detected as leaking; recorded=" + recorded.keySet());
     }
 
@@ -122,7 +122,7 @@ class CleanerServiceLocatorTest {
         final Map<ExceptionKey, Integer> recorded = Jvm.recordExceptions();
         // the probe ignores self-reported impact, so a SOME_IMPACT no-op is still caught
         CleanerServiceLocator.verifySelectedCleaner(new SomeImpactCleaner(), Jvm::usedDirectMemory);
-        assertTrue(countFrom(recorded, LogLevel.WARN, "leak") >= 1,
+        assertTrue(countFrom(recorded, LogLevel.WARN, "does not free direct memory") >= 1,
                 "a SOME_IMPACT cleaner that frees nothing must still warn; recorded=" + recorded.keySet());
     }
 
@@ -130,7 +130,7 @@ class CleanerServiceLocatorTest {
     void someImpactWorkingCleanerDoesNotWarn() {
         final Map<ExceptionKey, Integer> recorded = Jvm.recordExceptions();
         CleanerServiceLocator.verifySelectedCleaner(new SomeImpactWorkingCleaner(), Jvm::usedDirectMemory);
-        assertEquals(0, countFrom(recorded, LogLevel.WARN, "leak"),
+        assertEquals(0, countFrom(recorded, LogLevel.WARN, "does not free direct memory"),
                 "a working SOME_IMPACT cleaner must not warn; recorded=" + recorded.keySet());
         assertTrue(countFrom(recorded, LogLevel.DEBUG, "Selected") >= 1,
                 "expected a debug line naming the verified cleaner; recorded=" + recorded.keySet());
@@ -141,7 +141,7 @@ class CleanerServiceLocatorTest {
         assumeTrue(Jvm.isJava9Plus()); // Jdk9 cleaner only frees on Java 9+
         final Map<ExceptionKey, Integer> recorded = Jvm.recordExceptions();
         CleanerServiceLocator.verifySelectedCleaner(new Jdk9ByteBufferCleanerService(), Jvm::usedDirectMemory);
-        assertEquals(0, countFrom(recorded, LogLevel.WARN, "leak"),
+        assertEquals(0, countFrom(recorded, LogLevel.WARN, "does not free direct memory"),
                 "the real JDK9 cleaner must not warn; recorded=" + recorded.keySet());
         assertTrue(countFrom(recorded, LogLevel.DEBUG, "Selected") >= 1,
                 "expected a debug line for the verified JDK9 cleaner; recorded=" + recorded.keySet());

--- a/src/test/java/net/openhft/chronicle/core/cleaner/testimpl/WorkingCleaner.java
+++ b/src/test/java/net/openhft/chronicle/core/cleaner/testimpl/WorkingCleaner.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.core.cleaner.testimpl;
+
+import net.openhft.chronicle.core.Jvm;
+import net.openhft.chronicle.core.annotation.TargetMajorVersion;
+import net.openhft.chronicle.core.cleaner.spi.ByteBufferCleanerService;
+import net.openhft.chronicle.core.internal.cleaner.Jdk9ByteBufferCleanerService;
+import net.openhft.chronicle.core.internal.cleaner.ReflectionBasedByteBufferCleanerService;
+
+import java.nio.ByteBuffer;
+
+/** Test cleaner that genuinely frees the buffer, on both Java 8 and 9+. Not registered via META-INF/services. */
+@TargetMajorVersion(majorVersion = 0, includeNewer = true, includeOlder = true)
+public class WorkingCleaner implements ByteBufferCleanerService {
+    // Jdk9 (Unsafe.invokeCleaner) works on 9+; the reflection cleaner (sun.misc.Cleaner) works on 8.
+    private static final ByteBufferCleanerService DELEGATE = Jvm.isJava9Plus()
+            ? new Jdk9ByteBufferCleanerService()
+            : new ReflectionBasedByteBufferCleanerService();
+
+    @Override
+    public Impact impact() {
+        return Impact.NO_IMPACT;
+    }
+
+    @Override
+    public void clean(ByteBuffer buffer) {
+        DELEGATE.clean(buffer);
+    }
+}

--- a/src/test/java/net/openhft/chronicle/core/io/IOToolsTest.java
+++ b/src/test/java/net/openhft/chronicle/core/io/IOToolsTest.java
@@ -9,6 +9,7 @@ import net.openhft.chronicle.core.OS;
 import net.openhft.chronicle.core.cleaner.impl.CleanerTestUtil;
 import net.openhft.chronicle.core.util.Time;
 import net.openhft.chronicle.testframework.process.JavaProcessBuilder;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
@@ -39,6 +40,12 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assumptions.*;
 
 class IOToolsTest extends CoreTestCommon {
+
+    @BeforeEach
+    void ignoreCleanerLeakWarning() {
+        // IOTools.clean() selects the test classpath's no-op AllowedCleaner, so the probe warns of a leak
+        ignoreException("does not free direct memory");
+    }
 
     @Test
     void testIsClosedException() {


### PR DESCRIPTION
  ### Summary
  `CleanerServiceLocator` selected a cleaner with no indication of which one or whether it worked. A cleaner that cannot free direct memory was selected silently, leaking buffers until GC.

  ### Changes
  - After selection, `CleanerServiceLocator` probes the cleaner once: allocate a direct buffer, `clean()` it, and compare `Jvm.usedDirectMemory()`.
    - frees memory → `debug` naming the cleaner
    - frees nothing, or `Impact.UNAVAILABLE` → `Jvm.warn()` that buffers will leak, naming the cleaner
    - accounting unavailable → silent
  - Self-reported `Impact` is not trusted (a no-op cleaner can report `NO_IMPACT` yet free nothing).
  - Probe is diagnostic only: wrapped so it cannot throw or change the returned cleaner; runs once behind memoisation.
  - `IOToolsTest` ignores the expected warning (the only `CoreTestCommon` test that hits the cleaner path; test classpath registers the no-op `AllowedCleaner`).

  ### Tests
  - New `CleanerServiceLocatorTest` cases: no-op `NO_IMPACT` (incl. dedicated `AllowedCleaner`), no-op `SOME_IMPACT`, `UNAVAILABLE`, genuinely-freeing, real JDK9
