### PR TITLE
CORE-73 Add exact byte-size formatting to Jvm

### DIFF
--- a/src/main/java/net/openhft/chronicle/core/Jvm.java
+++ b/src/main/java/net/openhft/chronicle/core/Jvm.java
@@ -36,6 +36,7 @@ import java.net.URLClassLoader;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.channels.spi.AbstractInterruptibleChannel;
+import java.nio.file.FileSystemNotFoundException;
 import java.nio.file.Paths;
 import java.util.*;
 import java.util.Map.Entry;
@@ -1173,6 +1174,45 @@ public final class Jvm {
     }
 
     /**
+     * Formats a byte count as a compact size string using binary units ({@code K} = 1024,
+     * {@code M}, {@code G}, {@code T}) - the exact inverse of {@link #parseSize(String)}.
+     * <p>
+     * The largest unit that divides {@code size} <em>exactly</em> is used, so the result always
+     * round-trips: {@code parseSize(formatSize(size)) == size} for every {@code size >= 0}. A value
+     * that is not a whole multiple of 1024 is written as a plain byte count, and {@code 0} as
+     * {@code "0"}. This favours an exactly-parseable form over a rounded approximation, so an odd
+     * value renders as bytes (or a large {@code K}/{@code M}) rather than as, say, {@code "1.7G"}.
+     * <p>
+     * {@code T} is the largest unit emitted (as in {@link #parseSize(String)}); a larger exact
+     * multiple is still expressed in {@code T} - for example 1 PiB renders as {@code "1024T"}.
+     * <p>
+     * Examples: {@code formatSize(1024)} is {@code "1K"}, {@code formatSize(1536L << 20)} is
+     * {@code "1536M"}, {@code formatSize(5L << 30)} is {@code "5G"}, and {@code formatSize(500)} is
+     * {@code "500"}.
+     *
+     * @param size the number of bytes, must be &gt;= 0
+     * @return a size string parseable by {@link #parseSize(String)}
+     * @throws IllegalArgumentException if {@code size} is negative
+     * @see #parseSize(String)
+     */
+    public static String formatSize(long size) {
+        if (size < 0)
+            throw new IllegalArgumentException("Negative sizes not allowed: " + size);
+        if (size == 0)
+            return "0";
+        // Leading '.' is an unused placeholder so charAt(i / 10) maps 10 -> K, 20 -> M, 30 -> G, 40 -> T.
+        final String suffixes = ".KMGT";
+        // Largest unit first: (size >>> i) << i == size holds when size is an exact multiple of 2^i,
+        // so that unit divides it without remainder and the result round-trips through parseSize.
+        for (int i = 40; i >= 10; i -= 10)
+            if ((size >>> i) << i == size)
+                // String.valueOf forces string concatenation; (size >>> i) + a char would add as longs.
+                return (size >>> i) + String.valueOf(suffixes.charAt(i / 10));
+        // Not a whole multiple of 1024 - the exact byte count is itself parseable by parseSize.
+        return Long.toString(size);
+    }
+
+    /**
      * Uses Jvm.parseSize to parse a system property or returns defaultValue if
      * not present or unparseable.
      *
@@ -1312,7 +1352,7 @@ public final class Jvm {
                         debug().on(Jvm.class, "Adding " + path + " to the classpath");
                     classpath.append(File.pathSeparator).append(path);
                 }
-            } catch (URISyntaxException | IllegalArgumentException e) {
+            } catch (URISyntaxException | IllegalArgumentException | FileSystemNotFoundException e) {
                 debug().on(Jvm.class, "Could not add URL " + url + " to classpath");
             }
         }

--- a/src/test/java/net/openhft/chronicle/core/JvmFormatSizeTest.java
+++ b/src/test/java/net/openhft/chronicle/core/JvmFormatSizeTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.core;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Canonical test suite for size parsing and retrieval via {@link Jvm#parseSize(String)} and
+ * {@link Jvm#getSize(String, long)}. Keep related assertions here to avoid duplication.
+ */
+class JvmParseSizeTest extends CoreTestCommon {
+    private static final String PROPERTY = "JvmParseSizeTest";
+    private static final long KIB = 1L << 10;
+    private static final long MIB = 1L << 20;
+    private static final long GIB = 1L << 30;
+    private static final long TIB = 1L << 40;
+
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+                {"100", 100L},
+                {"  100  ", 100L},
+                {"100b", 100L},
+                {"100B", 100L},
+                {" 100B ", 100L},
+                {"0.5kb", 512L},
+                {"0.5KiB", 512L},
+                {"0.125MB", 128L << 10},
+                {"2M", 2L << 20},
+                {" 2 M", 2L << 20},
+                {"0.75GiB", 768L << 20},
+                {"1.5 GiB", 1536L << 20},
+                {"0.25TiB", Math.round((1L << 40) / 4.0)},
+                {"0", 0},
+                {"-0.0GB", 0}, // BigDecimal("-0.0").longValue() == 0, so the negative-size guard is not triggered
+                {Long.MAX_VALUE + "", Long.MAX_VALUE},
+                {Long.MAX_VALUE / KIB + "kb", Long.MAX_VALUE / KIB * KIB},
+                {Long.MAX_VALUE / MIB + "mb", Long.MAX_VALUE / MIB * MIB},
+                {Long.MAX_VALUE / GIB + "gb", Long.MAX_VALUE / GIB * GIB},
+                {Long.MAX_VALUE / TIB + "tb", Long.MAX_VALUE / TIB * TIB},
+        });
+    }
+
+    @AfterEach
+    void teardown() {
+        System.getProperties().remove(PROPERTY);
+    }
+
+    @ParameterizedTest(name = "{0} => {1}")
+    @MethodSource("data")
+    void parseSize(String text, long value) throws IllegalArgumentException {
+        assertEquals(value, Jvm.parseSize(text));
+    }
+
+    @ParameterizedTest(name = "{0} => {1}")
+    @MethodSource("data")
+    void getSize(String text, long value) {
+        System.setProperty(PROPERTY, text);
+        assertEquals(value, Jvm.getSize(PROPERTY, -1));
+    }
+
+    @Test
+    void formatSizeRenders() {
+        assertEquals("0", Jvm.formatSize(0));
+        assertEquals("500", Jvm.formatSize(500));      // not a whole 1024 multiple -> raw bytes
+        assertEquals("1K", Jvm.formatSize(KIB));
+        assertEquals("512M", Jvm.formatSize(512 * MIB));
+        assertEquals("1536M", Jvm.formatSize(1536 * MIB)); // 1.5 GiB is not a whole GiB
+        assertEquals("5G", Jvm.formatSize(5 * GIB));
+        assertEquals("3T", Jvm.formatSize(3 * TIB));
+    }
+
+    @Test
+    void formatSizeRoundTripsThroughParseSize() {
+        final long[] sizes = {0, 1, 1023, KIB, 1025, 500, MIB, 1536 * MIB, 5 * GIB, 3 * TIB,
+                123_456_789L, Long.MAX_VALUE, Long.MAX_VALUE - 1023};
+        for (long size : sizes)
+            assertEquals(size, Jvm.parseSize(Jvm.formatSize(size)),
+                    "round-trip failed for " + size + " (formatted as " + Jvm.formatSize(size) + ")");
+    }
+
+    @Test
+    void formatSizeRejectsNegative() {
+        assertThrows(IllegalArgumentException.class, () -> Jvm.formatSize(-1));
+    }
+}

--- a/src/test/java/net/openhft/chronicle/core/JvmFormatSizeTest.java
+++ b/src/test/java/net/openhft/chronicle/core/JvmFormatSizeTest.java
@@ -3,69 +3,16 @@
  */
 package net.openhft.chronicle.core;
 
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
 
-import java.util.Arrays;
-import java.util.Collection;
-
-import static org.junit.jupiter.api.Assertions.*;
+import static net.openhft.chronicle.core.JvmParseSizeTest.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
- * Canonical test suite for size parsing and retrieval via {@link Jvm#parseSize(String)} and
- * {@link Jvm#getSize(String, long)}. Keep related assertions here to avoid duplication.
+ * Canonical test suite for size formatting via {@link Jvm#formatSize(long)}
  */
-class JvmParseSizeTest extends CoreTestCommon {
-    private static final String PROPERTY = "JvmParseSizeTest";
-    private static final long KIB = 1L << 10;
-    private static final long MIB = 1L << 20;
-    private static final long GIB = 1L << 30;
-    private static final long TIB = 1L << 40;
-
-    public static Collection<Object[]> data() {
-        return Arrays.asList(new Object[][]{
-                {"100", 100L},
-                {"  100  ", 100L},
-                {"100b", 100L},
-                {"100B", 100L},
-                {" 100B ", 100L},
-                {"0.5kb", 512L},
-                {"0.5KiB", 512L},
-                {"0.125MB", 128L << 10},
-                {"2M", 2L << 20},
-                {" 2 M", 2L << 20},
-                {"0.75GiB", 768L << 20},
-                {"1.5 GiB", 1536L << 20},
-                {"0.25TiB", Math.round((1L << 40) / 4.0)},
-                {"0", 0},
-                {"-0.0GB", 0}, // BigDecimal("-0.0").longValue() == 0, so the negative-size guard is not triggered
-                {Long.MAX_VALUE + "", Long.MAX_VALUE},
-                {Long.MAX_VALUE / KIB + "kb", Long.MAX_VALUE / KIB * KIB},
-                {Long.MAX_VALUE / MIB + "mb", Long.MAX_VALUE / MIB * MIB},
-                {Long.MAX_VALUE / GIB + "gb", Long.MAX_VALUE / GIB * GIB},
-                {Long.MAX_VALUE / TIB + "tb", Long.MAX_VALUE / TIB * TIB},
-        });
-    }
-
-    @AfterEach
-    void teardown() {
-        System.getProperties().remove(PROPERTY);
-    }
-
-    @ParameterizedTest(name = "{0} => {1}")
-    @MethodSource("data")
-    void parseSize(String text, long value) throws IllegalArgumentException {
-        assertEquals(value, Jvm.parseSize(text));
-    }
-
-    @ParameterizedTest(name = "{0} => {1}")
-    @MethodSource("data")
-    void getSize(String text, long value) {
-        System.setProperty(PROPERTY, text);
-        assertEquals(value, Jvm.getSize(PROPERTY, -1));
-    }
+class JvmFormatSizeTest extends CoreTestCommon {
 
     @Test
     void formatSizeRenders() {

--- a/src/test/java/net/openhft/chronicle/core/JvmParseSizeTest.java
+++ b/src/test/java/net/openhft/chronicle/core/JvmParseSizeTest.java
@@ -19,10 +19,10 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 class JvmParseSizeTest extends CoreTestCommon {
     private static final String PROPERTY = "JvmParseSizeTest";
-    private static final long KIB = 1L << 10;
-    private static final long MIB = 1L << 20;
-    private static final long GIB = 1L << 30;
-    private static final long TIB = 1L << 40;
+     static final long KIB = 1L << 10;
+     static final long MIB = 1L << 20;
+     static final long GIB = 1L << 30;
+     static final long TIB = 1L << 40;
 
     public static Collection<Object[]> data() {
         return Arrays.asList(new Object[][]{


### PR DESCRIPTION
Adds `Jvm.formatSize(long)` as the exact inverse of `Jvm.parseSize(String)`.

The formatter:

* Uses the largest exact binary unit from `K`, `M`, `G`, and `T`.
* Falls back to the original byte count when no binary unit divides it exactly.
* Guarantees `parseSize(formatSize(size)) == size` for every non-negative `long`.
* Rejects negative sizes with an `IllegalArgumentException`.

Also updates `Jvm.addToClassPath()` to handle `FileSystemNotFoundException` when a URL refers to an unavailable filesystem provider.

## Testing

Adds tests covering:

* Bytes and binary units from kilobytes through terabytes.
* Values that cannot be represented using a larger exact unit.
* Round trips through `Jvm.parseSize()`, including values near `Long.MAX_VALUE`.
* Rejection of negative sizes.
