### PR TITLE
CORE-78: Fix closeable wait progress and interruption

### DIFF
--- a/src/main/java/net/openhft/chronicle/core/internal/CloseableUtils.java
+++ b/src/main/java/net/openhft/chronicle/core/internal/CloseableUtils.java
@@ -117,13 +117,12 @@ public final class CloseableUtils {
     }
 
     /**
-     * Waits for closeable resources to close within a specified time limit.
-     * This method checks if the closeable resources in the trace set have been closed.
-     * If all resources are closed within the specified time limit, it returns true.
-     * If the time limit is exceeded before all resources are closed, it returns false.
+     * Waits for all tracked closeable resources to enter the closing state.
+     * A successful return means that {@code close()} has been called on each resource,
+     * but does not guarantee that every close operation has completed.
      *
-     * @param millis The time limit in milliseconds to wait for the closeable resources to close.
-     * @return true if all closeable resources are closed within the time limit, false otherwise.
+     * @param millis the time limit in milliseconds for the resources to enter the closing state
+     * @return true if all closeable resources are closing within the time limit, false otherwise.
      * @see #assertCloseablesClosed()
      */
     @SuppressWarnings({"java:S3776", "java:S3516"}) // turned on by assert
@@ -132,30 +131,53 @@ public final class CloseableUtils {
         if (traceSet == null) {
             return true;
         }
-        if (Thread.currentThread().isInterrupted())
+        //! Preserve interruption for the caller, but clear it while polling: an already-set flag
+        //! would make every Jvm.pause sleep throw immediately instead of waiting.
+        boolean interrupted = Thread.interrupted();
+        if (interrupted)
             System.err.println("Interrupted in waitForCloseablesToClose!");
 
         long end = System.currentTimeMillis() + millis;
-        CleaningThreadLocal.cleanupNonCleaningThreads();
-        BackgroundResourceReleaser.releasePendingResources();
+        try {
+            while (true) {
+                //! A tracked thread can terminate, or a release can be queued, after an earlier poll.
+                //! Repeat both progress operations outside the registry monitor; polling alone may leave a resource open.
+                //! Explicit draining also supports callers with the background release thread disabled.
+                CleaningThreadLocal.cleanupNonCleaningThreads();
+                BackgroundResourceReleaser.releasePendingResources();
 
-        while (true) {
-            synchronized (traceSet) {
-                boolean allClosed = true;
+                //! isClosing() may take a resource lock while its close path holds that lock and calls unmonitor().
+                //! Only snapshot creation may hold the registry monitor; querying under it would invert the lock order
+                //! and could block beyond the wait deadline.
+                Collection<ManagedCloseable> traceSetCopy;
+                synchronized (traceSet) {
+                    traceSetCopy = new ArrayList<>(traceSet);
+                }
 
-                for (ManagedCloseable key : traceSet) {
+                boolean allClosing = true;
+                for (ManagedCloseable key : traceSetCopy) {
                     if (!key.isClosing()) {
-                        allClosed = false;
+                        allClosing = false;
                         break;
                     }
                 }
-                if (allClosed)
+                if (allClosing)
                     return true;
-            }
 
-            if (System.currentTimeMillis() > end)
-                return false;
-            Jvm.pause(25);
+                if (System.currentTimeMillis() > end)
+                    return false;
+
+                //! Jvm.pause restores interruptions received during its sleep. Capture and clear the flag on either side
+                //! so later polls can pause; the finally block restores remembered interruptions on every exit path.
+                if (Thread.interrupted())
+                    interrupted = true;
+                Jvm.pause(25);
+                if (Thread.interrupted())
+                    interrupted = true;
+            }
+        } finally {
+            if (interrupted)
+                Thread.currentThread().interrupt();
         }
     }
 

--- a/src/test/java/net/openhft/chronicle/core/internal/CloseableUtilsTest.java
+++ b/src/test/java/net/openhft/chronicle/core/internal/CloseableUtilsTest.java
@@ -6,6 +6,7 @@ package net.openhft.chronicle.core.internal;
 import net.openhft.chronicle.core.io.*;
 import net.openhft.chronicle.core.test.RecordingCloseable;
 import net.openhft.chronicle.core.test.RecordingManagedCloseable;
+import net.openhft.chronicle.core.threads.CleaningThreadLocal;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -14,6 +15,13 @@ import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -81,6 +89,132 @@ class CloseableUtilsTest {
         CloseableUtils.add(closeable);
 
         assertTrue(CloseableUtils.waitForCloseablesToClose(1000));
+    }
+
+    @Test
+    void waitForCloseablesToCloseReturnsFalseForOpenResource() {
+        CloseableUtils.add(closeable);
+
+        assertFalse(CloseableUtils.waitForCloseablesToClose(50));
+    }
+
+    @Test
+    void waitForCloseablesToCloseRepeatsOrphanCleanup() throws Exception {
+        CountDownLatch firstQuery = new CountDownLatch(1);
+        AtomicBoolean closing = new AtomicBoolean();
+        AtomicInteger cleanups = new AtomicInteger();
+        ManagedCloseable resource = new ManagedCloseable() {
+            @Override
+            public void close() {
+                cleanups.incrementAndGet();
+                closing.set(true);
+            }
+
+            @Override
+            public boolean isClosing() {
+                firstQuery.countDown();
+                return closing.get();
+            }
+
+            @Override
+            public boolean isClosed() {
+                return closing.get();
+            }
+        };
+        CleaningThreadLocal<ManagedCloseable> local =
+                CleaningThreadLocal.withCleanup(() -> resource, ManagedCloseable::close);
+        CountDownLatch populated = new CountDownLatch(1);
+        CountDownLatch stopOwner = new CountDownLatch(1);
+        Thread owner = new Thread(() -> {
+            local.get();
+            populated.countDown();
+            try {
+                stopOwner.await();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }, "closeable-orphan-owner");
+        ExecutorService waiter = Executors.newSingleThreadExecutor();
+
+        try {
+            owner.start();
+            assertTrue(populated.await(5, TimeUnit.SECONDS));
+            CloseableUtils.add(resource);
+
+            Future<Boolean> closed = waiter.submit(() -> CloseableUtils.waitForCloseablesToClose(2_000));
+            assertTrue(firstQuery.await(5, TimeUnit.SECONDS));
+            stopOwner.countDown();
+            owner.join(5_000);
+            assertFalse(owner.isAlive());
+
+            assertTrue(closed.get(5, TimeUnit.SECONDS));
+            assertEquals(1, cleanups.get());
+            CleaningThreadLocal.cleanupNonCleaningThreads();
+            assertEquals(1, cleanups.get(), "a later sweep must not repeat cleanup");
+        } finally {
+            stopOwner.countDown();
+            owner.join(5_000);
+            CleaningThreadLocal.cleanupNonCleaningThreads();
+            waiter.shutdownNow();
+        }
+    }
+
+    @Test
+    void waitForCloseablesToClosePreservesInterruptWithoutSpinning() {
+        AtomicInteger queries = new AtomicInteger();
+        ManagedCloseable resource = new ManagedCloseable() {
+            @Override
+            public void close() {
+            }
+
+            @Override
+            public boolean isClosing() {
+                queries.incrementAndGet();
+                return false;
+            }
+
+            @Override
+            public boolean isClosed() {
+                return false;
+            }
+        };
+        CloseableUtils.add(resource);
+
+        try {
+            Thread.currentThread().interrupt();
+            assertFalse(CloseableUtils.waitForCloseablesToClose(100));
+            assertTrue(Thread.currentThread().isInterrupted());
+            assertTrue(queries.get() < 100, "an interrupted wait must still pause between polls");
+        } finally {
+            Thread.interrupted();
+        }
+    }
+
+    @Test
+    void waitForCloseablesToCloseQueriesOutsideRegistryLock() {
+        Set<ManagedCloseable> traceSet = getCloseablesRef().get();
+        AtomicBoolean queried = new AtomicBoolean();
+        ManagedCloseable resource = new ManagedCloseable() {
+            @Override
+            public void close() {
+            }
+
+            @Override
+            public boolean isClosing() {
+                queried.set(true);
+                assertFalse(Thread.holdsLock(traceSet), "isClosing must not run under the registry lock");
+                return true;
+            }
+
+            @Override
+            public boolean isClosed() {
+                return true;
+            }
+        };
+        CloseableUtils.add(resource);
+
+        assertTrue(CloseableUtils.waitForCloseablesToClose(1_000));
+        assertTrue(queried.get());
     }
 
     @Test


### PR DESCRIPTION
## Summary

- retain the boolean waiting contract introduced by #843
- run orphan cleanup and pending background releases on every polling attempt
- query closeable state from a snapshot outside the global registry monitor
- preserve interruption on return while clearing it during pauses to avoid a busy loop
- document that success means resources are closing, not necessarily fully closed

## Review feedback addressed

- A thread-local owner that terminates after the first sweep can now be cleaned by a later sweep during the same wait.
- An interrupt present on entry, or received during the wait, is remembered and restored when the method returns without repeatedly interrupting every sleep.
- Overridable `isClosing()` calls no longer run while holding the closeable registry monitor, avoiding the reported lock-order inversion.
- Focused tests cover ordinary timeout, late orphan cleanup with exactly-once release, interruption without spinning, and registry lock scope.

The non-obvious concurrency and interruption decisions carry `//!` justification notes at their call sites.

## Verification

- `mvn -q clean verify -l /tmp/core-wait-closeables-final-verify.log` (Java 21)
- `mvn -q clean verify -l /tmp/core-wait-closeables-final-java8-verify.log` (Java 8)
- supplied standalone Java 21 probe reproduced all three failures in the pre-fix implementation

Follow-up to #843.
