### PR TITLE
Reject invalid array slices before unsafe copies

### DIFF
--- a/src/main/docs/unsafe-array-copy-bounds.adoc
+++ b/src/main/docs/unsafe-array-copy-bounds.adoc
@@ -1,0 +1,30 @@
+= Unsafe Array Copy Bounds
+:lang: en-GB
+:sectnums:
+
+== Contract and decision
+
+`UnsafeMemory.readBytes` and `writeBytes` must reject negative array offsets and lengths,
+and slices beyond the array, before calling Unsafe, whether Java assertions are enabled or disabled.
+The read offset remains a `long`; it must not be narrowed before validation.
+An empty slice at the array end, including an empty array, is valid with a caller-owned valid native address.
+Null arrays produce `NullPointerException`.
+Invalid non-null slices produce `IllegalArgumentException` with either assertion mode.
+
+Compare the offset with `array.length - (long) length` after rejecting negative inputs.
+An addition-based test can wrap and accept an invalid range.
+Keep the public signatures and native-address ownership contract unchanged: these checks establish
+the array bounds, not native allocation bounds or lifetime. No contract annotations are added.
+
+== Evidence
+
+`UnsafeMemoryCopyBoundsTest` runs both memory implementations in bounded child JVMs with `-ea` and `-da`.
+It checks negative, overflowing and long-offset inputs, exact-end and empty slices, and unchanged
+array/native data after rejection. Seeded valid slices compare the complete output and surrounding bytes.
+Forking contains a native crash if a future regression reaches Unsafe with invalid inputs.
+
+The `assertions` Maven profile can additionally compile the existing guarded assertions into the module;
+it is not required for these runtime checks.
+
+This is a behavioural extraction from https://github.com/OpenHFT/Chronicle-Core/pull/846[PR #846],
+not adoption of its annotation or scanner-comment scheme.

--- a/src/main/java/net/openhft/chronicle/core/UnsafeMemory.java
+++ b/src/main/java/net/openhft/chronicle/core/UnsafeMemory.java
@@ -710,14 +710,14 @@ public class UnsafeMemory implements Memory {
      * @param b       the byte array to be written.
      * @param offset  the starting offset in the byte array.
      * @param length  the number of bytes to write.
-     * @throws IllegalArgumentException if offset + length exceeds the byte array's length.
+     * @throws IllegalArgumentException if offset or length is negative, or the slice exceeds the array.
      */
     @Override
     public void writeBytes(long address, byte[] b, int offset, int length) throws IllegalArgumentException {
         assert address != 0;
-        assert SKIP_ASSERTIONS || offset >= 0;
-        assert SKIP_ASSERTIONS || length >= 0;
-        if (offset + length > b.length)
+        requireNonNull(b);
+        //! Array bounds must hold even without assertions: addition can wrap before Unsafe copies the slice.
+        if (offset < 0 || length < 0 || offset > b.length - (long) length)
             throw new IllegalArgumentException("Invalid offset or length, array's length is " + b.length);
         UnsafeMemory.UNSAFE.copyMemory(b, ARRAY_BYTE_BASE_OFFSET + offset, null, address, length);
     }
@@ -729,14 +729,14 @@ public class UnsafeMemory implements Memory {
      * @param b       the byte array to be filled.
      * @param offset  the starting offset in the byte array.
      * @param length  the number of bytes to read.
-     * @throws IllegalArgumentException if offset + length exceeds the byte array's length.
+     * @throws IllegalArgumentException if offset or length is negative, or the slice exceeds the array.
      */
     @Override
     public void readBytes(long address, byte[] b, long offset, int length) throws IllegalArgumentException {
         assert address != 0;
-        assert SKIP_ASSERTIONS || offset >= 0;
-        assert SKIP_ASSERTIONS || length >= 0;
-        if (offset + length > b.length)
+        requireNonNull(b);
+        //! Check the full long offset before adding the array base; narrowing it could admit an invalid slice.
+        if (offset < 0 || length < 0 || offset > b.length - (long) length)
             throw new IllegalArgumentException("Invalid offset or length, array's length is " + b.length);
         UnsafeMemory.UNSAFE.copyMemory(null, address, b, ARRAY_BYTE_BASE_OFFSET + offset, length);
     }

--- a/src/test/java/net/openhft/chronicle/core/UnsafeMemoryCopyBoundsTest.java
+++ b/src/test/java/net/openhft/chronicle/core/UnsafeMemoryCopyBoundsTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.core;
+
+import net.openhft.chronicle.core.io.Closeable;
+import net.openhft.chronicle.core.io.IOTools;
+import net.openhft.chronicle.testframework.process.JavaProcessBuilder;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class UnsafeMemoryCopyBoundsTest {
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void checksActualCopiesWithAndWithoutAssertions(boolean assertions) throws Exception {
+        // A missing guard must fail a bounded child process, not corrupt the owning test JVM.
+        Process process = JavaProcessBuilder.create(CopyBoundsProbe.class)
+                .withJvmArguments(assertions ? "-ea" : "-da")
+                .withProgramArguments(Boolean.toString(assertions))
+                .start();
+        try {
+            assertTrue(process.waitFor(30, TimeUnit.SECONDS), "copy probe did not terminate");
+            String output = new String(IOTools.readAsBytes(process.getInputStream()), StandardCharsets.UTF_8)
+                    + new String(IOTools.readAsBytes(process.getErrorStream()), StandardCharsets.UTF_8);
+            assertEquals(0, process.exitValue(), output);
+        } finally {
+            try {
+                if (process.isAlive()) {
+                    process.destroyForcibly();
+                    assertTrue(process.waitFor(10, TimeUnit.SECONDS), "copy probe did not stop");
+                }
+            } finally {
+                Closeable.closeQuietly(process.getInputStream(), process.getErrorStream(), process.getOutputStream());
+            }
+        }
+    }
+
+    public static final class CopyBoundsProbe {
+        public static void main(String[] args) {
+            assertEquals(Boolean.parseBoolean(args[0]), UnsafeMemory.class.desiredAssertionStatus());
+            verify(new UnsafeMemory());
+            verify(new UnsafeMemory.ARMMemory());
+        }
+
+        private static void verify(UnsafeMemory memory) {
+            long address = memory.allocate(64);
+            try {
+                byte[] bytes = new byte[16];
+                Arrays.fill(bytes, (byte) 37);
+                memory.setMemory(address, 64, (byte) 90);
+                byte[] nativeBefore = new byte[64];
+                memory.readBytes(address, nativeBefore, 0, nativeBefore.length);
+                byte[] arrayBefore = bytes.clone();
+
+                int[][] invalid = {{-1, 0}, {0, -1}, {-1, 1}, {17, 0}, {16, 1}, {0, 17},
+                        {Integer.MIN_VALUE, 0}, {Integer.MAX_VALUE, 1}, {Integer.MAX_VALUE, Integer.MAX_VALUE}};
+                for (int[] range : invalid) {
+                    assertThrows(IllegalArgumentException.class,
+                            () -> memory.writeBytes(address, bytes, range[0], range[1]), Arrays.toString(range));
+                    assertThrows(IllegalArgumentException.class,
+                            () -> memory.readBytes(address, bytes, range[0], range[1]), Arrays.toString(range));
+                }
+                for (long offset : new long[]{Long.MIN_VALUE, Long.MAX_VALUE, 1L << 32}) {
+                    assertThrows(IllegalArgumentException.class, () -> memory.readBytes(address, bytes, offset, 1));
+                }
+                assertThrows(NullPointerException.class, () -> memory.writeBytes(address, null, 0, 0));
+                assertThrows(NullPointerException.class, () -> memory.readBytes(address, null, 0, 0));
+                byte[] nativeAfter = new byte[64];
+                memory.readBytes(address, nativeAfter, 0, nativeAfter.length);
+                assertArrayEquals(nativeBefore, nativeAfter, "rejected slices changed native memory");
+                assertArrayEquals(arrayBefore, bytes, "rejected slices changed the array");
+
+                memory.writeBytes(address, bytes, bytes.length, 0);
+                memory.readBytes(address, bytes, bytes.length, 0);
+                memory.writeBytes(address, new byte[0], 0, 0);
+                memory.readBytes(address, new byte[0], 0, 0);
+                assertArrayEquals(arrayBefore, bytes);
+                memory.readBytes(address, nativeAfter, 0, nativeAfter.length);
+                assertArrayEquals(nativeBefore, nativeAfter, "empty copies changed native memory");
+
+                // Reproducible slices include exact-end boundaries and check bytes on both sides of every copy.
+                Random random = new Random(846);
+                for (int iteration = 0; iteration < 128; iteration++) {
+                    random.nextBytes(bytes);
+                    int length = iteration % 17;
+                    int offset = iteration < 17 ? bytes.length - length : random.nextInt(bytes.length - length + 1);
+                    memory.setMemory(address, 64, (byte) 90);
+                    memory.writeBytes(address + 8, bytes, offset, length);
+                    byte[] expectedNative = new byte[64];
+                    Arrays.fill(expectedNative, (byte) 90);
+                    System.arraycopy(bytes, offset, expectedNative, 8, length);
+                    memory.readBytes(address, nativeAfter, 0, nativeAfter.length);
+                    assertArrayEquals(expectedNative, nativeAfter, "write slice " + iteration);
+
+                    byte[] result = new byte[16];
+                    Arrays.fill(result, (byte) 91);
+                    memory.readBytes(address + 8, result, offset, length);
+                    byte[] expectedArray = new byte[16];
+                    Arrays.fill(expectedArray, (byte) 91);
+                    System.arraycopy(bytes, offset, expectedArray, offset, length);
+                    assertArrayEquals(expectedArray, result, "read slice " + iteration);
+                }
+            } finally {
+                memory.freeMemory(address, 64);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Refresh on 12 September 2026

Merged develop `9c26a484f3150c7f079aea626abffac22e53a506` into the existing branch without rewriting history. Updated head: `cd4454515252a6dbc4c8a739c5f5c88acf681ed7`. Both the declared base and develop are ancestors of this head.

Fresh Linux full Maven verification passed on Java 21 (1,876 reported tests, no skips) and Java 8 (1,876 reported tests, five existing skips), with no failures or errors. The assertions profile also passed full verification, and UnsafeMemoryCopyBoundsTest passed with JVM assertions disabled. Both memory implementations remain covered. The AsciiDoc contract renders without warnings.

Platform CI and repository merge gates remain separate. Earlier implementation and validation details follow; their recorded results apply to the revisions stated there.

---

## Why and scope

Each branch starts directly from current develop `ebcf76e91cb7a57b3626c1de7e0a67fc42a514a8`. This is an independent behavioural extraction from #846, not a JUnit migration or annotation/checker rewrite.

The addition-based array check can accept negative or overflowing offsets before Unsafe.copyMemory. Reject negative inputs and compare against an overflow-safe remaining length, retaining the long read offset and existing public APIs.

The actual readBytes/writeBytes methods now reject invalid non-null slices with IllegalArgumentException in either assertion mode. Valid empty and exact-end slices remain supported. Concise //! notes explain the runtime checks; native allocation bounds and lifetime remain caller responsibilities.

## Verification performed

Actual Chronicle-Core Maven builds on Linux x64, using Maven 3.9.11 and `mvn -B -nsu clean verify -Dsurefire.rerunFailingTestsCount=0 -l <log>`:

| JVM | Tests | Failures/errors | Skipped |
| --- | ---: | ---: | ---: |
| OpenJDK 8u502 | 1872 | 0 / 0 | 5 |
| OpenJDK 21.0.12 | 1872 | 0 / 0 | 0 |

The five Java 8 skips are existing JDK-specific tests; none of the added cases skipped. Full verify includes licence and binary-compatibility checks. Test retries were disabled.

UnsafeMemoryCopyBoundsTest runs the real UnsafeMemory and ARMMemory implementations in bounded child JVMs with -ea and -da. It covers negative/overflowing/long offsets, null/empty arrays, exact-end slices, unchanged memory on rejection, and 128 seeded valid slices per implementation/mode with surrounding-byte checks. This executes both implementations on Linux x64, not ARM hardware.

Both tests fail against the unchanged develop production code on the safe first negative control (-1, 0); no invalid non-empty native copy is needed to establish that failure. Both pass against the extraction. Clean focused builds with -Passertions also pass on Java 8 and 21, so the check is tested with Core's guarded assertions compiled in as well as with the default profile.

The unchanged POM resolves Chronicle Test Framework 2026.2, JUnit Jupiter 5.10.0, Affinity 2026.2 and POSIX 2026.2. No dependency bump is included. Platform CI remains a separate gate; Windows, Mac and ARM hardware were not run locally. Java 26+ results are informational under the project review policy.

## Boundaries

No new annotations, public API changes, POM/version changes or broad raw-address/object-offset assertion replacements. No native-allocation safety or performance improvement is claimed.
