### PR TITLE
Preserve deletion depth limits without following symlinks

### DIFF
--- a/src/main/docs/no-follow-directory-deletion.adoc
+++ b/src/main/docs/no-follow-directory-deletion.adoc
@@ -1,0 +1,28 @@
+= No-Follow Directory Deletion
+:lang: en-GB
+:sectnums:
+
+== Contract and decision
+
+`IOTools.deleteDirWithFiles(File, int)` deletes symbolic links as leaf entries, including root and dangling links.
+It must not enumerate a linked directory's target. A plain-file or missing root still returns `false`.
+
+Keep the existing recursive depth algorithm: the root is depth zero, files within an allowed directory
+are permitted, and a real directory immediately beyond `maxDepth` raises `AssertionError` without deleting it.
+Earlier permitted entries may already have been removed when a later entry fails; deletion is not atomic.
+Use no-follow directory classification for children and handle a root link before calling `listFiles`.
+
+This avoids the `walkFileTree` boundary distinction from PR #846, where maximum-depth directories
+arrive in `visitFile` rather than `preVisitDirectory`. It does not add real-path canonicalisation.
+This is protection against traversing links in a stable tree, not a race-free guarantee against hostile
+concurrent path replacement. Race-resistant directory operations require a separate design.
+
+== Evidence
+
+`IOToolsDeletionTest` covers empty and populated over-depth directories at limits 0, 1 and 2;
+permitted depth including an `Integer.MAX_VALUE` limit; child/root/dangling/cyclic links; and plain/missing roots.
+JUnit's `TempDir` fixture cleans up even if an assertion fails. Link tests are skipped only when
+the filesystem does not support them or Windows does not allow link creation.
+
+Extracted from https://github.com/OpenHFT/Chronicle-Core/pull/846[PR #846] without its depth regression,
+annotations, scanner commentary or stronger path-security claims.

--- a/src/main/java/net/openhft/chronicle/core/io/IOTools.java
+++ b/src/main/java/net/openhft/chronicle/core/io/IOTools.java
@@ -161,17 +161,28 @@ public final class IOTools {
     }
 
     /**
-     * Attempts to delete directories and their files. If any directory is not
-     * deleted successfully, throws an {@link AssertionError}.
+     * Attempts to delete a directory and its files without traversing symbolic links.
+     * Links, including a root link, are deleted as entries; their targets are preserved.
      *
-     * @param dir      The directories to be deleted
-     * @param maxDepth The maximum depth of directories to be deleted
+     * @param dir      The directory or symbolic link to be deleted
+     * @param maxDepth The maximum number of directory levels below the root
+     * @return true if deletion is successful, false otherwise
+     * @throws AssertionError if a real directory is encountered below the permitted depth
      * @throws IORuntimeException if an I/O error occurs
      */
     public static boolean deleteDirWithFiles(@NotNull File dir, int maxDepth) throws IORuntimeException {
+        //! A root link must be removed before listFiles can enumerate its target, including for dangling links.
+        if (Files.isSymbolicLink(dir.toPath())) {
+            try {
+                return Files.deleteIfExists(dir.toPath());
+            } catch (IOException e) {
+                throw new IORuntimeException(e);
+            }
+        }
         final File[] entries = dir.listFiles();
         if (entries == null) return false;
-        Stream.of(entries).filter(File::isDirectory).forEach(f -> {
+        //! Keep the existing depth check for real directories; a link is a leaf even when its target is a directory.
+        Stream.of(entries).filter(f -> Files.isDirectory(f.toPath(), LinkOption.NOFOLLOW_LINKS)).forEach(f -> {
             if (maxDepth < 1) {
                 throw new AssertionError("Contains directory " + f);
             } else {

--- a/src/test/java/net/openhft/chronicle/core/io/IOToolsDeletionTest.java
+++ b/src/test/java/net/openhft/chronicle/core/io/IOToolsDeletionTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.core.io;
+
+import net.openhft.chronicle.core.OS;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.io.IOException;
+import java.nio.file.FileSystemException;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+class IOToolsDeletionTest {
+    @TempDir
+    Path temporary;
+
+    @ParameterizedTest
+    @CsvSource({"0, false", "0, true", "1, false", "1, true", "2, false", "2, true"})
+    void rejectsDirectoriesImmediatelyBeyondLimit(int maxDepth, boolean populated) throws IOException {
+        Path root = Files.createDirectory(temporary.resolve("root"));
+        Path boundary = root;
+        for (int depth = 0; depth <= maxDepth; depth++)
+            boundary = Files.createDirectory(boundary.resolve("child"));
+        Path file = boundary.resolve("retained.txt");
+        if (populated)
+            Files.write(file, new byte[]{42});
+
+        assertThrows(AssertionError.class, () -> IOTools.deleteDirWithFiles(root.toFile(), maxDepth));
+
+        assertTrue(Files.isDirectory(boundary), "the over-depth directory must remain");
+        if (populated)
+            assertArrayEquals(new byte[]{42}, Files.readAllBytes(file));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, 1, 2, Integer.MAX_VALUE})
+    void deletesFilesAndDirectoriesWithinLimit(int maxDepth) throws IOException {
+        Path root = Files.createDirectory(temporary.resolve("root"));
+        Path directory = root;
+        for (int depth = 0; depth < Math.min(maxDepth, 2); depth++)
+            directory = Files.createDirectory(directory.resolve("child"));
+        Files.write(directory.resolve("data.txt"), new byte[]{42});
+
+        assertTrue(IOTools.deleteDirWithFiles(root.toFile(), maxDepth));
+        assertFalse(Files.exists(root, LinkOption.NOFOLLOW_LINKS));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, 1, Integer.MAX_VALUE})
+    void removesChildLinkWithoutTouchingForeignTree(int maxDepth) throws IOException {
+        Path root = Files.createDirectory(temporary.resolve("root"));
+        Path foreign = Files.createDirectory(temporary.resolve("foreign"));
+        Path file = Files.write(foreign.resolve("retained.txt"), new byte[]{42});
+        createLink(root.resolve("link"), foreign);
+
+        assertTrue(IOTools.deleteDirWithFiles(root.toFile(), maxDepth));
+        assertFalse(Files.exists(root, LinkOption.NOFOLLOW_LINKS));
+        assertArrayEquals(new byte[]{42}, Files.readAllBytes(file));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void removesRootLinkWithoutTouchingTarget(boolean directory) throws IOException {
+        Path target = temporary.resolve("target");
+        Path file = directory ? Files.createDirectory(target).resolve("retained.txt") : target;
+        Files.write(file, new byte[]{42});
+        Path link = temporary.resolve("root-link");
+        createLink(link, target);
+
+        assertTrue(IOTools.deleteDirWithFiles(link.toFile(), 0));
+        assertFalse(Files.exists(link, LinkOption.NOFOLLOW_LINKS));
+        assertArrayEquals(new byte[]{42}, Files.readAllBytes(file));
+    }
+
+    @Test
+    void removesDanglingRootLink() throws IOException {
+        Path link = temporary.resolve("root-link");
+        createLink(link, temporary.resolve("missing"));
+        assertTrue(IOTools.deleteDirWithFiles(link.toFile(), 0));
+        assertFalse(Files.exists(link, LinkOption.NOFOLLOW_LINKS));
+    }
+
+    @Test
+    void removesDanglingAndCyclicChildLinks() throws IOException {
+        Path root = Files.createDirectory(temporary.resolve("root"));
+        createLink(root.resolve("missing"), temporary.resolve("missing"));
+        createLink(root.resolve("cycle"), root);
+        assertTrue(IOTools.deleteDirWithFiles(root.toFile(), 0));
+        assertFalse(Files.exists(root, LinkOption.NOFOLLOW_LINKS));
+    }
+
+    @Test
+    void preservesPlainFileAndReportsMissingRoot() throws IOException {
+        Path file = Files.write(temporary.resolve("plain.txt"), new byte[]{42});
+        assertFalse(IOTools.deleteDirWithFiles(file.toFile(), 0));
+        assertArrayEquals(new byte[]{42}, Files.readAllBytes(file));
+        assertFalse(IOTools.deleteDirWithFiles(temporary.resolve("missing").toFile(), 0));
+    }
+
+    private static void createLink(Path link, Path target) throws IOException {
+        try {
+            Files.createSymbolicLink(link, target);
+        } catch (UnsupportedOperationException e) {
+            assumeTrue(false, "symbolic links are unsupported: " + e);
+        } catch (FileSystemException e) {
+            if (OS.isWindows())
+                assumeTrue(false, "Windows symbolic-link creation is unavailable: " + e);
+            throw e;
+        }
+    }
+}


### PR DESCRIPTION
## Refresh on 12 September 2026

Merged develop `9c26a484f3150c7f079aea626abffac22e53a506` into the existing branch without rewriting history. Updated head: `7b5d27f5386af50d5df54e3c94696806ebba46a0`. Both the declared base and develop are ancestors of this head.

Fresh Linux/OpenJDK 21 full Maven verify passed: 1892 reported tests, no failures or errors.

Platform CI and repository merge gates remain separate. Earlier implementation and validation details follow; their recorded results apply to the revisions stated there.

---

## Why and scope

Each branch starts directly from current develop `ebcf76e91cb7a57b3626c1de7e0a67fc42a514a8`. This is an independent behavioural extraction from #846, not a JUnit migration or annotation/checker rewrite.

The existing deletion recursion follows directory symlinks into their targets. The walkFileTree rewrite in #846 prevents this but bypasses the established depth error for boundary directories delivered to visitFile.

Keep the existing recursion and depth check. Classify child directories without following links and delete a root link before listFiles can enumerate its target. Add concise //! explanations. Plain-file and missing roots still return false; that is preservation, not a newly fixed plain-file deletion defect.

## Verification performed

Actual Chronicle-Core Maven builds on Linux x64, using Maven 3.9.11 and `mvn -B -nsu clean verify -Dsurefire.rerunFailingTestsCount=0 -l <log>`:

| JVM | Tests | Failures/errors | Skipped |
| --- | ---: | ---: | ---: |
| OpenJDK 8u502 | 1888 | 0 / 0 | 5 |
| OpenJDK 21.0.12 | 1888 | 0 / 0 | 0 |

The five Java 8 skips are existing JDK-specific tests; none of the added cases skipped. Full verify includes licence and binary-compatibility checks. Test retries were disabled.

All 18 focused cases pass: empty/populated directories beyond depths 0/1/2, permitted depths including Integer.MAX_VALUE, root/child/dangling/cyclic links, and plain/missing roots. TempDir provides cleanup after failed assertions.

Against develop, seven cases fail/error, demonstrating traversal of foreign trees and missing link handling. Against the exact #846 head (73ab2a6b), all six over-depth cases fail. Those same cases pass here.

The unchanged POM resolves Chronicle Test Framework 2026.2, JUnit Jupiter 5.10.0, Affinity 2026.2 and POSIX 2026.2. No dependency bump is included. Platform CI remains a separate gate; Windows, Mac and ARM hardware were not run locally. Java 26+ results are informational under the project review policy.

## Boundaries

This prevents link traversal in a stable tree; it is not race-resistant protection against hostile concurrent path replacement. No canonicalisation, walkFileTree rewrite, POM/version changes or annotation sweep. Windows link tests can skip if link creation is unavailable; none skipped on the tested Linux hosts.
