### PR TITLE
Encode file paths when creating resource URLs

### DIFF
--- a/src/main/docs/file-url-encoding.adoc
+++ b/src/main/docs/file-url-encoding.adoc
@@ -1,0 +1,20 @@
+= Filesystem URL Encoding
+:lang: en-GB
+:sectnums:
+
+== Contract and decision
+
+When `IOTools.urlFor` falls back from classpath lookup to an existing filesystem path, it must encode
+that path as a file URI before creating the URL. A literal `#` in a filename is part of the path, not
+a fragment; spaces and percent signs must also retain their filename meaning when the URL is opened.
+
+Use `toAbsolutePath().toUri().toURL()`. Do not introduce `toRealPath()` or a canonical-path policy:
+the URL must retain a symlink's path rather than substitute its target. Resource lookup order,
+the `.gz` resource fallback, and missing-file exceptions remain unchanged.
+
+== Evidence
+
+`IOToolsFileUrlTest` opens actual files containing reserved filename characters, checks link-path
+preservation, and covers resource precedence and missing files. `TempDir` provides failure-path cleanup.
+This one-line behavioural fix is extracted from https://github.com/OpenHFT/Chronicle-Core/pull/846[PR #846]
+without its separate real-path policy or scanner annotations.

--- a/src/main/java/net/openhft/chronicle/core/io/IOTools.java
+++ b/src/main/java/net/openhft/chronicle/core/io/IOTools.java
@@ -285,7 +285,8 @@ public final class IOTools {
             url = classLoader.getResource(name + ".gz");
         if (url == null && new File(name).exists())
             try {
-                url = new URL("file", "", new File(name).getAbsolutePath());
+                //! URI encoding keeps filename characters such as '#' out of the URL fragment without resolving links.
+                url = Paths.get(name).toAbsolutePath().toUri().toURL();
             } catch (MalformedURLException e) {
                 FileNotFoundException fnfe = new FileNotFoundException(name);
                 fnfe.initCause(e);

--- a/src/test/java/net/openhft/chronicle/core/io/IOToolsFileUrlTest.java
+++ b/src/test/java/net/openhft/chronicle/core/io/IOToolsFileUrlTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.core.io;
+
+import net.openhft.chronicle.core.OS;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.nio.file.FileSystemException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+class IOToolsFileUrlTest {
+    private static final ClassLoader NO_RESOURCES = new ClassLoader(null) {
+        @Override
+        public URL getResource(String name) {
+            return null;
+        }
+    };
+
+    @TempDir
+    Path temporary;
+
+    @ParameterizedTest
+    @ValueSource(strings = {"a#b.txt", "a b.txt", "a%b.txt", "a+b.txt", "plain.txt"})
+    void opensTheExactFilename(String name) throws IOException {
+        byte[] content = {1, 2, 3, 42};
+        Path file = Files.write(temporary.resolve(name), content);
+
+        URL url = IOTools.urlFor(NO_RESOURCES, file.toString());
+
+        assertEquals("file", url.getProtocol());
+        assertNull(url.getRef(), "a filename must not create a URL fragment");
+        assertNull(url.getQuery(), "a filename must not create a URL query");
+        try (InputStream input = url.openStream()) {
+            assertArrayEquals(content, IOTools.readAsBytes(input));
+        }
+    }
+
+    @Test
+    void preservesSymlinkPathRatherThanCanonicalisingIt() throws Exception {
+        Path target = Files.write(temporary.resolve("target.txt"), new byte[]{42});
+        Path link = temporary.resolve("link#name.txt");
+        try {
+            Files.createSymbolicLink(link, target);
+        } catch (UnsupportedOperationException e) {
+            assumeTrue(false, "symbolic links are unsupported: " + e);
+        } catch (FileSystemException e) {
+            if (OS.isWindows())
+                assumeTrue(false, "Windows symbolic-link creation is unavailable: " + e);
+            throw e;
+        }
+
+        URL url = IOTools.urlFor(NO_RESOURCES, link.toString());
+
+        assertEquals(link.toAbsolutePath().toUri(), url.toURI());
+        assertNotEquals(target.toAbsolutePath().toUri(), url.toURI());
+        try (InputStream input = url.openStream()) {
+            assertArrayEquals(new byte[]{42}, IOTools.readAsBytes(input));
+        }
+    }
+
+    @Test
+    void preservesResourceLookupAndCompressedFallback() throws Exception {
+        URL resource = temporary.resolve("resource.txt").toUri().toURL();
+        ClassLoader loader = new ClassLoader(null) {
+            @Override
+            public URL getResource(String name) {
+                return "direct".equals(name) || "compressed.gz".equals(name) ? resource : null;
+            }
+        };
+        assertSame(resource, IOTools.urlFor(loader, "direct"));
+        assertSame(resource, IOTools.urlFor(loader, "/direct"));
+        assertSame(resource, IOTools.urlFor(loader, "compressed"));
+    }
+
+    @Test
+    void stillReportsMissingFiles() {
+        assertThrows(FileNotFoundException.class,
+                () -> IOTools.urlFor(NO_RESOURCES, temporary.resolve("missing#file.txt").toString()));
+    }
+}


### PR DESCRIPTION
## Refresh on 12 September 2026

Merged develop `9c26a484f3150c7f079aea626abffac22e53a506` into the existing branch without rewriting history. Updated head: `65a3751bcb73bb88b8336f9106ad1bdd7f207a91`. Both the declared base and develop are ancestors of this head.

Fresh Linux/OpenJDK 21 full Maven verify passed: 1882 reported tests, no failures or errors.

Platform CI and repository merge gates remain separate. Earlier implementation and validation details follow; their recorded results apply to the revisions stated there.

---

## Why and scope

Each branch starts directly from current develop `ebcf76e91cb7a57b3626c1de7e0a67fc42a514a8`. This is an independent behavioural extraction from #846, not a JUnit migration or annotation/checker rewrite.

Constructing a file URL from an unescaped pathname treats a literal # as a fragment and can misinterpret percent signs, so the returned URL does not reliably open the requested file.

Use toAbsolutePath().toUri().toURL() for the existing filesystem fallback. Keep resource lookup, compressed-resource fallback and missing-file behaviour unchanged. Do not introduce the separate toRealPath policy from #846; a symlink URL retains its supplied path.

## Verification performed

Actual Chronicle-Core Maven builds on Linux x64, using Maven 3.9.11 and `mvn -B -nsu clean verify -Dsurefire.rerunFailingTestsCount=0 -l <log>`:

| JVM | Tests | Failures/errors | Skipped |
| --- | ---: | ---: | ---: |
| OpenJDK 8u502 | 1878 | 0 / 0 | 5 |
| OpenJDK 21.0.12 | 1878 | 0 / 0 | 0 |

The five Java 8 skips are existing JDK-specific tests; none of the added cases skipped. Full verify includes licence and binary-compatibility checks. Test retries were disabled.

All eight focused cases pass: actual reads of filenames with #, spaces, percent signs and plus signs, a plain filename, link-path preservation, resource lookup/fallback and missing files. TempDir and try-with-resources provide failure-path cleanup.

Three cases fail/error against develop. Against #846's exact head (73ab2a6b), the symlink-path test fails because toRealPath substitutes the target. All pass with this one-line behavioural fix.

The unchanged POM resolves Chronicle Test Framework 2026.2, JUnit Jupiter 5.10.0, Affinity 2026.2 and POSIX 2026.2. No dependency bump is included. Platform CI remains a separate gate; Windows, Mac and ARM hardware were not run locally. Java 26+ results are informational under the project review policy.

## Boundaries

Only URL encoding changes in release code, with an adjacent //! reason. No canonicalisation/security-policy claim, public API or POM/version changes, annotations or unrelated I/O cleanup.
