### PR TITLE
Preserve interruption during closeable assertion waits

### DIFF
--- a/src/main/docs/closeable-assertion-interruption.adoc
+++ b/src/main/docs/closeable-assertion-interruption.adoc
@@ -9,6 +9,11 @@ Interruption is not cancellation: remember and temporarily clear an entry interr
 block, and restore the flag on success or failure. Interruptions received during a sleep must also be
 remembered and restored, without making subsequent sleeps repeatedly throw immediately.
 
+When the grace period expires, transfer the polling helper's restored status into the outer method's
+remembered state before diagnostic cleanup. Clear the live flag for cleanup and retain the saved state
+until the outer `finally`: a resource's `close()` can consume the flag and can then return or throw.
+Restoring the flag only at the helper boundary is therefore insufficient.
+
 Preserve the existing stderr diagnostic and registry locking; changing logger behaviour or the
 snapshot/locking model is outside this fix. The separate `waitForCloseablesToClose()` repair is PR #862.
 Merely replacing `Thread.interrupted()` with `isInterrupted()` would preserve the flag but collapse
@@ -22,5 +27,11 @@ resource queries begin; it closes the resource after observing the waiter in a r
 It also interrupts an active sleep, requires another query and a subsequent blocking sleep, and verifies
 the resulting status. Worker completion is bounded
 and failures are propagated to the owning test. No fixed sleep guesses when a worker is ready.
+
+The diagnostic-cleanup regression keeps a resource open until the grace loop expires and interrupts
+the assertion thread after observing a polling sleep. Its `close()` consumes interruption and either
+returns or throws a specific exception. Both entry states must retain the polling interrupt on exit,
+without changing the existing assertion/cleanup failure or closing more than once. Against the first
+revision of PR #866, both initially-clear cases fail; the initially-interrupted controls pass.
 
 This is extracted and corrected from https://github.com/OpenHFT/Chronicle-Core/pull/846[PR #846].

--- a/src/main/docs/closeable-assertion-interruption.adoc
+++ b/src/main/docs/closeable-assertion-interruption.adoc
@@ -1,0 +1,26 @@
+= Closeable Assertion Interruption
+:lang: en-GB
+:sectnums:
+
+== Contract and decision
+
+`CloseableUtils.assertCloseablesClosed()` retains its existing grace period and diagnostic cleanup.
+Interruption is not cancellation: remember and temporarily clear an entry interrupt, let polling sleeps
+block, and restore the flag on success or failure. Interruptions received during a sleep must also be
+remembered and restored, without making subsequent sleeps repeatedly throw immediately.
+
+Preserve the existing stderr diagnostic and registry locking; changing logger behaviour or the
+snapshot/locking model is outside this fix. The separate `waitForCloseablesToClose()` repair is PR #862.
+Merely replacing `Thread.interrupted()` with `isInterrupted()` would preserve the flag but collapse
+the grace period, which is why the one-line change in PR #846 is not extracted in isolation.
+
+== Evidence
+
+`CloseableAssertionInterruptionTest` covers initially clear/set interruption on empty-registry success,
+state-query failure and unclosed-resource reporting. A latch starts a background observer only after
+resource queries begin; it closes the resource after observing the waiter in a real timed wait.
+It also interrupts an active sleep, requires another query and a subsequent blocking sleep, and verifies
+the resulting status. Worker completion is bounded
+and failures are propagated to the owning test. No fixed sleep guesses when a worker is ready.
+
+This is extracted and corrected from https://github.com/OpenHFT/Chronicle-Core/pull/846[PR #846].

--- a/src/main/java/net/openhft/chronicle/core/internal/CloseableUtils.java
+++ b/src/main/java/net/openhft/chronicle/core/internal/CloseableUtils.java
@@ -188,6 +188,8 @@ public final class CloseableUtils {
                 if (waitForTraceSet(traceSet, traceSet2))
                     return;
 
+                //! Cleanup callbacks can consume the flag restored by polling; remember it until the outer finally.
+                interrupted |= Thread.interrupted();
                 captureTheUnclosed(openFiles, traceSet2);
             }
 

--- a/src/main/java/net/openhft/chronicle/core/internal/CloseableUtils.java
+++ b/src/main/java/net/openhft/chronicle/core/internal/CloseableUtils.java
@@ -163,6 +163,7 @@ public final class CloseableUtils {
      * Asserts that all closeable resources are closed.
      * This method checks if there are any remaining open closeable resources.
      * If any resources are found to be open, an AssertionError is thrown.
+     * The existing grace period is not cancelled by interruption; interrupt status is restored on exit.
      *
      * @see #waitForCloseablesToClose(long)
      */
@@ -172,23 +173,30 @@ public final class CloseableUtils {
             Jvm.warn().on(AbstractCloseable.class, "closable tracing disabled");
             return;
         }
-        if (Thread.interrupted())
-            System.err.println("Interrupted in assertCloseablesClosed!");
+        //! Temporarily clear an entry interrupt so the grace-period sleeps can block; preserve it on every exit.
+        boolean interrupted = Thread.interrupted();
+        try {
+            if (interrupted)
+                System.err.println("Interrupted in assertCloseablesClosed!");
 
-        BackgroundResourceReleaser.releasePendingResources();
+            BackgroundResourceReleaser.releasePendingResources();
 
-        AssertionError openFiles = new AssertionError("Closeables still open");
+            AssertionError openFiles = new AssertionError("Closeables still open");
 
-        synchronized (traceSet) {
-            Set<Closeable> traceSet2 = Collections.newSetFromMap(new IdentityHashMap<>());
-            if (waitForTraceSet(traceSet, traceSet2))
-                return;
+            synchronized (traceSet) {
+                Set<Closeable> traceSet2 = Collections.newSetFromMap(new IdentityHashMap<>());
+                if (waitForTraceSet(traceSet, traceSet2))
+                    return;
 
-            captureTheUnclosed(openFiles, traceSet2);
-        }
+                captureTheUnclosed(openFiles, traceSet2);
+            }
 
-        if (openFiles.getSuppressed().length > 0) {
-            throw openFiles;
+            if (openFiles.getSuppressed().length > 0) {
+                throw openFiles;
+            }
+        } finally {
+            if (interrupted)
+                Thread.currentThread().interrupt();
         }
     }
 
@@ -201,13 +209,24 @@ public final class CloseableUtils {
         traceSet2.addAll(traceSet);
         traceSet2.removeAll(nested);
 
-        // wait up to 250 ms for resources to be closed in the background.
-        for (int i = 0; i < 250; i++) {
-            if (traceSet2.stream().allMatch(Closeable::isClosing))
-                return true;
-            Jvm.pause(1);
+        //! An interrupt during a sleep must not make every following poll spin with the flag still set.
+        boolean interrupted = false;
+        try {
+            // wait up to 250 ms for resources to be closed in the background.
+            for (int i = 0; i < 250; i++) {
+                if (traceSet2.stream().allMatch(Closeable::isClosing))
+                    return true;
+                try {
+                    Thread.sleep(1);
+                } catch (InterruptedException e) {
+                    interrupted = true;
+                }
+            }
+            return false;
+        } finally {
+            if (interrupted)
+                Thread.currentThread().interrupt();
         }
-        return false;
     }
 
     private static void captureTheUnclosed(AssertionError openFiles, Set<Closeable> traceSet2) {

--- a/src/test/java/net/openhft/chronicle/core/internal/CloseableAssertionInterruptionTest.java
+++ b/src/test/java/net/openhft/chronicle/core/internal/CloseableAssertionInterruptionTest.java
@@ -72,6 +72,83 @@ class CloseableAssertionInterruptionTest {
     }
 
     @ParameterizedTest
+    @CsvSource({"false, false", "false, true", "true, false", "true, true"})
+    void retainsPollingInterruptThroughDiagnosticCleanup(boolean initiallyInterrupted, boolean cleanupThrows) throws Exception {
+        CountDownLatch queried = new CountDownLatch(1);
+        AtomicBoolean closed = new AtomicBoolean();
+        AtomicInteger closeCalls = new AtomicInteger();
+        IllegalStateException cleanupFailure = new IllegalStateException("diagnostic cleanup failed");
+        ManagedCloseable resource = new ManagedCloseable() {
+            @Override public void close() {
+                closeCalls.incrementAndGet();
+                Thread.interrupted();
+                closed.set(true);
+                if (cleanupThrows)
+                    throw cleanupFailure;
+            }
+            @Override public boolean isClosed() { return closed.get(); }
+            @Override public boolean isClosing() {
+                queried.countDown();
+                return closed.get();
+            }
+        };
+        CloseableUtils.add(resource);
+        Thread waiter = Thread.currentThread();
+        CountDownLatch ready = new CountDownLatch(1);
+        AtomicBoolean stop = new AtomicBoolean();
+        AtomicBoolean interruptedDuringPolling = new AtomicBoolean();
+        AtomicReference<Throwable> workerFailure = new AtomicReference<>();
+        Thread worker = new Thread(() -> {
+            ready.countDown();
+            try {
+                assertTrue(queried.await(5, TimeUnit.SECONDS), "resource was never queried");
+                long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+                while (!stop.get() && System.nanoTime() < deadline) {
+                    if (waiter.getState() == Thread.State.TIMED_WAITING) {
+                        interruptedDuringPolling.set(true);
+                        waiter.interrupt();
+                        return;
+                    }
+                    LockSupport.parkNanos(TimeUnit.MICROSECONDS.toNanos(100));
+                }
+            } catch (Throwable failure) {
+                workerFailure.set(failure);
+            }
+        }, "assertion-diagnostic-interrupter");
+        worker.setDaemon(true);
+        worker.start();
+        try {
+            assertTrue(ready.await(5, TimeUnit.SECONDS));
+            if (initiallyInterrupted)
+                waiter.interrupt();
+            // Keep the resource open throughout polling so the diagnostic close, not the worker, consumes the flag.
+            if (cleanupThrows) {
+                assertSame(cleanupFailure, assertThrows(IllegalStateException.class, CloseableUtils::assertCloseablesClosed));
+            } else {
+                AssertionError failure = assertThrows(AssertionError.class, CloseableUtils::assertCloseablesClosed);
+                assertEquals("Closeables still open", failure.getMessage());
+                assertEquals(1, failure.getSuppressed().length);
+            }
+            assertTrue(interruptedDuringPolling.get(), "no polling sleep was interrupted");
+            assertEquals(1, closeCalls.get(), "diagnostic cleanup must run exactly once");
+            assertTrue(closed.get());
+            assertTrue(waiter.isInterrupted(), "diagnostic cleanup consumed the remembered polling interrupt");
+        } finally {
+            stop.set(true);
+            queried.countDown();
+            Thread.interrupted();
+            try {
+                worker.join(5000);
+            } finally {
+                closed.set(true);
+                CloseableUtils.unmonitor(resource);
+            }
+        }
+        assertFalse(worker.isAlive(), "interrupter did not stop");
+        assertNull(workerFailure.get(), () -> String.valueOf(workerFailure.get()));
+    }
+
+    @ParameterizedTest
     @CsvSource({"false, false", "true, false", "false, true", "true, true"})
     void givesBackgroundClosureARealPause(boolean initiallyInterrupted, boolean interruptDuringPause) throws Exception {
         ProbeCloseable resource = new ProbeCloseable();

--- a/src/test/java/net/openhft/chronicle/core/internal/CloseableAssertionInterruptionTest.java
+++ b/src/test/java/net/openhft/chronicle/core/internal/CloseableAssertionInterruptionTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.core.internal;
+
+import net.openhft.chronicle.core.io.ManagedCloseable;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.LockSupport;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CloseableAssertionInterruptionTest {
+    @BeforeEach
+    void enableTracing() {
+        assertFalse(Thread.currentThread().isInterrupted(), "test entered interrupted");
+        CloseableUtils.enableCloseableTracing();
+    }
+
+    @AfterEach
+    void restoreFixture() {
+        Thread.interrupted();
+        CloseableUtils.disableCloseableTracing();
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void preservesEntryStatusWhenNothingRemains(boolean initiallyInterrupted) {
+        if (initiallyInterrupted)
+            Thread.currentThread().interrupt();
+        CloseableUtils.assertCloseablesClosed();
+        assertEquals(initiallyInterrupted, Thread.currentThread().isInterrupted());
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void restoresEntryStatusWhenStateQueryFails(boolean initiallyInterrupted) {
+        IllegalStateException failure = new IllegalStateException("state query failed");
+        ManagedCloseable resource = new ManagedCloseable() {
+            @Override public void close() { }
+            @Override public boolean isClosed() { return false; }
+            @Override public boolean isClosing() { throw failure; }
+        };
+        CloseableUtils.add(resource);
+        if (initiallyInterrupted)
+            Thread.currentThread().interrupt();
+        assertSame(failure, assertThrows(IllegalStateException.class, CloseableUtils::assertCloseablesClosed));
+        assertEquals(initiallyInterrupted, Thread.currentThread().isInterrupted());
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void restoresEntryStatusWhenReportingAnUnclosedResource(boolean initiallyInterrupted) {
+        ProbeCloseable resource = new ProbeCloseable();
+        CloseableUtils.add(resource);
+        if (initiallyInterrupted)
+            Thread.currentThread().interrupt();
+        AssertionError failure = assertThrows(AssertionError.class, CloseableUtils::assertCloseablesClosed);
+        assertEquals("Closeables still open", failure.getMessage());
+        assertEquals(1, failure.getSuppressed().length);
+        assertTrue(resource.isClosed(), "the existing diagnostic cleanup must still run");
+        assertEquals(initiallyInterrupted, Thread.currentThread().isInterrupted());
+    }
+
+    @ParameterizedTest
+    @CsvSource({"false, false", "true, false", "false, true", "true, true"})
+    void givesBackgroundClosureARealPause(boolean initiallyInterrupted, boolean interruptDuringPause) throws Exception {
+        ProbeCloseable resource = new ProbeCloseable();
+        CloseableUtils.add(resource);
+        Thread waiter = Thread.currentThread();
+        CountDownLatch ready = new CountDownLatch(1);
+        AtomicBoolean stop = new AtomicBoolean();
+        AtomicBoolean observedPause = new AtomicBoolean();
+        AtomicReference<Throwable> workerFailure = new AtomicReference<>();
+        Thread worker = new Thread(() -> {
+            ready.countDown();
+            try {
+                assertTrue(resource.queried.await(5, TimeUnit.SECONDS), "resource was never queried");
+                long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+                int minimumQueries = 0;
+                boolean interruptionSent = false;
+                while (!stop.get() && System.nanoTime() < deadline) {
+                    if (resource.queryCount.get() >= minimumQueries && waiter.getState() == Thread.State.TIMED_WAITING) {
+                        if (interruptDuringPause && !interruptionSent) {
+                            interruptionSent = true;
+                            waiter.interrupt();
+                            minimumQueries = resource.queryCount.get() + 1;
+                            continue;
+                        }
+                        // After interruption, require another query and another blocking sleep before closing.
+                        observedPause.set(true);
+                        resource.close();
+                        return;
+                    }
+                    LockSupport.parkNanos(TimeUnit.MICROSECONDS.toNanos(100));
+                }
+            } catch (Throwable failure) {
+                workerFailure.set(failure);
+            }
+        }, "assertion-grace-observer");
+        worker.setDaemon(true);
+        worker.start();
+        try {
+            assertTrue(ready.await(5, TimeUnit.SECONDS));
+            if (initiallyInterrupted)
+                Thread.currentThread().interrupt();
+            assertDoesNotThrow(CloseableUtils::assertCloseablesClosed);
+            assertEquals(initiallyInterrupted || interruptDuringPause, Thread.currentThread().isInterrupted());
+            assertTrue(observedPause.get(), "state queries ran but the grace-period sleep never blocked");
+        } finally {
+            Thread.interrupted();
+            stop.set(true);
+            resource.queried.countDown();
+            try {
+                worker.join(5000);
+            } finally {
+                resource.close();
+            }
+        }
+        assertFalse(worker.isAlive(), "observer did not stop");
+        assertNull(workerFailure.get(), () -> String.valueOf(workerFailure.get()));
+    }
+
+    private static final class ProbeCloseable implements ManagedCloseable {
+        private final CountDownLatch queried = new CountDownLatch(1);
+        private final AtomicInteger queryCount = new AtomicInteger();
+        private volatile boolean closed;
+
+        @Override public void close() { closed = true; }
+        @Override public boolean isClosed() { return closed; }
+        @Override public boolean isClosing() {
+            queryCount.incrementAndGet();
+            queried.countDown();
+            return closed;
+        }
+    }
+}


### PR DESCRIPTION
## Refresh on 12 September 2026

Merged develop `9c26a484f3150c7f079aea626abffac22e53a506` into the existing branch without rewriting history. Updated head: `d83d6c986f5f58012a8dc897c13266a87246946c`. Both the declared base and develop are ancestors of this head.

Fresh Linux/OpenJDK 21 full Maven verify passed: 1888 reported tests, no failures or errors. Both closeable regression groups also pass together on Java 8 (30 tests).

Platform CI and repository merge gates remain separate. Earlier implementation and validation details follow; their recorded results apply to the revisions stated there.

---

## Why and scope

Each branch starts directly from current develop `ebcf76e91cb7a57b3626c1de7e0a67fc42a514a8`. This is an independent behavioural extraction from #846, not a JUnit migration or annotation/checker rewrite.

The base loses an incoming interrupt while reporting it. Simply switching to isInterrupted, as #846 does, leaves the flag set during Jvm.pause and collapses the grace period into immediately interrupted sleeps.

Remember/temporarily clear the entry flag and restore it on every exit. Remember interruptions during polling sleeps, allow later sleeps to block, and transfer the helper's restored status into the outer saved state before diagnostic cleanup. A resource close can consume the flag and return or throw; the outer finally must still restore the remembered entry/polling interruption. Preserve the existing diagnostic, cleanup, grace-loop count and registry locking. //! notes explain both boundaries.

## Review follow-up: diagnostic cleanup

Confirmed the review finding against the actual production class at `7b4d2d4423b92d15d8ccd94e99a4c9df7dde56fe`, using repository JUnit tests rather than a copied-method harness. Both initially-clear cases lost a polling interrupt when cleanup consumed it (normal return or a specific thrown exception); both initially-interrupted controls passed. The original ten cases also passed, demonstrating the previous coverage gap.

The correction is one state-transfer line, with an adjacent `//!` reason, immediately before `captureTheUnclosed`. The polling loop is unchanged. Four new parameterised cases verify both entry states and both cleanup outcomes, exactly-once diagnostic close, preservation of the expected failure, and retained interruption on exit. A latch and observation of an actual polling sleep establish when the interrupt is delivered; worker shutdown is bounded.

All fourteen focused cases now pass. The five extraction PRs also apply together without conflict, and their combined Java 21 clean verify passes **1,914 tests**, with zero failures, errors or skips and retries disabled. No combined branch was published or merged; #863, #864, #865 and #867 are unchanged.

## Verification performed

Actual Chronicle-Core Maven builds on Linux x64, using Maven 3.9.11 and `mvn -B -nsu clean verify -Dsurefire.rerunFailingTestsCount=0 -l <log>`:

| JVM | Tests | Failures/errors | Skipped |
| --- | ---: | ---: | ---: |
| OpenJDK 8u502 | 1884 | 0 / 0 | 5 |
| OpenJDK 21.0.12 | 1884 | 0 / 0 | 0 |

The five Java 8 skips are existing JDK-specific tests; none of the added cases skipped. Full verify includes licence and binary-compatibility checks. Test retries were disabled.

All fourteen focused cases pass: both entry states on success, state-query failure and unclosed-resource reporting; real background closure; and interruption during a sleep. Latches establish query ordering. The interrupted cases require a later query and another blocking sleep before the resource closes; worker failures reach the owning test.

The original ten-case suite, before this follow-up, failed six cases against develop and three against #846's exact head (73ab2a6b). A previous targeted mutation retaining the fix's entry-status preservation but putting Jvm.pause back into the loop fails both interrupted-during-wait cases. This confirms the tests cover subsequent sleeping, not just final flag state.

The unchanged POM resolves Chronicle Test Framework 2026.2, JUnit Jupiter 5.10.0, Affinity 2026.2 and POSIX 2026.2. No dependency bump is included. Platform CI remains a separate gate; Windows, Mac and ARM hardware were not run locally. Java 26+ results are informational per the maintainer's instruction for this review. This does not establish that the Java 27 failure is unrelated, nor does it change branch protection.

## Boundaries

Only assertCloseablesClosed and its private grace helper change. This does not alter waitForCloseablesToClose or duplicate #862/CORE-78. Existing global-registry locking is not redesigned. No public API, POM/version or annotation changes.
