### PR TITLE
Exclude test service registrations from the exported test JAR

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -234,6 +234,33 @@
                         <goals>
                             <goal>test-jar</goal>
                         </goals>
+                        <configuration>
+                            <excludes>
+                                <exclude>META-INF/services/**</exclude>
+                            </excludes>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>verify-test-jar</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <includes>
+                                <include>**/PackagedTestServicesIT.java</include>
+                            </includes>
+                            <systemPropertyVariables>
+                                <packagedCoreJar>${project.build.directory}/${project.build.finalName}.jar</packagedCoreJar>
+                                <packagedCoreTestJar>${project.build.directory}/${project.build.finalName}-tests.jar</packagedCoreTestJar>
+                            </systemPropertyVariables>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/src/main/docs/project-requirements.adoc
+++ b/src/main/docs/project-requirements.adoc
@@ -87,3 +87,5 @@ CORE-FN-053 :: The histogram shall allow configurable precision or accuracy.
 === Interfaces & Dependencies
 CORE-FN-054 :: Chronicle Core APIs consumed by other Chronicle libraries shall be designed for long-term stability.
 CORE-FN-055 :: Evolution of Core APIs shall minimise breaking changes for dependent libraries.
+The exported test JAR shall not register Core's test-only service providers in consumer JVMs.
+Core's own tests retain those registrations in their local test-class output; `mvn verify` also checks the packaged fixtures in separate consumer JVMs.

--- a/src/test/java/net/openhft/chronicle/core/packaging/PackagedTestServicesIT.java
+++ b/src/test/java/net/openhft/chronicle/core/packaging/PackagedTestServicesIT.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.core.packaging;
+
+import net.openhft.chronicle.core.ChronicleInitRunnable;
+import net.openhft.chronicle.core.cleaner.CleanerServiceLocator;
+import net.openhft.chronicle.core.cleaner.spi.ByteBufferCleanerService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.lang.management.BufferPoolMXBean;
+import java.lang.management.ManagementFactory;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.ServiceLoader;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** Runs after packaging, using the exported fixtures ahead of the main JAR. */
+public class PackagedTestServicesIT {
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void exportedFixturesDoNotSelectTestCleaner() throws Exception {
+        runConsumer("cleaner");
+    }
+
+    @Test
+    void exportedFixturesDoNotRegisterTestInitialiser() throws Exception {
+        runConsumer("initialiser");
+    }
+
+    private void runConsumer(String mode) throws Exception {
+        final List<String> command = new ArrayList<>();
+        final String java = System.getProperty("os.name").startsWith("Windows") ? "java.exe" : "java";
+        command.add(Paths.get(System.getProperty("java.home"), "bin", java).toString());
+        // Preserve the parent test JVM's module access without its test-class directories.
+        for (String argument : ManagementFactory.getRuntimeMXBean().getInputArguments()) {
+            if (argument.startsWith("--add-opens=") || argument.startsWith("--add-exports="))
+                command.add(argument);
+        }
+        command.add("-cp");
+        command.add(consumerClasspath());
+        command.add(PackagedTestServicesIT.class.getName());
+        command.add(mode);
+        final Path output = tempDir.resolve(mode + ".log");
+        final Process child = new ProcessBuilder(command).redirectErrorStream(true).redirectOutput(output.toFile()).start();
+        try {
+            assertTrue(child.waitFor(20, TimeUnit.SECONDS), "Packaged fixture consumer did not finish");
+            assertEquals(0, child.exitValue(), new String(Files.readAllBytes(output), StandardCharsets.UTF_8));
+        } finally {
+            if (child.isAlive()) {
+                child.destroyForcibly();
+                assertTrue(child.waitFor(5, TimeUnit.SECONDS), "Packaged fixture consumer did not terminate");
+            }
+        }
+    }
+
+    private static String consumerClasspath() {
+        final List<String> entries = new ArrayList<>();
+        entries.add(System.getProperty("packagedCoreTestJar"));
+        entries.add(System.getProperty("packagedCoreJar"));
+        for (String entry : System.getProperty("java.class.path").split(File.pathSeparator)) {
+            if (entry.endsWith(".jar"))
+                entries.add(entry);
+        }
+        return String.join(File.pathSeparator, entries);
+    }
+
+    public static void main(String[] args) {
+        if ("initialiser".equals(args[0])) {
+            for (ChronicleInitRunnable initialiser : ServiceLoader.load(ChronicleInitRunnable.class))
+                throw new AssertionError("Exported fixture registered an initialiser: " + initialiser.getClass().getName());
+            return;
+        }
+
+        final ByteBufferCleanerService cleaner = CleanerServiceLocator.cleanerService();
+        System.out.println("Selected " + cleaner.getClass().getName());
+        if (cleaner.getClass().getName().contains(".testimpl."))
+            throw new AssertionError("Exported fixture selected a test cleaner");
+        final BufferPoolMXBean direct = ManagementFactory.getPlatformMXBeans(BufferPoolMXBean.class).stream()
+                .filter(pool -> "direct".equals(pool.getName())).findFirst().orElseThrow(AssertionError::new);
+        final ByteBuffer buffer = ByteBuffer.allocateDirect(64 * 1024);
+        final long allocated = direct.getMemoryUsed();
+        cleaner.clean(buffer);
+        if (direct.getMemoryUsed() >= allocated)
+            throw new AssertionError("Selected cleaner did not free the consumer's direct buffer");
+    }
+}


### PR DESCRIPTION
The exported Core test JAR includes service registrations for a no-op ByteBuffer cleaner and a test bootstrap hook. Putting it ahead of the main JAR can select `AllowedCleaner`, leaving direct buffers unreleased, and activate `ChronicleInitTest.ServiceLoaderInit` inside a consumer JVM.

Exclude service descriptors only from the test-JAR packaging execution. Core's own test-class output retains them, so service selection, fallback, version filtering and bootstrap tests continue to execute. Test helper classes remain available to consumers. No runtime cleaner selection, warning or release check is changed.

Two checks run after packaging in `mvn verify`, using bounded consumer JVMs with the actual test JAR ahead of the main JAR and no unpackaged project classes. The cleaner check verifies production-provider selection and release of a real direct buffer; the bootstrap check rejects test initialisers. The fixture-delivery contract is recorded under CORE-FN-055.

Validation:

- Both consumer checks fail on unchanged develop `9c26a484f3150c7f079aea626abffac22e53a506`, with only the regression and its verify execution added.
- Independently downloaded Maven Central 2026.6 main/test JARs reproduce both failures on Java 8. Released test-JAR SHA-256: `98431aa5203523c728173399d0f34e21f46d5cfb751c86e7bccdd43428dd5f35`.
- Full clean Maven verification on OpenJDK 21.0.12 passes all 1,876 cases, zero retries.
- Full clean Maven verification on Java 8u502 passes 1,871 cases, with five existing JDK-specific skips and zero retries. Both new checks execute on both JDKs.
- Licence, Checkstyle and binary compatibility checks pass. The candidate test JAR has no service descriptors; local test-class output retains both originals.

Publish a Core test artifact containing this change and update consumers through their normal dependency/BOM process. Rebuild shaded consumers as needed. Local qualification does not establish downstream exact-head CI success or waive review requirements. Windows, Mac and ARM execution remain unvalidated here.
