### PR TITLE
Disable automatic unit-test retries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -265,6 +265,8 @@
                 <configuration>
                     <argLine>${argLine} ${jvm.requiredArgs}</argLine>
                     <forkCount>4</forkCount>
+                    <!-- Keep failures visible even when CI requests retries on the command line. -->
+                    <rerunFailingTestsCount>0</rerunFailingTestsCount>
                     <reuseForks>true</reuseForks>
                     <runOrder>hourly</runOrder>
                 </configuration>

--- a/src/main/docs/decision-log.adoc
+++ b/src/main/docs/decision-log.adoc
@@ -15,6 +15,7 @@ Identifiers follow the
 * link:#CORE-RISK-003[CORE-RISK-003 Guard Native-Memory Mapping with Directory Whitelist]
 * link:#CORE-NF-O-004[CORE-NF-O-004 Background Resource Releaser Thread (Opt-In)]
 * link:#CORE-FN-005[CORE-FN-005 ChronicleInit for Pre/Post Application Hooks]
+* link:#CORE-TEST-006[CORE-TEST-006 Preserve First-Attempt Unit-Test Failures]
 
 [[CORE-DOC-001]]
 == CORE-DOC-001 Adopt Nine-Box Requirement & Decision Taxonomy
@@ -123,3 +124,24 @@ Impact & Consequences::
 Notes/Links::
 * link:functional-requirements.adoc#CORE-FN-015[CORE-FN-015]
 * link:functional-requirements.adoc#CORE-FN-016[CORE-FN-016]
+
+[[CORE-TEST-006]]
+== CORE-TEST-006 Preserve First-Attempt Unit-Test Failures
+
+Date:: 2026-09-12
+Context::
+* Automatic Surefire retries can turn an intermittent failure into a successful build.
+* Shared CI command lines can request retries with `-Dsurefire.rerunFailingTestsCount`.
+Decision Statement::
+* Set `rerunFailingTestsCount` to the literal value `0` in the Core Surefire plugin configuration.
+* Keep this value independent of Maven properties so command-line retry requests cannot enable automatic reruns.
+Rationale for Decision::
+* Each test invocation must retain its original outcome for failure triage.
+* Bounded, explicitly recorded repeat runs remain useful for investigating intermittent failures.
+Impact & Consequences::
+* Intermittent unit-test failures remain visible and need investigation.
+* This controls Surefire reruns; CI must still treat reported test failures as failures when it uses `maven.test.failure.ignore` to continue to later steps.
+Validation::
+* Check the effective POM with a non-zero command-line retry count, including the `sonar` and `run-all-tests` profiles.
+* Run ordinary and dynamic JUnit tests that fail on their first invocation and would pass on a second invocation.
+* With `-Dsurefire.rerunFailingTestsCount=3`, both `test` and direct `surefire:test` must execute each probe once and report failure.


### PR DESCRIPTION
TeamCity ARM [build 1356472](https://teamcity.chronicle.software/buildConfiguration/Chronicle_ChronicleCore_SnapshotARM/1356472) for #860 finished successfully after two failed test invocations passed on retry. Set Core's Surefire `rerunFailingTestsCount` to the literal value `0`, so shared CI command lines such as `-Dsurefire.rerunFailingTestsCount=3` cannot enable automatic reruns. Document the first-attempt failure policy in CORE-TEST-006.

Validation used isolated Maven repositories and Maven 3.9.11 / Surefire 3.1.2:

- Ordinary and dynamic JUnit probes that fail first and would pass on retry: `develop` invoked each twice and returned success; this branch invoked each once and returned failure. Verified through both `test` and direct `surefire:test`, requesting three retries.
- Effective default and Sonar configurations retain zero retries with the non-zero CLI property. The CI-requested `run-all-tests` profile is absent in the inherited POM and emits a warning.
- Java 21: `mvn -q clean verify -Dsurefire.rerunFailingTestsCount=3` passed; 1,874 tests, zero failures, skips or retries.
- Java 8: 1,874 tests, zero failures or retries, five skipped. Verification initially stopped because the isolated cache lacked the released 2026.0 binary-compatibility reference JAR; after restoring it, the remaining checks passed with `verify -DskipTests`, preserving the original test results.

The underlying ordering failures remain under investigation in #860. This change preserves their first-attempt outcomes; CI must still handle reported failures when it uses `maven.test.failure.ignore` to continue later steps.
